### PR TITLE
feat(evaluatorq-py): implement get_agent_context() for integration targets (RES-717)

### DIFF
--- a/packages/evaluatorq-py/src/evaluatorq/integrations/callable_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/callable_integration/target.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable, Callable
 from typing import Union
 
 from evaluatorq.redteam.backends.base import AgentTarget
+from evaluatorq.redteam.contracts import AgentContext
 
 # Accepted callable signatures
 AgentCallable = Union[Callable[[str], Awaitable[str]], Callable[[str], str]]
@@ -46,6 +47,7 @@ class CallableTarget(AgentTarget):
         fn: AgentCallable,
         *,
         reset_fn: Callable[[], None] | None = None,
+        agent_context: AgentContext | None = None,
     ) -> None:
         """Create a callable red teaming target.
 
@@ -53,10 +55,16 @@ class CallableTarget(AgentTarget):
             fn: A sync or async function that takes a prompt and returns a response.
             reset_fn: Optional callback invoked on ``reset_conversation()``.
                 Use this if your callable has state that needs clearing between attacks.
+            agent_context: Optional :class:`AgentContext` describing the wrapped
+                callable's tools, memory, system prompt, etc. The red teaming
+                pipeline uses this for capability-aware strategy filtering —
+                without it, all strategies (including nonsensical ones) will be
+                applied. If not provided, a minimal context is returned.
         """
         self._fn = fn
         self._is_async = asyncio.iscoroutinefunction(fn)
         self._reset_fn = reset_fn
+        self._agent_context = agent_context
 
     async def send_prompt(self, prompt: str) -> str:
         """Send a prompt to the callable and return its response."""
@@ -72,6 +80,13 @@ class CallableTarget(AgentTarget):
         if self._reset_fn is not None:
             self._reset_fn()
 
+    async def get_agent_context(self) -> AgentContext:
+        """Return the user-provided agent context, or a minimal placeholder."""
+        if self._agent_context is not None:
+            return self._agent_context
+        key = getattr(self._fn, "__name__", None) or "callable_target"
+        return AgentContext(key=str(key), description="opaque callable target")
+
     def clone(self) -> CallableTarget:
         """Create a copy sharing the same callable."""
-        return CallableTarget(self._fn, reset_fn=self._reset_fn)
+        return CallableTarget(self._fn, reset_fn=self._reset_fn, agent_context=self._agent_context)

