### PR TITLE
feat(evaluatorq-py): callback-based token capture for LangGraphTarget (RES-741)

### DIFF
--- a/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
@@ -44,10 +44,10 @@ class _TokenUsageCollector(BaseCallbackHandler):
                 # underlying API call; iterating all candidates would multiply-count.
                 gen = inner[0]
                 meta = getattr(getattr(gen, "message", None), "usage_metadata", None)
-                if not meta:
+                if meta is None:
                     continue
-                prompt = int(meta.get("input_tokens") or 0)
-                completion = int(meta.get("output_tokens") or 0)
+                prompt = int(meta.get("input_tokens")) if meta.get("input_tokens") is not None else 0
+                completion = int(meta.get("output_tokens")) if meta.get("output_tokens") is not None else 0
                 raw_total = meta.get("total_tokens")
                 # CRITICAL: use `is not None`, not truthiness — total_tokens=0 is valid.
                 total = int(raw_total) if raw_total is not None else prompt + completion
@@ -126,6 +126,8 @@ class LangGraphTarget(AgentTarget):
         self._extra_config = config or {}
         self.memory_entity_id: str = uuid4().hex
         self._agent_context = agent_context
+        # NOTE: _last_token_usage is not safe for concurrent send_prompt calls on
+        # the same instance — use .new() to get independent instances for parallel use.
         self._last_token_usage: TokenUsage | None = None
         graph_name: str = getattr(graph, "name", None) or "langgraph_target"
         self._key = f"{graph_name}_{uuid4().hex[:8]}"
@@ -160,6 +162,11 @@ class LangGraphTarget(AgentTarget):
             new_callbacks = manager_copy
         else:
             # Unknown type — wrap alongside existing without mutating.
+            logger.warning(
+                "LangGraphTarget: unrecognised callbacks type %s; wrapping in list. "
+                "Pass a list or BaseCallbackManager instead.",
+                type(existing).__name__,
+            )
             new_callbacks = [existing, collector]
 
         new_config: RunnableConfig = {**base_config, "callbacks": new_callbacks}
@@ -194,7 +201,12 @@ class LangGraphTarget(AgentTarget):
         return content
 
     def consume_last_token_usage(self) -> TokenUsage | None:
-        """Return and clear token usage from the last send_prompt() call."""
+        """Return and clear token usage from the last send_prompt() call.
+
+        Must be called between send_prompt() calls to avoid silently dropping
+        usage from earlier calls — each new send_prompt() overwrites the stored
+        value regardless of whether it has been consumed.
+        """
         usage = self._last_token_usage
         self._last_token_usage = None
         return usage

--- a/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
@@ -55,7 +55,7 @@ class _TokenUsageCollector(BaseCallbackHandler):
                 self.completion_tokens += completion
                 self.total_tokens += total
                 self.calls += 1
-        except BaseException as exc:
+        except Exception as exc:
             logger.warning("_TokenUsageCollector.on_llm_end: failed to extract usage: %s", exc)
 
     def on_llm_error(self, error: BaseException, **kwargs: Any) -> None:
@@ -67,7 +67,7 @@ class _TokenUsageCollector(BaseCallbackHandler):
                 partial_result = getattr(response, "llm_result", None) or getattr(response, "llm_output", None)
                 if isinstance(partial_result, LLMResult):
                     self.on_llm_end(partial_result)
-        except BaseException as exc:
+        except Exception as exc:
             logger.warning("_TokenUsageCollector.on_llm_error: failed to extract partial usage: %s", exc)
 
     def to_token_usage(self) -> TokenUsage | None:
@@ -152,10 +152,10 @@ class LangGraphTarget(AgentTarget):
             new_callbacks: Any = [collector]
         elif isinstance(existing, list):
             new_callbacks = [*existing, collector]
-        elif isinstance(existing, BaseCallbackManager):
+        elif isinstance(existing, BaseCallbackManager) and hasattr(existing, "copy"):
             # Copy before mutating — avoid accumulating stale collectors on the
             # original manager across repeated send_prompt calls and .new() clones.
-            manager_copy = existing.copy() if hasattr(existing, "copy") else existing
+            manager_copy = existing.copy()
             manager_copy.add_handler(collector, inherit=True)
             new_callbacks = manager_copy
         else:

