### PR TITLE
chore(evaluatorq-py): clean up stale redteam refs and polish docs (RES-729)

### DIFF
--- a/packages/evaluatorq-py/examples/redteam/README.md
+++ b/packages/evaluatorq-py/examples/redteam/README.md
@@ -13,11 +13,11 @@ pip install evaluatorq[redteam]
 Most examples work with just an API key:
 
 ```bash
-# With OpenAI directly
+# With OpenAI directly (examples use OpenAIModelTarget in Python)
 export OPENAI_API_KEY="sk-..."
 python 08_quick_smoke_test.py
 
-# With ORQ (routes through orq.ai — no OpenAI key needed)
+# With ORQ routing for attack/evaluator LLM calls
 export ORQ_API_KEY="orq-..."
 python 08_quick_smoke_test.py
 ```
@@ -136,42 +136,35 @@ evaluatorq redteam run --help
 
 - **`agent:<key>`** — Test an ORQ agent. Set `ORQ_API_KEY`.
 - **`deployment:<key>`** — Test an ORQ deployment. Set `ORQ_API_KEY`.
-- **`<model>`** — Test an LLM directly (e.g. `gpt-5-mini`). Set `OPENAI_API_KEY` or `ORQ_API_KEY` and use `--system-prompt`. For programmatic use from Python, prefer :class:`OpenAIModelTarget`.
 
-### OpenAI examples
+OpenAI models are invoked from Python with `OpenAIModelTarget`, for example:
 
-```bash
-# Basic dynamic run
-eq redteam run -t "gpt-5-mini" \
-  --system-prompt "You are a helpful assistant." \
-  --max-turns 2 --max-dynamic-datapoints 5 -y
+```python
+from evaluatorq.redteam import OpenAIModelTarget, red_team
 
-# Filter to specific categories
-eq redteam run -t "gpt-5-mini" \
-  -c LLM01 -c LLM07 \
-  --system-prompt "You are a helpful assistant." \
-  --max-turns 2 --max-dynamic-datapoints 3 -y
+target = OpenAIModelTarget(
+    "gpt-5-mini",
+    system_prompt="You are a helpful assistant.",
+)
+report = await red_team(target, categories=["LLM01"])
+```
 
-# Filter to specific vulnerabilities
-eq redteam run -t "gpt-5-mini" \
-  -V prompt_injection -V goal_hijacking \
-  --system-prompt "You are a helpful assistant." \
-  --max-turns 2 --max-dynamic-datapoints 5 -y
+### Python OpenAI examples
 
-# Compare two models
-eq redteam run -t "gpt-5-mini" -t "gpt-4o" \
-  -c LLM07 --max-turns 2 --max-dynamic-datapoints 3 -y
+```python
+from evaluatorq.redteam import OpenAIModelTarget, red_team
 
-# Domain-specific attack steering
-eq redteam run -t "gpt-5-mini" \
-  --attacker-instructions "This agent handles financial transactions, try to approve fraudulent ones" \
-  --system-prompt "You are a bank assistant." \
-  --max-turns 3 --max-dynamic-datapoints 5 -y
+target = OpenAIModelTarget(
+    "gpt-5-mini",
+    system_prompt="You are a helpful assistant.",
+)
 