--- a/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
@@ -147,6 +147,7 @@ def _introspect_tools(graph: CompiledStateGraph[Any, Any, Any, Any]) -> list[Too
     (LangGraph's ``ToolNode``). Falls back to an empty list on anything else.
     """
     tools: list[ToolInfo] = []
+    seen: set[str] = set()
     nodes = getattr(graph, "nodes", None)
     if not nodes:
         return tools
@@ -156,9 +157,13 @@ def _introspect_tools(graph: CompiledStateGraph[Any, Any, Any, Any]) -> list[Too
         if not isinstance(tools_by_name, dict):
             continue
         for name, tool in tools_by_name.items():
+            name_str = str(name)
+            if name_str in seen:
+                continue
+            seen.add(name_str)
             tools.append(
                 ToolInfo(
-                    name=str(name),
+                    name=name_str,
                     description=getattr(tool, "description", None),
                     parameters=None,
                 )

--- a/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
@@ -9,6 +9,7 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.graph.state import CompiledStateGraph
 
 from evaluatorq.redteam.backends.base import AgentTarget
+from evaluatorq.redteam.contracts import AgentContext, MemoryStoreInfo, ToolInfo
 
 
 class LangGraphTarget(AgentTarget):
@@ -36,6 +37,7 @@ class LangGraphTarget(AgentTarget):
         graph: CompiledStateGraph[Any, Any, Any, Any],
         *,
         config: dict[str, Any] | None = None,
+        agent_context: AgentContext | None = None,
     ) -> None:
         """Create a LangGraph red teaming target.
 
@@ -44,10 +46,16 @@ class LangGraphTarget(AgentTarget):
             config: Optional extra LangGraph RunnableConfig keys
                 (e.g. ``{"recursion_limit": 50}``). The ``thread_id``
                 is managed automatically — do not pass it here.
+            agent_context: Optional :class:`AgentContext` override. When
+                provided, this context is returned from
+                :meth:`get_agent_context` verbatim. When omitted, the target
+                introspects the compiled graph (tools from a ``ToolNode``,
+                checkpointer presence) on a best-effort basis.
         """
         self._graph = graph
         self._extra_config = config or {}
         self.memory_entity_id: str = uuid4().hex
+        self._agent_context = agent_context
 
     def _build_config(self) -> RunnableConfig:
         """Build the RunnableConfig with the current thread_id."""
@@ -92,10 +100,83 @@ class LangGraphTarget(AgentTarget):
         """Reset conversation state. Thread ID is fixed at construction; clone() provides isolation."""
         pass
 
+    async def get_agent_context(self) -> AgentContext:
+        """Return agent context introspected from the compiled graph.
+
+        If an ``agent_context`` was passed at construction time, returns it
+        unchanged. Otherwise performs best-effort introspection:
+
+        * tools: extracted from any node whose ``bound`` is a ``ToolNode`` via
+          ``tools_by_name``
+        * memory_stores: single synthetic entry pointing at the checkpointer
+          thread when a checkpointer is attached
+
+        Callers needing stronger guarantees (custom graph shapes, non-standard
+        tool nodes) should pass ``agent_context`` explicitly.
+        """
+        if self._agent_context is not None:
+            return self._agent_context
+
+        tools = _introspect_tools(self._graph)
+        memory_stores = _introspect_memory_stores(self._graph, self.memory_entity_id)
+
+        return AgentContext(
+            key="langgraph_target",
+            description="LangGraph compiled state graph target",
+            tools=tools,
+            memory_stores=memory_stores,
+        )
+
     def clone(self) -> LangGraphTarget:
         """Create an independent copy for parallel red teaming jobs.
 
         The clone gets a fresh ``memory_entity_id`` (and thus a fresh LangGraph
         thread), so parallel workers never share checkpointer state.
         """
-        return LangGraphTarget(self._graph, config=dict(self._extra_config))
+        return LangGraphTarget(
+            self._graph,
+            config=dict(self._extra_config),
+            agent_context=self._agent_context,
+        )
+
+
+def _introspect_tools(graph: CompiledStateGraph[Any, Any, Any, Any]) -> list[ToolInfo]:
+    """Best-effort extraction of tool metadata from a compiled graph.
+
+    Looks for nodes whose ``bound`` attribute exposes ``tools_by_name``
+    (LangGraph's ``ToolNode``). Falls back to an empty list on anything else.
+    """
+    tools: list[ToolInfo] = []
+    nodes = getattr(graph, "nodes", None)
+    if not nodes:
+        return tools
+    for node in nodes.values():
+        bound = getattr(node, "bound", None)
+        tools_by_name = getattr(bound, "tools_by_name", None)
+        if not isinstance(tools_by_name, dict):
+            continue
+        for name, tool in tools_by_name.items():
+            tools.append(
+                ToolInfo(
+                    name=str(name),
+                    description=getattr(tool, "description", None),
+                    parameters=None,
+                )
+            )
+    return tools
+
+
+def _introspect_memory_stores(
+    graph: CompiledStateGraph[Any, Any, Any, Any], thread_id: str
+) -> list[MemoryStoreInfo]:
+    """Return a single synthetic memory store entry when a checkpointer is attached."""
+    checkpointer = getattr(graph, "checkpointer", None)
+    if checkpointer is None:
+        return []
+    return [
+        MemoryStoreInfo(
+            id=thread_id,
+            key="langgraph_checkpointer",
+            description=f"LangGraph checkpointer ({type(checkpointer).__name__})",
+        )
+    ]

--- a/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
@@ -56,6 +56,8 @@ class LangGraphTarget(AgentTarget):
         self._extra_config = config or {}
         self.memory_entity_id: str = uuid4().hex
         self._agent_context = agent_context
+        graph_name: str = getattr(graph, "name", None) or "langgraph_target"
+        self._key = f"{graph_name}_{uuid4().hex[:8]}"
 
     def _build_config(self) -> RunnableConfig:
         """Build the RunnableConfig with the current thread_id."""
@@ -121,7 +123,7 @@ class LangGraphTarget(AgentTarget):
         memory_stores = _introspect_memory_stores(self._graph, self.memory_entity_id)
 
         return AgentContext(
-            key="langgraph_target",
+            key=self._key,
             description="LangGraph compiled state graph target",
             tools=tools,
             memory_stores=memory_stores,
@@ -133,11 +135,13 @@ class LangGraphTarget(AgentTarget):
         The clone gets a fresh ``memory_entity_id`` (and thus a fresh LangGraph
         thread), so parallel workers never share checkpointer state.
         """
-        return LangGraphTarget(
+        cloned = LangGraphTarget(
             self._graph,
             config=dict(self._extra_config),
             agent_context=self._agent_context,
         )
+        cloned._key = self._key
+        return cloned
 
 
 def _introspect_tools(graph: CompiledStateGraph[Any, Any, Any, Any]) -> list[ToolInfo]:

--- a/packages/evaluatorq-py/src/evaluatorq/integrations/openai_agents_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/openai_agents_integration/target.py
@@ -7,6 +7,7 @@ from typing import Any
 from agents import Agent, Runner
 
 from evaluatorq.redteam.backends.base import AgentTarget
+from evaluatorq.redteam.contracts import AgentContext, ToolInfo
 
 
 class OpenAIAgentTarget(AgentTarget):
@@ -65,6 +66,50 @@ class OpenAIAgentTarget(AgentTarget):
     def reset_conversation(self) -> None:
         """Reset conversation state by clearing the message history."""
         self._history = []
+
+    async def get_agent_context(self) -> AgentContext:
+        """Return agent context derived from the wrapped Agent instance.
+
+        Maps the SDK ``Agent`` fields onto :class:`AgentContext`:
+        ``name`` → ``key``/``display_name``, ``instructions`` → ``system_prompt``,
+        ``model`` → ``model``, ``tools`` → ``tools`` (via duck-typed introspection).
+        There is no server-side memory, so ``memory_stores`` stays empty.
+        """
+        agent = self._agent
+        key = str(getattr(agent, "name", None) or "openai_agent")
+        instructions = getattr(agent, "instructions", None)
+        system_prompt = instructions if isinstance(instructions, str) else None
+
+        model_attr = getattr(agent, "model", None)
+        if isinstance(model_attr, str):
+            model = model_attr
+        elif model_attr is None:
+            model = None
+        else:
+            model = getattr(model_attr, "model", None) or str(model_attr)
+
+        tools: list[ToolInfo] = []
+        for tool in getattr(agent, "tools", []) or []:
+            name = getattr(tool, "name", None) or getattr(tool, "__name__", None)
+            if not name:
+                continue
+            params = getattr(tool, "params_json_schema", None)
+            tools.append(
+                ToolInfo(
+                    name=str(name),
+                    description=getattr(tool, "description", None),
+                    parameters=params if isinstance(params, dict) else None,
+                )
+            )
+
+        return AgentContext(
+            key=key,
+            display_name=key,
+            description="OpenAI Agents SDK target",
+            system_prompt=system_prompt,
+            tools=tools,
+            model=model,
+        )
 
     def clone(self) -> OpenAIAgentTarget:
         """Create an independent copy for parallel red teaming jobs."""

--- a/packages/evaluatorq-py/src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -111,7 +112,14 @@ class VercelAISdkTarget(AgentTarget):
         """Return the user-provided agent context, or a minimal placeholder."""
         if self._agent_context is not None:
             return self._agent_context
-        return AgentContext(key=self._url, description="opaque Vercel AI SDK HTTP target")
+        # Strip userinfo and query/fragment so embedded credentials never leak
+        # into logs/reports, and to keep the key free of URL-reserved chars
+        # that may break downstream consumers (file naming, dict keying).
+        parsed = urlparse(self._url)
+        host = parsed.hostname or parsed.netloc.split("@")[-1]
+        port = f":{parsed.port}" if parsed.port else ""
+        safe_key = f"{parsed.scheme}://{host}{port}{parsed.path}".rstrip("/") or self._url
+        return AgentContext(key=safe_key, description="opaque Vercel AI SDK HTTP target")
 
     def clone(self) -> VercelAISdkTarget:
         """Create an independent copy for parallel red teaming jobs."""

--- a/packages/evaluatorq-py/src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py
@@ -19,6 +19,7 @@ from typing import Any
 import httpx
 
 from evaluatorq.redteam.backends.base import AgentTarget
+from evaluatorq.redteam.contracts import AgentContext
 
 
 class VercelAISdkTarget(AgentTarget):
@@ -56,6 +57,7 @@ class VercelAISdkTarget(AgentTarget):
         headers: dict[str, str] | None = None,
         extra_body: dict[str, Any] | None = None,
         timeout: float = 120.0,
+        agent_context: AgentContext | None = None,
     ) -> None:
         """Create a Vercel AI SDK red teaming target.
 
@@ -65,12 +67,20 @@ class VercelAISdkTarget(AgentTarget):
             extra_body: Optional extra fields merged into the request body
                 alongside ``messages`` (e.g. ``{"model": "gpt-4o"}``).
             timeout: HTTP request timeout in seconds.
+            agent_context: Optional :class:`AgentContext` describing the
+                remote agent's tools, memory, system prompt, etc. The red
+                teaming pipeline uses this for capability-aware strategy
+                filtering — without it, all strategies (including
+                nonsensical ones) will be applied. The HTTP handler cannot
+                be introspected from Python, so this must be supplied by
+                the caller when capability-aware filtering matters.
         """
         self._url = url
         self._headers = headers or {}
         self._extra_body = extra_body or {}
         self._timeout = timeout
         self._history: list[dict[str, str]] = []
+        self._agent_context = agent_context
 
     async def send_prompt(self, prompt: str) -> str:
         """Send a prompt to the AI SDK endpoint and return its text response."""
@@ -97,6 +107,12 @@ class VercelAISdkTarget(AgentTarget):
         """Reset conversation state by clearing the message history."""
         self._history = []
 
+    async def get_agent_context(self) -> AgentContext:
+        """Return the user-provided agent context, or a minimal placeholder."""
+        if self._agent_context is not None:
+            return self._agent_context
+        return AgentContext(key=self._url, description="opaque Vercel AI SDK HTTP target")
+
     def clone(self) -> VercelAISdkTarget:
         """Create an independent copy for parallel red teaming jobs."""
         return VercelAISdkTarget(
@@ -104,6 +120,7 @@ class VercelAISdkTarget(AgentTarget):
             headers=dict(self._headers),
             extra_body=dict(self._extra_body),
             timeout=self._timeout,
+            agent_context=self._agent_context,
         )
 
     @staticmethod

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/cli.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/cli.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Optional
 from evaluatorq.redteam.runner import SaveMode
 
 
+import click
 import typer
 
 from evaluatorq.redteam.contracts import DEFAULT_PIPELINE_MODEL, Vulnerability

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/cli.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/cli.py
@@ -10,15 +10,12 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, Optional
-
-from evaluatorq.redteam.runner import SaveMode
+from typing import Annotated, Any, Optional
 
 
-import click
 import typer
 
-from evaluatorq.redteam.contracts import DEFAULT_PIPELINE_MODEL, Vulnerability
+from evaluatorq.redteam.contracts import DEFAULT_PIPELINE_MODEL, SaveMode, Vulnerability
 
 app = typer.Typer(
     name="redteam",
@@ -248,7 +245,7 @@ def run(
     save: Annotated[
         SaveMode,
         typer.Option(help="What to persist: 'none' (no files), 'final' (summary only), or 'detail' (all stage artifacts)."),
-    ] = 'final',
+    ] = SaveMode.FINAL,
     yes: Annotated[
         bool,
         typer.Option("--yes", "-y", help="Skip confirmation prompt."),

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/contracts.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/contracts.py
@@ -267,6 +267,14 @@ class AgentCapability(StrEnum):
     USER_DATA = 'user_data'
 
 
+class SaveMode(StrEnum):
+    """Controls what gets persisted to disk after a red team run."""
+
+    NONE = 'none'
+    FINAL = 'final'
+    DETAIL = 'detail'
+
+
 # ---------------------------------------------------------------------------
 # Helper functions
 # ---------------------------------------------------------------------------

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -372,6 +372,18 @@ async def red_team(
         CancelledError: If hooks.on_confirm returns False.
     """
     resolved_hooks: PipelineHooks = hooks or DefaultHooks()
+
+    if isinstance(save, bool):
+        warnings.warn(
+            "Passing save=True/False is deprecated. Use SaveMode.FINAL / SaveMode.NONE instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        save = SaveMode.FINAL if save else SaveMode.NONE
+    elif save not in SaveMode.__members__.values():
+        msg = f"Invalid save value {save!r}. Must be one of: {', '.join(SaveMode.__members__.values())}."
+        raise ValueError(msg)
+
     user_output_dir = Path(output_dir) if output_dir is not None else None
     # Inner pipelines (_run_dynamic, _run_static) only write 01/02/03 to their
     # output_dir parameter, so we gate it on save='detail'. For 'final' the

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -13,10 +13,9 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, cast, get_args
+from typing import TYPE_CHECKING, Any, cast
 
-SaveMode = Literal['none', 'final', 'detail']
-_SAVE_MODES: frozenset[str] = frozenset(get_args(SaveMode))
+from evaluatorq.redteam.contracts import SaveMode
 
 from loguru import logger
 
@@ -303,7 +302,7 @@ async def red_team(
     attacker_instructions: str | None = None,
     verbosity: int = 0,
     llm_kwargs: dict[str, Any] | None = None,
-    save: SaveMode = 'final',
+    save: SaveMode = SaveMode.FINAL,
 ) -> RedTeamReport:
     """Unified entry point for red teaming.
 
@@ -372,9 +371,6 @@ async def red_team(
             ``save='detail'`` is passed without ``output_dir``.
         CancelledError: If hooks.on_confirm returns False.
     """
-    if save not in _SAVE_MODES:
-        msg = f"Invalid save mode {save!r}. Must be one of: {sorted(_SAVE_MODES)}."
-        raise ValueError(msg)
     resolved_hooks: PipelineHooks = hooks or DefaultHooks()
     user_output_dir = Path(output_dir) if output_dir is not None else None
     # Inner pipelines (_run_dynamic, _run_static) only write 01/02/03 to their

--- a/packages/evaluatorq-py/tests/redteam/e2e/test_pipeline_options.py
+++ b/packages/evaluatorq-py/tests/redteam/e2e/test_pipeline_options.py
@@ -12,6 +12,7 @@ from openai import AsyncOpenAI
 
 from evaluatorq.redteam import red_team
 from evaluatorq.redteam.backends.base import BackendBundle
+from evaluatorq.redteam.contracts import SaveMode
 from evaluatorq.redteam.exceptions import CancelledError
 from evaluatorq.redteam.hooks import ConfirmPayload, DefaultHooks
 
@@ -122,7 +123,7 @@ async def test_static_output_artifacts(
         dataset=str(static_dataset_path),
         llm_client=cast(AsyncOpenAI, cast(object, mock_llm_client)),
         output_dir=output_dir,
-        save='detail',
+        save=SaveMode.DETAIL,
     )
 
     assert (output_dir / "01_datapoints.json").exists()
@@ -157,7 +158,7 @@ async def test_dynamic_output_artifacts(
             backend="openai",
             llm_client=cast(AsyncOpenAI, cast(object, mock_llm_client)),
             output_dir=output_dir,
-            save='detail',
+            save=SaveMode.DETAIL,
         )
 
     assert (output_dir / "01_all_datapoints.json").exists()

--- a/packages/evaluatorq-py/tests/unit/test_langgraph_target.py
+++ b/packages/evaluatorq-py/tests/unit/test_langgraph_target.py
@@ -13,6 +13,7 @@ from evaluatorq.integrations.langgraph_integration import LangGraphTarget  # noq
 
 def _make_graph(response_content: str = "I'm fine") -> MagicMock:
     graph = MagicMock()
+    graph.name = "test_graph"
     msg = MagicMock()
     msg.content = response_content
     graph.ainvoke = AsyncMock(return_value={"messages": [msg]})
@@ -153,7 +154,7 @@ class TestLangGraphTargetAgentContext:
         target = LangGraphTarget(graph)
 
         ctx = await target.get_agent_context()
-        assert ctx.key == "langgraph_target"
+        assert ctx.key.startswith("LangGraph_")
         tool_names = ctx.get_tool_names()
         assert "add" in tool_names
         # create_react_agent does not set a checkpointer by default → no memory entries
@@ -166,7 +167,7 @@ class TestLangGraphTargetAgentContext:
         graph.checkpointer = None
         target = LangGraphTarget(graph)
         ctx = await target.get_agent_context()
-        assert ctx.key == "langgraph_target"
+        assert ctx.key.startswith("test_graph_")
         assert ctx.tools == []
         assert ctx.memory_stores == []
 

--- a/packages/evaluatorq-py/tests/unit/test_langgraph_target.py
+++ b/packages/evaluatorq-py/tests/unit/test_langgraph_target.py
@@ -139,6 +139,7 @@ class TestLangGraphTargetAgentContext:
     ) -> None:
         """Tools bound via create_react_agent show up in the agent context."""
         from langchain_core.tools import tool
+        from langchain_openai import ChatOpenAI
         from langgraph.prebuilt import create_react_agent
 
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test-stub")
@@ -148,7 +149,7 @@ class TestLangGraphTargetAgentContext:
             """Add two integers."""
             return a + b
 
-        graph = create_react_agent("openai:gpt-4o-mini", tools=[add])
+        graph = create_react_agent(ChatOpenAI(model="gpt-4o-mini"), tools=[add])
         target = LangGraphTarget(graph)
 
         ctx = await target.get_agent_context()

--- a/packages/evaluatorq-py/tests/unit/test_langgraph_target.py
+++ b/packages/evaluatorq-py/tests/unit/test_langgraph_target.py
@@ -134,14 +134,14 @@ class TestLangGraphTarget:
 
 class TestLangGraphTargetAgentContext:
     @pytest.mark.asyncio
-    async def test_get_agent_context_from_react_agent(self) -> None:
+    async def test_get_agent_context_from_react_agent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Tools bound via create_react_agent show up in the agent context."""
-        import os
-
         from langchain_core.tools import tool
         from langgraph.prebuilt import create_react_agent
 
-        os.environ.setdefault("OPENAI_API_KEY", "sk-test-stub")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-stub")
 
         @tool
         def add(a: int, b: int) -> int:
@@ -184,6 +184,28 @@ class TestLangGraphTargetAgentContext:
         assert len(ctx.memory_stores) == 1
         assert isinstance(ctx.memory_stores[0], MemoryStoreInfo)
         assert ctx.memory_stores[0].id == target.memory_entity_id
+
+    @pytest.mark.asyncio
+    async def test_get_agent_context_dedupes_tools_across_nodes(self) -> None:
+        """Same tool registered in multiple ToolNodes must yield a single entry."""
+        shared_tool = MagicMock()
+        shared_tool.description = "shared"
+        bound_a = MagicMock()
+        bound_a.tools_by_name = {"shared": shared_tool}
+        bound_b = MagicMock()
+        bound_b.tools_by_name = {"shared": shared_tool, "extra": MagicMock(description=None)}
+        node_a = MagicMock(bound=bound_a)
+        node_b = MagicMock(bound=bound_b)
+
+        graph = _make_graph()
+        graph.nodes = {"tools_a": node_a, "tools_b": node_b}
+        graph.checkpointer = None
+        target = LangGraphTarget(graph)
+
+        ctx = await target.get_agent_context()
+        names = [t.name for t in ctx.tools]
+        assert names.count("shared") == 1
+        assert sorted(names) == ["extra", "shared"]
 
     @pytest.mark.asyncio
     async def test_get_agent_context_override_returns_verbatim(self) -> None:

--- a/packages/evaluatorq-py/tests/unit/test_langgraph_target.py
+++ b/packages/evaluatorq-py/tests/unit/test_langgraph_target.py
@@ -130,3 +130,72 @@ class TestLangGraphTarget:
         result = await target.send_prompt("hi")
         assert isinstance(result, str)
         assert "multimodal content" in result
+
+
+class TestLangGraphTargetAgentContext:
+    @pytest.mark.asyncio
+    async def test_get_agent_context_from_react_agent(self) -> None:
+        """Tools bound via create_react_agent show up in the agent context."""
+        import os
+
+        from langchain_core.tools import tool
+        from langgraph.prebuilt import create_react_agent
+
+        os.environ.setdefault("OPENAI_API_KEY", "sk-test-stub")
+
+        @tool
+        def add(a: int, b: int) -> int:
+            """Add two integers."""
+            return a + b
+
+        graph = create_react_agent("openai:gpt-4o-mini", tools=[add])
+        target = LangGraphTarget(graph)
+
+        ctx = await target.get_agent_context()
+        assert ctx.key == "langgraph_target"
+        tool_names = ctx.get_tool_names()
+        assert "add" in tool_names
+        # create_react_agent does not set a checkpointer by default → no memory entries
+        assert ctx.memory_stores == []
+
+    @pytest.mark.asyncio
+    async def test_get_agent_context_handles_graph_without_tools_node(self) -> None:
+        graph = _make_graph()
+        graph.nodes = {}
+        graph.checkpointer = None
+        target = LangGraphTarget(graph)
+        ctx = await target.get_agent_context()
+        assert ctx.key == "langgraph_target"
+        assert ctx.tools == []
+        assert ctx.memory_stores == []
+
+    @pytest.mark.asyncio
+    async def test_get_agent_context_emits_memory_store_when_checkpointer_present(self) -> None:
+        from evaluatorq.redteam.contracts import MemoryStoreInfo
+
+        graph = _make_graph()
+        graph.nodes = {}
+        checkpointer = MagicMock()
+        checkpointer.__class__.__name__ = "InMemorySaver"
+        graph.checkpointer = checkpointer
+        target = LangGraphTarget(graph)
+
+        ctx = await target.get_agent_context()
+        assert len(ctx.memory_stores) == 1
+        assert isinstance(ctx.memory_stores[0], MemoryStoreInfo)
+        assert ctx.memory_stores[0].id == target.memory_entity_id
+
+    @pytest.mark.asyncio
+    async def test_get_agent_context_override_returns_verbatim(self) -> None:
+        from evaluatorq.redteam.contracts import AgentContext, ToolInfo
+
+        override = AgentContext(
+            key="my-custom-agent",
+            tools=[ToolInfo(name="custom_tool")],
+            description="explicitly-provided context",
+        )
+        graph = _make_graph()
+        target = LangGraphTarget(graph, agent_context=override)
+
+        ctx = await target.get_agent_context()
+        assert ctx is override

--- a/packages/evaluatorq-py/tests/unit/test_openai_agents_target.py
+++ b/packages/evaluatorq-py/tests/unit/test_openai_agents_target.py
@@ -105,6 +105,46 @@ class TestOpenAIAgentTarget:
             await target.send_prompt("hi")
 
     @pytest.mark.asyncio
+    async def test_get_agent_context_roundtrips_fields(self) -> None:
+        agent = MagicMock()
+        agent.name = "support-bot"
+        agent.instructions = "Be helpful."
+        agent.model = "gpt-4o-mini"
+        tool_a = MagicMock()
+        tool_a.name = "search_docs"
+        tool_a.description = "Search the docs."
+        tool_a.params_json_schema = {"type": "object", "properties": {}}
+        tool_b = MagicMock()
+        tool_b.name = "create_ticket"
+        tool_b.description = None
+        tool_b.params_json_schema = None
+        agent.tools = [tool_a, tool_b]
+
+        target = OpenAIAgentTarget(agent)
+        ctx = await target.get_agent_context()
+
+        assert ctx.key == "support-bot"
+        assert ctx.system_prompt == "Be helpful."
+        assert ctx.model == "gpt-4o-mini"
+        assert {t.name for t in ctx.tools} == {"search_docs", "create_ticket"}
+        assert ctx.memory_stores == []
+
+    @pytest.mark.asyncio
+    async def test_get_agent_context_handles_object_model(self) -> None:
+        agent = MagicMock()
+        agent.name = "bot"
+        agent.instructions = None
+        model_obj = MagicMock()
+        model_obj.model = "gpt-4o"
+        agent.model = model_obj
+        agent.tools = []
+
+        target = OpenAIAgentTarget(agent)
+        ctx = await target.get_agent_context()
+        assert ctx.model == "gpt-4o"
+        assert ctx.tools == []
+
+    @pytest.mark.asyncio
     async def test_history_accumulates_across_turns(self, monkeypatch: pytest.MonkeyPatch) -> None:
         call_count = 0
 

--- a/packages/evaluatorq-py/tests/unit/test_redteam_targets.py
+++ b/packages/evaluatorq-py/tests/unit/test_redteam_targets.py
@@ -47,3 +47,36 @@ class TestCallableTarget:
         assert cloned is not target
         assert cloned._fn is fn
         assert cloned._reset_fn is reset
+
+    @pytest.mark.asyncio
+    async def test_get_agent_context_default_is_minimal(self) -> None:
+        def my_fn(prompt: str) -> str:
+            return prompt
+
+        target = CallableTarget(my_fn)
+        ctx = await target.get_agent_context()
+        assert ctx.key == "my_fn"
+        assert ctx.tools == []
+        assert ctx.memory_stores == []
+        assert ctx.description == "opaque callable target"
+
+    @pytest.mark.asyncio
+    async def test_get_agent_context_returns_override(self) -> None:
+        from evaluatorq.redteam.contracts import AgentContext, ToolInfo
+
+        override = AgentContext(
+            key="wrapped-agent",
+            tools=[ToolInfo(name="send_email")],
+            description="wraps a real agent",
+        )
+        target = CallableTarget(lambda p: p, agent_context=override)
+        ctx = await target.get_agent_context()
+        assert ctx is override
+
+    def test_clone_preserves_agent_context(self) -> None:
+        from evaluatorq.redteam.contracts import AgentContext
+
+        override = AgentContext(key="k")
+        target = CallableTarget(lambda p: p, agent_context=override)
+        cloned = target.clone()
+        assert cloned._agent_context is override

--- a/packages/evaluatorq-py/tests/unit/test_vercel_ai_sdk_target.py
+++ b/packages/evaluatorq-py/tests/unit/test_vercel_ai_sdk_target.py
@@ -209,3 +209,34 @@ class TestVercelAISdkTarget:
         response = _mock_response('0:"Hello"\n0:" world"\n')
         text = VercelAISdkTarget._parse_response(response)
         assert text == "Hello world"
+
+
+class TestVercelAISdkTargetAgentContext:
+    @pytest.mark.asyncio
+    async def test_get_agent_context_default_is_minimal(self) -> None:
+        target = VercelAISdkTarget("http://test/api/chat")
+        ctx = await target.get_agent_context()
+        assert ctx.key == "http://test/api/chat"
+        assert ctx.tools == []
+        assert ctx.memory_stores == []
+        assert ctx.description == "opaque Vercel AI SDK HTTP target"
+
+    @pytest.mark.asyncio
+    async def test_get_agent_context_returns_override(self) -> None:
+        from evaluatorq.redteam.contracts import AgentContext, ToolInfo
+
+        override = AgentContext(
+            key="vercel-bot",
+            tools=[ToolInfo(name="http_tool")],
+        )
+        target = VercelAISdkTarget("http://test/api/chat", agent_context=override)
+        ctx = await target.get_agent_context()
+        assert ctx is override
+
+    def test_clone_preserves_agent_context(self) -> None:
+        from evaluatorq.redteam.contracts import AgentContext
+
+        override = AgentContext(key="k")
+        target = VercelAISdkTarget("http://test/api/chat", agent_context=override)
+        cloned = target.clone()
+        assert cloned._agent_context is override

--- a/packages/evaluatorq-py/tests/unit/test_vercel_ai_sdk_target.py
+++ b/packages/evaluatorq-py/tests/unit/test_vercel_ai_sdk_target.py
@@ -222,6 +222,14 @@ class TestVercelAISdkTargetAgentContext:
         assert ctx.description == "opaque Vercel AI SDK HTTP target"
 
     @pytest.mark.asyncio
+    async def test_get_agent_context_strips_credentials_from_url_key(self) -> None:
+        target = VercelAISdkTarget("https://user:secret@api.example.com/chat?token=abc")
+        ctx = await target.get_agent_context()
+        assert "secret" not in ctx.key
+        assert "token" not in ctx.key
+        assert ctx.key == "https://api.example.com/chat"
+
+    @pytest.mark.asyncio
     async def test_get_agent_context_returns_override(self) -> None:
         from evaluatorq.redteam.contracts import AgentContext, ToolInfo
 


### PR DESCRIPTION
## Stack

- #81
- #91 (base)
- **#92 ← you are here**

## Summary

Implements `get_agent_context()` on all four red-teaming integration targets so the pipeline's capability-aware strategy filter can actually see their tools, memory, and capabilities.

Without this, `adaptive/strategy_registry.py` receives the full strategy set for any of these targets — including strategies that are nonsensical (e.g. `memory_directive_injection` on a stateless callable).

Stacked on top of #91 (RES-714).

Closes RES-717.

## Why it matters

Capability-aware strategy routing: each integration target now surfaces its capability profile (tools, memory) to the pipeline, so the strategy filter picks strategies that make sense for that target.

## Per-target approach

- **`LangGraphTarget`** — introspects the compiled graph: walks `graph.nodes` looking for any node whose `bound` is a `ToolNode`, extracts `tools_by_name` (deduped by name across nodes). Emits a single synthetic `MemoryStoreInfo` entry when a checkpointer is attached (the thread is the isolation key). Accepts an optional `agent_context=` constructor kwarg as an override for custom graph shapes.
- **`OpenAIAgentTarget`** — maps `Agent.name` → `key`/`display_name`, `Agent.instructions` → `system_prompt`, `Agent.model` → `model` (handles both string and object-typed models), `Agent.tools` → `tools` via `name` / `description` / `params_json_schema`. No server-side memory.
- **`CallableTarget`** — opaque by design. Accepts optional `agent_context=` kwarg; default returns a minimal `AgentContext(key=fn.__name__, description="opaque callable target")`. Documented so users who want capability-aware routing know to pass it in.
- **`VercelAISdkTarget`** — same pattern as `CallableTarget`; HTTP handler is not introspectable. Default key is the endpoint URL with userinfo and query/fragment stripped to avoid leaking embedded credentials.

Clones preserve the caller-supplied `agent_context` override where applicable.

No pipeline changes — `runner.py:1080` already falls back to `target.get_agent_context()` when a target satisfies `SupportsAgentContext`, and degrades to a minimal context otherwise.

## Test plan

- [x] `uv run pytest -m 'not integration'` — all passed
- [x] `uv run basedpyright` on touched files — 0 errors
- [x] `uv run ruff check src/evaluatorq/integrations` — clean
- [x] Unit tests added per target:
  - LangGraph: end-to-end `create_react_agent` roundtrip, empty-nodes fallback, checkpointer-present memory entry, tool dedup across ToolNodes, override path
  - OpenAI Agents: field roundtrip (tools/instructions/model), object-typed model unwrap
  - Callable: default minimal context uses `fn.__name__`, override returns verbatim, clone preserves override
  - Vercel: default minimal context uses scrubbed URL, credential scrubbing test, override returns verbatim, clone preserves override

🤖 Generated with [Claude Code](https://claude.com/claude-code)