--- a/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
@@ -2,16 +2,84 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.callbacks.base import BaseCallbackManager
+from langchain_core.outputs import LLMResult
 from langchain_core.runnables import RunnableConfig
 
 from evaluatorq.redteam.backends.base import AgentTarget
-from evaluatorq.redteam.contracts import AgentContext, MemoryStoreInfo, ToolInfo
+from evaluatorq.redteam.contracts import AgentContext, MemoryStoreInfo, TokenUsage, ToolInfo
 
 if TYPE_CHECKING:
     from langgraph.graph.state import CompiledStateGraph
+
+logger = logging.getLogger(__name__)
+
+
+class _TokenUsageCollector(BaseCallbackHandler):
+    """Sync LangChain callback handler that accumulates token usage across LLM calls.
+
+    Subclasses sync ``BaseCallbackHandler`` (not ``AsyncCallbackHandler``) so it
+    is invoked correctly from both ``invoke`` and ``ainvoke`` call paths.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.prompt_tokens: int = 0
+        self.completion_tokens: int = 0
+        self.total_tokens: int = 0
+        self.calls: int = 0
+
+    def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
+        """Accumulate token usage from a completed LLM call."""
+        try:
+            for inner in response.generations:
+                if not inner:
+                    continue
+                # Only read first candidate — higher-n sampling reuses the same
+                # underlying API call; iterating all candidates would multiply-count.
+                gen = inner[0]
+                meta = getattr(getattr(gen, "message", None), "usage_metadata", None)
+                if not meta:
+                    continue
+                prompt = int(meta.get("input_tokens") or 0)
+                completion = int(meta.get("output_tokens") or 0)
+                raw_total = meta.get("total_tokens")
+                # CRITICAL: use `is not None`, not truthiness — total_tokens=0 is valid.
+                total = int(raw_total) if raw_total is not None else prompt + completion
+                self.prompt_tokens += prompt
+                self.completion_tokens += completion
+                self.total_tokens += total
+                self.calls += 1
+        except BaseException as exc:
+            logger.warning("_TokenUsageCollector.on_llm_end: failed to extract usage: %s", exc)
+
+    def on_llm_error(self, error: BaseException, **kwargs: Any) -> None:
+        """Handle LLM errors — try to extract partial usage, otherwise no-op."""
+        try:
+            # Some providers attach a partial LLMResult / usage on the exception.
+            response = getattr(error, "response", None)
+            if response is not None:
+                partial_result = getattr(response, "llm_result", None) or getattr(response, "llm_output", None)
+                if isinstance(partial_result, LLMResult):
+                    self.on_llm_end(partial_result)
+        except BaseException as exc:
+            logger.warning("_TokenUsageCollector.on_llm_error: failed to extract partial usage: %s", exc)
+
+    def to_token_usage(self) -> TokenUsage | None:
+        """Return aggregated usage, or None if no calls were recorded."""
+        if self.calls == 0:
+            return None
+        return TokenUsage(
+            prompt_tokens=self.prompt_tokens,
+            completion_tokens=self.completion_tokens,
+            total_tokens=self.total_tokens,
+            calls=self.calls,
+        )
 
 
 class LangGraphTarget(AgentTarget):
@@ -58,6 +126,7 @@ class LangGraphTarget(AgentTarget):
         self._extra_config = config or {}
         self.memory_entity_id: str = uuid4().hex
         self._agent_context = agent_context
+        self._last_token_usage: TokenUsage | None = None
         graph_name: str = getattr(graph, "name", None) or "langgraph_target"
         self._key = f"{graph_name}_{uuid4().hex[:8]}"
 
@@ -74,10 +143,37 @@ class LangGraphTarget(AgentTarget):
 
     async def send_prompt(self, prompt: str) -> str:
         """Send a prompt to the LangGraph agent and return its text response."""
-        result = await self._graph.ainvoke(
-            {"messages": [{"role": "user", "content": prompt}]},
-            config=self._build_config(),
-        )
+        collector = _TokenUsageCollector()
+
+        base_config = self._build_config()
+        existing = base_config.get("callbacks")
+
+        if existing is None:
+            new_callbacks: Any = [collector]
+        elif isinstance(existing, list):
+            new_callbacks = [*existing, collector]
+        elif isinstance(existing, BaseCallbackManager):
+            # Copy before mutating — avoid accumulating stale collectors on the
+            # original manager across repeated send_prompt calls and .new() clones.
+            manager_copy = existing.copy() if hasattr(existing, "copy") else existing
+            manager_copy.add_handler(collector, inherit=True)
+            new_callbacks = manager_copy
+        else:
+            # Unknown type — wrap alongside existing without mutating.
+            new_callbacks = [existing, collector]
+
+        new_config: RunnableConfig = {**base_config, "callbacks": new_callbacks}
+
+        try:
+            result = await self._graph.ainvoke(
+                {"messages": [{"role": "user", "content": prompt}]},
+                config=new_config,
+            )
+        finally:
+            # Always persist usage — including when ainvoke raises — so that
+            # error-path token spend is not silently dropped.
+            self._last_token_usage = collector.to_token_usage()
+
         messages = result.get("messages")
         if messages is None:
             raise ValueError(
@@ -96,6 +192,12 @@ class LangGraphTarget(AgentTarget):
         if not isinstance(content, str):
             content = str(content)
         return content
+
+    def consume_last_token_usage(self) -> TokenUsage | None:
+        """Return and clear token usage from the last send_prompt() call."""
+        usage = self._last_token_usage
+        self._last_token_usage = None
+        return usage
 
     async def get_agent_context(self) -> AgentContext:
         """Return agent context introspected from the compiled graph.

