### PR TITLE
fix(n8n-nodes-orq): add author email for n8n verification submission

### DIFF
--- a/packages/n8n-nodes-orq/package.json
+++ b/packages/n8n-nodes-orq/package.json
@@ -32,7 +32,8 @@
     "url": "https://github.com/orq-ai/orqkit/issues"
   },
   "author": {
-    "name": "orq.ai"
+    "name": "orq.ai",
+    "email": "kevin.lopez@orq.ai"
   },
   "engines": {
     "node": ">=20.15"


### PR DESCRIPTION
## Summary
- Add `author.email` to `packages/n8n-nodes-orq/package.json` so the n8n verification submission form can resolve. Without it the form errors out with "error getting author email npm".