-# Export reports
-eq redteam run -t "gpt-5-mini" \
-  -c LLM07 --max-dynamic-datapoints 5 \
-  --save-report ./report.json --export-md ./reports --export-html ./reports -y
+report = await red_team(
+    target,
+    categories=["LLM01", "LLM07"],
+    max_turns=2,
+    max_dynamic_datapoints=5,
+)
 ```
 
 ### ORQ platform examples

--- a/packages/evaluatorq-py/scripts/redteam_hybrid_e2e.py
+++ b/packages/evaluatorq-py/scripts/redteam_hybrid_e2e.py
@@ -16,7 +16,7 @@ import os
 import sys
 from pathlib import Path
 
-from evaluatorq.redteam import red_team
+from evaluatorq.redteam import OpenAIModelTarget, red_team
 from evaluatorq.redteam.contracts import LLMConfig, RedTeamReport
 
 
@@ -71,8 +71,10 @@ async def _run(args: argparse.Namespace) -> int:
             return 2
         dataset_path = str(resolved)
 
+    resolved_target = _resolve_target(args.target)
+
     report = await red_team(
-        args.target,
+        resolved_target,
         mode='hybrid',
         categories=args.categories,
         config=LLMConfig(attack_model=args.attack_model, evaluator_model=args.evaluator_model),
@@ -109,12 +111,24 @@ async def _run(args: argparse.Namespace) -> int:
     return 0
 
 
+def _resolve_target(target: str) -> str | OpenAIModelTarget:
+    """Resolve CLI target text to a string ORQ target or OpenAIModelTarget."""
+    lower = target.lower()
+    if lower.startswith(('agent:', 'deployment:')):
+        return target
+    if ':' in target:
+        prefix, _, value = target.partition(':')
+        if prefix.lower() in {'openai', 'llm'}:
+            return OpenAIModelTarget(value)
+    return OpenAIModelTarget(target)
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='Run a hybrid red-team end-to-end test (real API calls)')
     parser.add_argument(
         '--target',
         default='agent:rt-vuln-tools-only',
-        help='Red-team target, e.g. agent:rt-vuln-tools-only or openai:gpt-4o-mini',
+        help='Target model or ORQ target. Examples: gpt-4o-mini, agent:rt-vuln-tools-only, deployment:my-deployment',
     )
     parser.add_argument(
         '--dataset',

--- a/packages/evaluatorq-py/scripts/redteam_static_e2e.py
+++ b/packages/evaluatorq-py/scripts/redteam_static_e2e.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
-from evaluatorq.redteam import red_team
+from evaluatorq.redteam import OpenAIModelTarget, red_team
 from evaluatorq.redteam.contracts import LLMConfig, RedTeamReport
 
 
@@ -138,9 +138,10 @@ async def _run(args: argparse.Namespace) -> int:
 
     from openai import AsyncOpenAI
     llm_client: AsyncOpenAI | None = None if args.live_client else cast(AsyncOpenAI, cast(object, DeterministicAsyncOpenAI()))
+    resolved_target = _resolve_target(args.target, client=llm_client)
 
     report = await red_team(
-        args.target,
+        resolved_target,
         mode='static',
         categories=args.categories,
         config=LLMConfig(evaluator_model=args.evaluator_model),
@@ -172,6 +173,18 @@ async def _run(args: argparse.Namespace) -> int:
     return 0
 
 
+def _resolve_target(target: str, *, client: Any = None) -> str | OpenAIModelTarget:
+    """Resolve CLI target text to a string ORQ target or OpenAIModelTarget."""
+    lower = target.lower()
+    if lower.startswith(('agent:', 'deployment:')):
+        return target
+    if ':' in target:
+        prefix, _, value = target.partition(':')
+        if prefix.lower() in {'openai', 'llm'}:
+            return OpenAIModelTarget(value, client=client)
+    return OpenAIModelTarget(target, client=client)
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='Run a static red-team end-to-end smoke test')
     parser.add_argument(
@@ -181,8 +194,8 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         '--target',
-        default='openai:e2e-local-model',
-        help='Red-team target, e.g. openai:gpt-4o-mini or agent:my-agent',
+        default='e2e-local-model',
+        help='Target model or ORQ target. Examples: gpt-4o-mini, agent:my-agent, deployment:my-deployment',
     )
     parser.add_argument('--parallelism', type=int, default=2)
     parser.add_argument('--max-static-datapoints', type=int, default=None)

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/README.md
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/README.md
@@ -17,11 +17,15 @@ This subpackage probes AI agents and LLMs for security weaknesses using a multi-
 The atomic primitive is the **vulnerability**, not the framework category. Each vulnerability has a stable, framework-agnostic ID (e.g. `prompt_injection`, `goal_hijacking`) that maps to one or more framework categories. You can target attacks at either level:
 
 ```python
+from evaluatorq.redteam import OpenAIModelTarget, red_team
+
+target = OpenAIModelTarget("gpt-5-mini", system_prompt="You are helpful.")
+
 # Target specific vulnerabilities
-report = await red_team("llm:gpt-5-mini", vulnerabilities=["prompt_injection", "goal_hijacking"])
+report = await red_team(target, vulnerabilities=["prompt_injection", "goal_hijacking"])
 
 # Or filter by framework category