--- a/packages/evaluatorq-py/tests/unit/test_langgraph_target.py
+++ b/packages/evaluatorq-py/tests/unit/test_langgraph_target.py
@@ -223,3 +223,298 @@ class TestLangGraphTargetAgentContext:
 
         ctx = await target.get_agent_context()
         assert ctx is override
+
+
+class TestLangGraphTargetTokenUsage:
+    """Tests for callback-handler-based token usage capture."""
+
+    def test_direct_collector_accumulates_usage(self) -> None:
+        """Collector accumulates tokens from a real LLMResult with ChatGeneration."""
+        from langchain_core.messages import AIMessage
+        from langchain_core.messages.ai import UsageMetadata
+        from langchain_core.outputs import ChatGeneration, LLMResult
+
+        from evaluatorq.integrations.langgraph_integration.target import _TokenUsageCollector
+
+        collector = _TokenUsageCollector()
+        msg = AIMessage(
+            content="hi",
+            usage_metadata=UsageMetadata(input_tokens=100, output_tokens=10, total_tokens=110),
+        )
+        gen = ChatGeneration(message=msg)
+        result = LLMResult(generations=[[gen]])
+        collector.on_llm_end(result)
+
+        assert collector.prompt_tokens == 100
+        assert collector.completion_tokens == 10
+        assert collector.total_tokens == 110
+        assert collector.calls == 1
+
+        usage = collector.to_token_usage()
+        assert usage is not None
+        assert usage.prompt_tokens == 100
+        assert usage.completion_tokens == 10
+        assert usage.total_tokens == 110
+        assert usage.calls == 1
+
+    def test_total_tokens_zero_not_re_synthesized(self) -> None:
+        """total_tokens=0 must be kept as 0, not replaced by prompt+completion sum."""
+        from langchain_core.messages import AIMessage
+        from langchain_core.messages.ai import UsageMetadata
+        from langchain_core.outputs import ChatGeneration, LLMResult
+
+        from evaluatorq.integrations.langgraph_integration.target import _TokenUsageCollector
+
+        collector = _TokenUsageCollector()
+        msg = AIMessage(
+            content="hi",
+            usage_metadata=UsageMetadata(input_tokens=50, output_tokens=50, total_tokens=0),
+        )
+        gen = ChatGeneration(message=msg)
+        result = LLMResult(generations=[[gen]])
+        collector.on_llm_end(result)
+
+        assert collector.total_tokens == 0
+        usage = collector.to_token_usage()
+        assert usage is not None
+        assert usage.total_tokens == 0
+
+    def test_n_greater_than_1_no_double_count(self) -> None:
+        """When n>1, only the first candidate in each inner list is counted."""
+        from langchain_core.messages import AIMessage
+        from langchain_core.messages.ai import UsageMetadata
+        from langchain_core.outputs import ChatGeneration, LLMResult
+
+        from evaluatorq.integrations.langgraph_integration.target import _TokenUsageCollector
+
+        collector = _TokenUsageCollector()
+        meta = UsageMetadata(input_tokens=20, output_tokens=5, total_tokens=25)
+        msg1 = AIMessage(content="candidate 1", usage_metadata=meta)
+        msg2 = AIMessage(content="candidate 2", usage_metadata=meta)
+        gen1 = ChatGeneration(message=msg1)
+        gen2 = ChatGeneration(message=msg2)
+        # Both candidates are in the same inner list (same API call, n=2)
+        result = LLMResult(generations=[[gen1, gen2]])
+        collector.on_llm_end(result)
+
+        # Only gen1 should be counted
+        assert collector.calls == 1
+        assert collector.prompt_tokens == 20
+        assert collector.completion_tokens == 5
+        assert collector.total_tokens == 25
+
+    def test_on_llm_error_does_not_crash(self) -> None:
+        """on_llm_error must not raise; to_token_usage returns None when nothing captured."""
+        from evaluatorq.integrations.langgraph_integration.target import _TokenUsageCollector
+
+        collector = _TokenUsageCollector()
+        collector.on_llm_error(Exception("boom"))
+        assert collector.to_token_usage() is None
+
+    def test_on_llm_error_after_success_preserves_prior_usage(self) -> None:
+        """on_llm_error must not wipe usage captured by a prior on_llm_end call."""
+        from langchain_core.messages import AIMessage
+        from langchain_core.messages.ai import UsageMetadata
+        from langchain_core.outputs import ChatGeneration, LLMResult
+
+        from evaluatorq.integrations.langgraph_integration.target import _TokenUsageCollector
+
+        collector = _TokenUsageCollector()
+        msg = AIMessage(
+            content="ok",
+            usage_metadata=UsageMetadata(input_tokens=10, output_tokens=2, total_tokens=12),
+        )
+        result = LLMResult(generations=[[ChatGeneration(message=msg)]])
+        collector.on_llm_end(result)
+
+        collector.on_llm_error(Exception("later error"))
+
+        usage = collector.to_token_usage()
+        assert usage is not None
+        assert usage.calls == 1
+        assert usage.prompt_tokens == 10
+
+    @pytest.mark.asyncio
+    async def test_callbacks_as_list_integration(self) -> None:
+        """Collector is appended after existing list callbacks; both reach ainvoke."""
+        from langchain_core.callbacks import BaseCallbackHandler
+
+        class SentinelHandler(BaseCallbackHandler):
+            pass
+
+        sentinel = SentinelHandler()
+        graph = _make_graph("response")
+        target = LangGraphTarget(graph, config={"callbacks": [sentinel]})
+        await target.send_prompt("hi")
+
+        config_passed = graph.ainvoke.call_args[1]["config"]
+        callbacks = config_passed["callbacks"]
+        assert isinstance(callbacks, list)
+        assert len(callbacks) == 2
+        assert callbacks[0] is sentinel
+
+        from evaluatorq.integrations.langgraph_integration.target import _TokenUsageCollector
+        assert isinstance(callbacks[1], _TokenUsageCollector)
+
+    @pytest.mark.asyncio
+    async def test_callbacks_as_manager_not_mutated(self) -> None:
+        """Original BaseCallbackManager must not be mutated across send_prompt calls.
+
+        The implementation must copy the manager before adding the per-call collector
+        so that stale collectors do not accumulate on the original instance or on
+        .new() clones that share the same _extra_config reference.
+        """
+        from langchain_core.callbacks.manager import AsyncCallbackManager
+
+        from evaluatorq.integrations.langgraph_integration.target import _TokenUsageCollector
+
+        original_manager = MagicMock(spec=AsyncCallbackManager)
+        # copy() must return a fresh mock so we can assert the original was not touched.
+        manager_copy = MagicMock(spec=AsyncCallbackManager)
+        original_manager.copy.return_value = manager_copy
+
+        graph = _make_graph("response")
+        target = LangGraphTarget(graph, config={"callbacks": original_manager})
+
+        await target.send_prompt("first")
+        await target.send_prompt("second")
+
+        # copy() called once per send_prompt — never mutate the original.
+        assert original_manager.copy.call_count == 2
+        original_manager.add_handler.assert_not_called()
+
+        # add_handler was called on the copy, not the original.
+        assert manager_copy.add_handler.call_count == 2
+        first_arg = manager_copy.add_handler.call_args_list[0][0][0]
+        assert isinstance(first_arg, _TokenUsageCollector)
+
+    @pytest.mark.asyncio
+    async def test_new_yields_independent_token_state(self) -> None:
+        """Parent and clone have independent _last_token_usage after respective calls."""
+        from langchain_core.messages import AIMessage
+        from langchain_core.messages.ai import UsageMetadata
+        from langchain_core.outputs import ChatGeneration, LLMResult
+
+        from evaluatorq.integrations.langgraph_integration.target import _TokenUsageCollector
+
+        # Set up a graph that fires on_llm_end via a real collector invocation.
+        # We use a custom ainvoke side-effect to simulate the callback being fired.
+        captured_collectors: list[_TokenUsageCollector] = []
+
+        def _fake_ainvoke(input_dict: dict, *, config: dict) -> dict:
+            callbacks = config.get("callbacks", [])
+            for cb in (callbacks if isinstance(callbacks, list) else []):
+                if isinstance(cb, _TokenUsageCollector):
+                    captured_collectors.append(cb)
+                    meta = UsageMetadata(input_tokens=7, output_tokens=3, total_tokens=10)
+                    msg = AIMessage(content="ok", usage_metadata=meta)
+                    gen = ChatGeneration(message=msg)
+                    cb.on_llm_end(LLMResult(generations=[[gen]]))
+            return {"messages": [MagicMock(content="ok")]}
+
+        graph = MagicMock()
+        graph.name = "test_graph"
+        graph.ainvoke = AsyncMock(side_effect=_fake_ainvoke)
+
+        parent = LangGraphTarget(graph)
+        await parent.send_prompt("p1")
+        parent_usage = parent._last_token_usage
+
+        clone = parent.new()
+        await clone.send_prompt("p2")
+        clone_usage = clone._last_token_usage
+
+        assert parent_usage is not None
+        assert clone_usage is not None
+        assert parent_usage is not clone_usage
+        # Parent's state is unaffected by clone's call
+        assert parent._last_token_usage is parent_usage
+
+    @pytest.mark.asyncio
+    async def test_usage_persisted_when_ainvoke_raises(self) -> None:
+        """Token usage captured before ainvoke fails must still be recorded.
+
+        on_llm_error can fire before ainvoke propagates the exception.
+        The try/finally in send_prompt must persist the collector's state even
+        when ainvoke raises, so error-path token spend is not silently dropped.
+        """
+        from langchain_core.messages import AIMessage
+        from langchain_core.outputs import ChatGeneration, LLMResult
+
+        from evaluatorq.integrations.langgraph_integration.target import _TokenUsageCollector
+
+        ai_msg = AIMessage(
+            content="partial",
+            usage_metadata={"input_tokens": 40, "output_tokens": 5, "total_tokens": 45},
+        )
+        gen = ChatGeneration(message=ai_msg)
+
+        graph = MagicMock()
+        graph.name = "test_graph"
+
+        # Collector fires on_llm_end before ainvoke raises — simulate by calling
+        # on_llm_end ourselves then having ainvoke raise.
+        collector_ref: list[_TokenUsageCollector] = []
+
+        async def failing_ainvoke(input: Any, config: Any) -> Any:  # noqa: A002
+            # Grab the collector injected into config and fire on_llm_end on it.
+            handlers = config.get("callbacks") or []
+            for h in handlers:
+                if isinstance(h, _TokenUsageCollector):
+                    collector_ref.append(h)
+                    h.on_llm_end(LLMResult(generations=[[gen]]))
+            raise RuntimeError("provider error")
+
+        graph.ainvoke = failing_ainvoke
+
+        target = LangGraphTarget(graph)
+        with pytest.raises(RuntimeError, match="provider error"):
+            await target.send_prompt("hi")
+
+        # Despite the exception, token usage must be stored.
+        usage = target.consume_last_token_usage()
+        assert usage is not None
+        assert usage.prompt_tokens == 40
+        assert usage.completion_tokens == 5
+
+    @pytest.mark.asyncio
+    async def test_consume_clears_state(self) -> None:
+        """consume_last_token_usage() returns usage first call, None on second."""
+        from langchain_core.messages import AIMessage
+        from langchain_core.messages.ai import UsageMetadata
+        from langchain_core.outputs import ChatGeneration, LLMResult
+
+        from evaluatorq.integrations.langgraph_integration.target import _TokenUsageCollector
+
+        def _fake_ainvoke(input_dict: dict, *, config: dict) -> dict:
+            callbacks = config.get("callbacks", [])
+            for cb in (callbacks if isinstance(callbacks, list) else []):
+                if isinstance(cb, _TokenUsageCollector):
+                    meta = UsageMetadata(input_tokens=5, output_tokens=2, total_tokens=7)
+                    msg = AIMessage(content="ok", usage_metadata=meta)
+                    gen = ChatGeneration(message=msg)
+                    cb.on_llm_end(LLMResult(generations=[[gen]]))
+            return {"messages": [MagicMock(content="ok")]}
+
+        graph = MagicMock()
+        graph.name = "test_graph"
+        graph.ainvoke = AsyncMock(side_effect=_fake_ainvoke)
+
+        target = LangGraphTarget(graph)
+        await target.send_prompt("hi")
+
+        first = target.consume_last_token_usage()
+        assert first is not None
+        assert first.total_tokens == 7
+
+        second = target.consume_last_token_usage()
+        assert second is None
+
+    @pytest.mark.asyncio
+    async def test_no_usage_metadata_returns_none(self) -> None:
+        """When graph fires no LLM callbacks, to_token_usage returns None."""
+        graph = _make_graph("no usage")
+        target = LangGraphTarget(graph)
+        await target.send_prompt("hi")
+        # ainvoke mock doesn't fire callbacks, so collector gets no calls
+        assert target.consume_last_token_usage() is None

--- a/packages/evaluatorq-py/tests/unit/test_langgraph_target.py
+++ b/packages/evaluatorq-py/tests/unit/test_langgraph_target.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -401,7 +402,7 @@ class TestLangGraphTargetTokenUsage:
         # We use a custom ainvoke side-effect to simulate the callback being fired.
         captured_collectors: list[_TokenUsageCollector] = []
 
-        def _fake_ainvoke(input_dict: dict, *, config: dict) -> dict:
+        def _fake_ainvoke(input_dict: dict[str, Any], *, config: dict[str, Any]) -> dict[str, Any]:
             callbacks = config.get("callbacks", [])
             for cb in (callbacks if isinstance(callbacks, list) else []):
                 if isinstance(cb, _TokenUsageCollector):
@@ -486,7 +487,7 @@ class TestLangGraphTargetTokenUsage:
 
         from evaluatorq.integrations.langgraph_integration.target import _TokenUsageCollector
 
-        def _fake_ainvoke(input_dict: dict, *, config: dict) -> dict:
+        def _fake_ainvoke(input_dict: dict[str, Any], *, config: dict[str, Any]) -> dict[str, Any]:
             callbacks = config.get("callbacks", [])
             for cb in (callbacks if isinstance(callbacks, list) else []):
                 if isinstance(cb, _TokenUsageCollector):


### PR DESCRIPTION
## Summary

- Replaces message-list diffing with a `BaseCallbackHandler` injected per `send_prompt` call via `RunnableConfig.callbacks`
- Eliminates silent token loss from compaction, reducer rewrites, shrinking state, and parallel graph branches
- Manager copy-before-mutate prevents stale collector accumulation across repeated calls and `.new()` clones
- `try/finally` on `ainvoke` ensures error-path token spend is always persisted
- Keeps `consume_last_token_usage()` interface unchanged — no call-site changes in pipeline/orchestrator

## Test plan

- [ ] 28 unit tests pass (`tests/unit/test_langgraph_target.py`)
- [ ] 642 redteam unit tests pass (`tests/redteam -m 'not integration'`)
- [ ] `ruff check` clean on `target.py`
- [ ] Callback manager not mutated: `test_callbacks_as_manager_not_mutated`
- [ ] Error-path persistence: `test_usage_persisted_when_ainvoke_raises`
- [ ] Integration: red team run against LangGraph target produces non-null `execution.token_usage` for every result

Linear: [RES-741](https://linear.app/orqai/issue/RES-741/fix-langgraph-token-usage-tracking-callback-based-capture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)