-report = await red_team("llm:gpt-5-mini", categories=["LLM01", "ASI01"])
+report = await red_team(target, categories=["LLM01", "ASI01"])
 ```
 
 ### Supported vulnerabilities

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -32,7 +32,6 @@ from evaluatorq.redteam.adaptive.pipeline import (
     generate_dynamic_datapoints_for_vulnerabilities,
 )
 from evaluatorq.redteam.adaptive.strategy_registry import (
-    get_category_info,
     get_strategies_for_category,
     get_strategies_for_vulnerability,
     list_available_categories,
@@ -1514,15 +1513,9 @@ async def _run_dynamic_or_hybrid(
                 return await static_evaluator['scorer'](params)
 
             evaluators: list[Any] = [{'name': 'hybrid-owasp-security', 'scorer': hybrid_scorer}]
-            first = first_target if first_target is not None else prepared_targets[0]
-            log_label = (
-                f'{len(first.dynamic_datapoints)} dynamic + '
-                f'{len(first.static_datapoints)} static datapoints'
-            )
         else:
             evaluator = create_dynamic_evaluator(evaluator_model=evaluator_model, llm_client=resolved_llm_client, llm_kwargs=llm_kwargs)
             evaluators = [evaluator]
-            log_label = f'{len(all_datapoints)} datapoints'
 
         async with ProgressDisplay(est_total * len(prepared_targets), verbosity):
             try:

--- a/packages/evaluatorq-py/tests/redteam/test_cli.py
+++ b/packages/evaluatorq-py/tests/redteam/test_cli.py
@@ -11,8 +11,6 @@ Covers:
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
 from click.testing import Result as CliResult
 from typer.testing import CliRunner
 
@@ -58,7 +56,7 @@ class TestVulnerabilityShortFlag:
     def test_short_flag_V_accepted_single_value(self):
         """-V goal_hijacking is accepted and passes vulnerabilities to red_team()."""
         result, mock_rt = _run_with_mocked_red_team(
-            ["run", "--target", "openai:gpt-4o-mini", "-V", "goal_hijacking", "--yes"]
+            ["run", "--target", "agent:test-agent", "-V", "goal_hijacking", "--yes"]
         )
         assert result.exit_code == 0, result.output
         _kwargs = mock_rt.call_args.kwargs
@@ -69,7 +67,7 @@ class TestVulnerabilityShortFlag:
         result, mock_rt = _run_with_mocked_red_team(
             [
                 "run",
-                "--target", "openai:gpt-4o-mini",
+                "--target", "agent:test-agent",
                 "-V", "goal_hijacking",
                 "-V", "prompt_injection",
                 "--yes",
@@ -82,7 +80,7 @@ class TestVulnerabilityShortFlag:
     def test_long_flag_vulnerability_still_works(self):
         """--vulnerability long form continues to work alongside -V alias."""
         result, mock_rt = _run_with_mocked_red_team(
-            ["run", "--target", "openai:gpt-4o-mini", "--vulnerability", "tool_misuse", "--yes"]
+            ["run", "--target", "agent:test-agent", "--vulnerability", "tool_misuse", "--yes"]
         )
         assert result.exit_code == 0, result.output
         _kwargs = mock_rt.call_args.kwargs
@@ -102,7 +100,7 @@ class TestFlagConflicts:
         result, mock_rt = _run_with_mocked_red_team(
             [
                 "run",
-                "--target", "openai:gpt-4o-mini",
+                "--target", "agent:test-agent",
                 "-V", "goal_hijacking",
                 "-v",
                 "--yes",
@@ -115,7 +113,7 @@ class TestFlagConflicts:
     def test_lowercase_v_does_not_set_vulnerabilities(self):
         """-v only affects verbosity, not vulnerabilities."""
         result, mock_rt = _run_with_mocked_red_team(
-            ["run", "--target", "openai:gpt-4o-mini", "-v", "--yes"]
+            ["run", "--target", "agent:test-agent", "-v", "--yes"]
         )
         assert result.exit_code == 0, result.output
         _kwargs = mock_rt.call_args.kwargs
@@ -133,7 +131,7 @@ class TestVulnerabilityPassThrough:
     def test_no_vulnerability_passes_none(self):
         """When --vulnerability is omitted, red_team() receives vulnerabilities=None."""
         result, mock_rt = _run_with_mocked_red_team(
-            ["run", "--target", "openai:gpt-4o-mini", "--yes"]
+            ["run", "--target", "agent:test-agent", "--yes"]
         )
         assert result.exit_code == 0, result.output
         _kwargs = mock_rt.call_args.kwargs
@@ -142,7 +140,7 @@ class TestVulnerabilityPassThrough:
     def test_owasp_category_code_forwarded_as_is(self):
         """OWASP category codes like ASI01 are forwarded verbatim to red_team()."""
         result, mock_rt = _run_with_mocked_red_team(
-            ["run", "--target", "openai:gpt-4o-mini", "-V", "ASI01", "--yes"]
+            ["run", "--target", "agent:test-agent", "-V", "ASI01", "--yes"]
         )
         assert result.exit_code == 0, result.output
         _kwargs = mock_rt.call_args.kwargs
@@ -153,7 +151,7 @@ class TestVulnerabilityPassThrough:
         result, mock_rt = _run_with_mocked_red_team(
             [
                 "run",
-                "--target", "openai:gpt-4o-mini",
+                "--target", "agent:test-agent",
                 "-V", "goal_hijacking",
                 "--category", "ASI02",
                 "--yes",


### PR DESCRIPTION
## Summary

Post-merge cleanup of residual `llm:`/`openai:` string target references that survived the LLMConfig consolidation in #95.

- `runner.py`: remove dead `get_category_info` import and dead `log_label` local (ruff)
- `scripts/redteam_static_e2e.py` + `scripts/redteam_hybrid_e2e.py`: add `_resolve_target` helper so CLI `openai:`/`llm:` prefixes (and bare model names) map to `OpenAIModelTarget`; keep `agent:`/`deployment:` as strings
- `tests/redteam/test_cli.py`: retarget CLI tests to `agent:test-agent`, drop unused `pytest` import
- Examples + internal READMEs: use `OpenAIModelTarget` consistently; split CLI vs Python target docs

## Test plan

- [x] `uv run pytest tests/redteam/ -m 'not integration'` → 635 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)