### PR TITLE
feat(redteam): emit call counts and truncate span text payloads

### DIFF
--- a/packages/evaluatorq-py/pyproject.toml
+++ b/packages/evaluatorq-py/pyproject.toml
@@ -149,7 +149,7 @@ version = "1.3.1"
 description = "An evaluation framework library for Python that provides a flexible way to run parallel evaluations and optionally integrate with the Orq AI platform."
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = [ "pydantic>=2.0", "httpx>=0.28.1", "rich>=14.2.0" ]
+dependencies = [ "pydantic>=2.0", "httpx>=0.28.1", "rich>=14.2.0", "loguru>=0.6.0" ]
 
   [project.license]
   text = "MIT"
@@ -167,7 +167,6 @@ dependencies = [ "pydantic>=2.0", "httpx>=0.28.1", "rich>=14.2.0" ]
   openai-agents = [ "openai-agents>=0.1.0" ]
   redteam = [
   "openai>=1.0.0,<3.0.0",
-  "loguru>=0.6.0",
   "typer>=0.12.0",
   "python-dotenv>=1.0.0",
   "huggingface-hub>=0.20.0"
@@ -203,7 +202,6 @@ dev = [
   "langchain-core>=0.3.0",
   "langchain-openai>=0.3.0",
   "langgraph>=0.2.0",
-  "loguru",
   "typer>=0.12.0",
   "python-dotenv>=1.0.0",
   "pytest-cov>=7.0.0",

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/tracing.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/tracing.py
@@ -36,9 +36,13 @@ All other red teaming spans use ``SpanKind.INTERNAL``.
 
 from __future__ import annotations
 
+import functools
 import json
+import os
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
+
+from loguru import logger
 
 from evaluatorq.tracing.setup import get_tracer
 
@@ -237,7 +241,10 @@ def record_llm_response(
         input_tokens = int(getattr(usage, 'prompt_tokens', 0) or 0)
         output_tokens = int(getattr(usage, 'completion_tokens', 0) or 0)
         raw_total = getattr(usage, 'total_tokens', None)
-        total = int(raw_total) if raw_total else (input_tokens + output_tokens)
+        if raw_total is not None and int(raw_total) > 0:
+            total = int(raw_total)
+        else:
+            total = input_tokens + output_tokens
         span.set_attribute("gen_ai.usage.input_tokens", input_tokens)
         span.set_attribute("gen_ai.usage.output_tokens", output_tokens)
         span.set_attribute("gen_ai.usage.prompt_tokens", input_tokens)
@@ -271,7 +278,8 @@ def record_llm_response(
     # Output content
     if output_content is not None:
         serialized = json.dumps(
-            [{"role": "assistant", "content": output_content}], ensure_ascii=False,
+            [{"role": "assistant", "content": truncate_for_span(output_content)}],
+            ensure_ascii=False,
         )
         span.set_attribute("gen_ai.output.messages", serialized)
         span.set_attribute("output", serialized)
@@ -310,6 +318,10 @@ def record_token_usage(
     span.set_attribute("input_tokens", prompt_tokens)
     span.set_attribute("output_tokens", completion_tokens)
     span.set_attribute("total_tokens", computed_total)
+    # Call count — records how many LLM calls contributed to this aggregate
+    if calls:
+        span.set_attribute("gen_ai.usage.calls", calls)
+        span.set_attribute("calls", calls)
 
 
 def _derive_provider(model: str) -> str:
@@ -323,19 +335,77 @@ def _derive_provider(model: str) -> str:
     return "openai"
 
 
-def _sanitize_messages(
-    messages: list[Any],
-) -> list[dict[str, str]]:
-    """Produce a JSON-safe list of {role, content} dicts.
+_TRUNCATION_MARKER = '... [truncated]'
 
-    Truncates very long content to keep span attributes bounded.
+
+@functools.lru_cache(maxsize=1)
+def _default_span_max_text_chars() -> int | None:
+    """Read EVALUATORQ_SPAN_MAX_TEXT_CHARS once. Default ``None`` = unlimited.
+
+    Set the env var to a positive integer to cap span text payloads. ``0``
+    is also treated as unlimited. Negative values raise ``ValueError``.
+
+    Use ``_default_span_max_text_chars.cache_clear()`` in tests to force
+    re-read after changing the env var.
     """
-    MAX_CONTENT_LEN = 2000
+    raw = os.getenv('EVALUATORQ_SPAN_MAX_TEXT_CHARS')
+    if raw is None or raw == '':
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            'EVALUATORQ_SPAN_MAX_TEXT_CHARS=%r is not a valid int; ignoring (truncation disabled)',
+            raw,
+        )
+        return None
+    if value < 0:
+        raise ValueError(
+            f'EVALUATORQ_SPAN_MAX_TEXT_CHARS must be non-negative, got {value}'
+        )
+    return value
+
+
+def truncate_for_span(text: object, *, max_chars: int | None = None) -> str:
+    """Truncate text for span attribute storage.
+
+    Defaults to ``EVALUATORQ_SPAN_MAX_TEXT_CHARS`` env var (or ``None`` =
+    unlimited if unset). ``None`` and ``0`` both disable truncation.
+    Negative values raise ``ValueError``.
+
+    Output never exceeds ``max_chars``: the marker ``... [truncated]`` is
+    reserved within the budget when truncation fires.
+    """
+    if isinstance(text, str):
+        s = text
+    else:
+        try:
+            s = str(text)
+        except Exception as e:  # pragma: no cover  # noqa: BLE001
+            s = f'<unrepresentable {type(text).__name__}: {e}>'
+    if max_chars is None:
+        max_chars = _default_span_max_text_chars()
+    if max_chars is None or max_chars == 0:
+        return s
+    if max_chars < 0:
+        raise ValueError(f'max_chars must be non-negative, got {max_chars}')
+    if len(s) <= max_chars:
+        return s
+    marker_len = len(_TRUNCATION_MARKER)
+    if max_chars <= marker_len:
+        return _TRUNCATION_MARKER[:max_chars]
+    return s[: max_chars - marker_len] + _TRUNCATION_MARKER
+
+
+def _sanitize_messages(messages: list[Any]) -> list[dict[str, str]]:
+    """JSON-safe list of {role, content}. Accepts dicts or pydantic message-like objects."""
     sanitized: list[dict[str, str]] = []
     for msg in messages:
-        role = str(msg.get('role', ''))
-        content = str(msg.get('content', ''))
-        if len(content) > MAX_CONTENT_LEN:
-            content = content[:MAX_CONTENT_LEN] + '... [truncated]'
-        sanitized.append({'role': role, 'content': content})
+        if hasattr(msg, 'get') and callable(msg.get):
+            role = msg.get('role', '')
+            content = msg.get('content', '')
+        else:
+            role = getattr(msg, 'role', '')
+            content = getattr(msg, 'content', '')
+        sanitized.append({'role': str(role), 'content': truncate_for_span(content)})
     return sanitized

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/tracing.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/tracing.py
@@ -355,14 +355,17 @@ def _default_span_max_text_chars() -> int | None:
         value = int(raw)
     except ValueError:
         logger.warning(
-            'EVALUATORQ_SPAN_MAX_TEXT_CHARS=%r is not a valid int; ignoring (truncation disabled)',
+            'EVALUATORQ_SPAN_MAX_TEXT_CHARS={!r} is not a valid int; ignoring (truncation disabled)',
             raw,
+        )
         )
         return None
     if value < 0:
-        raise ValueError(
-            f'EVALUATORQ_SPAN_MAX_TEXT_CHARS must be non-negative, got {value}'
+        logger.warning(
+            'EVALUATORQ_SPAN_MAX_TEXT_CHARS={!r} must be non-negative; ignoring (truncation disabled)',
+            value,
         )
+        return None
     return value
 
 

--- a/packages/evaluatorq-py/tests/redteam/test_truncate_for_span.py
+++ b/packages/evaluatorq-py/tests/redteam/test_truncate_for_span.py
@@ -263,10 +263,8 @@ class TestTruncateForSpanEnvOverride:
         try:
             with caplog.at_level(logging.WARNING):
                 _default_span_max_text_chars()
-            # Either loguru or stdlib warning should contain the bad value
-            # (loguru propagates to stdlib by default in test environments)
             all_messages = " ".join(caplog.messages)
-            # If loguru doesn't propagate, the function still returns None correctly
+            assert "bad_value" in all_messages, f"Expected bad_value in warning, got: {all_messages!r}"
             assert _default_span_max_text_chars.cache_info().currsize >= 1
         finally:
             _default_span_max_text_chars.cache_clear()

--- a/packages/evaluatorq-py/tests/redteam/test_truncate_for_span.py
+++ b/packages/evaluatorq-py/tests/redteam/test_truncate_for_span.py
@@ -1,0 +1,272 @@
+"""Unit tests for truncate_for_span and _default_span_max_text_chars.
+
+Covers evaluatorq.redteam.tracing.truncate_for_span and
+evaluatorq.redteam.tracing._default_span_max_text_chars.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestTruncateForSpanExplicitMaxChars:
+    def test_default_behavior_returns_input_unchanged(self) -> None:
+        """With env unset and no max_chars, returns input regardless of length."""
+        from evaluatorq.redteam.tracing import _default_span_max_text_chars, truncate_for_span
+
+        _default_span_max_text_chars.cache_clear()
+        long_text = "x" * 10_000
+        assert truncate_for_span(long_text) == long_text
+
+    def test_max_chars_zero_returns_input_unchanged(self) -> None:
+        from evaluatorq.redteam.tracing import truncate_for_span
+
+        text = "x" * 1000
+        assert truncate_for_span(text, max_chars=0) == text
+
+    def test_max_chars_none_returns_input_unchanged(self) -> None:
+        from evaluatorq.redteam.tracing import _default_span_max_text_chars, truncate_for_span
+
+        _default_span_max_text_chars.cache_clear()
+        text = "hello world " * 100
+        assert truncate_for_span(text, max_chars=None) == text
+
+    def test_short_input_unchanged(self) -> None:
+        """Input shorter than max_chars is returned unchanged."""
+        from evaluatorq.redteam.tracing import truncate_for_span
+
+        text = "hello"
+        assert truncate_for_span(text, max_chars=100) == text
+
+    def test_exact_length_input_unchanged(self) -> None:
+        """Input exactly max_chars long is returned unchanged."""
+        from evaluatorq.redteam.tracing import truncate_for_span
+
+        text = "x" * 50
+        assert truncate_for_span(text, max_chars=50) == text
+
+    def test_long_input_truncated_to_max_chars(self) -> None:
+        """Output is exactly max_chars long when input exceeds max_chars."""
+        from evaluatorq.redteam.tracing import truncate_for_span
+
+        text = "x" * 200
+        result = truncate_for_span(text, max_chars=100)
+        assert len(result) == 100
+
+    def test_long_input_ends_with_marker(self) -> None:
+        """Truncated output ends with '... [truncated]' marker."""
+        from evaluatorq.redteam.tracing import _TRUNCATION_MARKER, truncate_for_span
+
+        text = "x" * 200
+        result = truncate_for_span(text, max_chars=100)
+        assert result.endswith(_TRUNCATION_MARKER)
+
+    def test_output_never_exceeds_max_chars(self) -> None:
+        """Output length is always <= max_chars."""
+        from evaluatorq.redteam.tracing import truncate_for_span
+
+        for max_chars in [1, 5, 15, 16, 50, 100]:
+            text = "a" * (max_chars * 2)
+            result = truncate_for_span(text, max_chars=max_chars)
+            assert len(result) <= max_chars, f"Failed for max_chars={max_chars}"
+
+    def test_degenerate_max_chars_at_or_below_marker_length(self) -> None:
+        """When max_chars <= len(marker), return marker truncated to max_chars so truncation is signalled."""
+        from evaluatorq.redteam.tracing import _TRUNCATION_MARKER, truncate_for_span
+
+        marker_len = len(_TRUNCATION_MARKER)
+        text = "x" * 100
+
+        # Exactly at marker length — full marker is returned
+        result = truncate_for_span(text, max_chars=marker_len)
+        assert len(result) == marker_len
+        assert result == _TRUNCATION_MARKER  # budget fits the marker exactly
+
+        # One below marker length — marker is trimmed to fit budget
+        result = truncate_for_span(text, max_chars=marker_len - 1)
+        assert len(result) == marker_len - 1
+        assert result == _TRUNCATION_MARKER[: marker_len - 1]
+
+    def test_degenerate_max_chars_one_returns_first_marker_char(self) -> None:
+        """With max_chars=1, return the first character of the truncation marker."""
+        from evaluatorq.redteam.tracing import _TRUNCATION_MARKER, truncate_for_span
+
+        text = "x" * 100
+        result = truncate_for_span(text, max_chars=1)
+        assert result == _TRUNCATION_MARKER[:1]
+        assert len(result) == 1
+
+    def test_negative_max_chars_raises_value_error(self) -> None:
+        from evaluatorq.redteam.tracing import truncate_for_span
+
+        with pytest.raises(ValueError, match="non-negative"):
+            truncate_for_span("hello", max_chars=-1)
+
+    def test_large_negative_max_chars_raises_value_error(self) -> None:
+        from evaluatorq.redteam.tracing import truncate_for_span
+
+        with pytest.raises(ValueError):
+            truncate_for_span("hello", max_chars=-999)
+
+    def test_non_string_input_coerced_via_str(self) -> None:
+        """Non-string input is coerced via str() before truncation."""
+        from evaluatorq.redteam.tracing import truncate_for_span
+
+        result = truncate_for_span(123, max_chars=10)
+        assert result == "123"
+
+    def test_non_string_large_coerced_and_truncated(self) -> None:
+        """Non-string values that stringify longer than max_chars are truncated."""
+        from evaluatorq.redteam.tracing import _TRUNCATION_MARKER, truncate_for_span
+
+        long_list = list(range(1000))
+        result = truncate_for_span(long_list, max_chars=50)
+        assert len(result) == 50
+        assert result.endswith(_TRUNCATION_MARKER)
+
+
+class TestTruncateForSpanEnvOverride:
+    def test_env_override_limits_output(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """EVALUATORQ_SPAN_MAX_TEXT_CHARS env var caps output length."""
+        from evaluatorq.redteam.tracing import _default_span_max_text_chars, truncate_for_span
+
+        monkeypatch.setenv("EVALUATORQ_SPAN_MAX_TEXT_CHARS", "20")
+        _default_span_max_text_chars.cache_clear()
+        try:
+            result = truncate_for_span("x" * 100)
+            assert len(result) == 20
+            from evaluatorq.redteam.tracing import _TRUNCATION_MARKER
+            assert result.endswith(_TRUNCATION_MARKER)
+        finally:
+            _default_span_max_text_chars.cache_clear()
+
+    def test_env_override_zero_means_unlimited(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """EVALUATORQ_SPAN_MAX_TEXT_CHARS=0 means unlimited."""
+        from evaluatorq.redteam.tracing import _default_span_max_text_chars, truncate_for_span
+
+        monkeypatch.setenv("EVALUATORQ_SPAN_MAX_TEXT_CHARS", "0")
+        _default_span_max_text_chars.cache_clear()
+        try:
+            text = "x" * 1000
+            result = truncate_for_span(text)
+            assert result == text
+        finally:
+            _default_span_max_text_chars.cache_clear()
+
+    def test_env_override_invalid_falls_back_to_unlimited(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-integer env value falls back to None (unlimited)."""
+        from evaluatorq.redteam.tracing import _default_span_max_text_chars, truncate_for_span
+
+        monkeypatch.setenv("EVALUATORQ_SPAN_MAX_TEXT_CHARS", "abc")
+        _default_span_max_text_chars.cache_clear()
+        try:
+            text = "x" * 1000
+            result = truncate_for_span(text)
+            assert result == text
+        finally:
+            _default_span_max_text_chars.cache_clear()
+
+    def test_env_unset_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unset env var returns None from _default_span_max_text_chars."""
+        from evaluatorq.redteam.tracing import _default_span_max_text_chars
+
+        monkeypatch.delenv("EVALUATORQ_SPAN_MAX_TEXT_CHARS", raising=False)
+        _default_span_max_text_chars.cache_clear()
+        try:
+            assert _default_span_max_text_chars() is None
+        finally:
+            _default_span_max_text_chars.cache_clear()
+
+    def test_env_empty_string_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty string env var treated same as unset — returns None."""
+        from evaluatorq.redteam.tracing import _default_span_max_text_chars
+
+        monkeypatch.setenv("EVALUATORQ_SPAN_MAX_TEXT_CHARS", "")
+        _default_span_max_text_chars.cache_clear()
+        try:
+            assert _default_span_max_text_chars() is None
+        finally:
+            _default_span_max_text_chars.cache_clear()
+
+    def test_cache_clear_re_reads_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """cache_clear() forces re-read on next call."""
+        from evaluatorq.redteam.tracing import _default_span_max_text_chars
+
+        monkeypatch.setenv("EVALUATORQ_SPAN_MAX_TEXT_CHARS", "100")
+        _default_span_max_text_chars.cache_clear()
+        first = _default_span_max_text_chars()
+        assert first == 100
+
+        monkeypatch.setenv("EVALUATORQ_SPAN_MAX_TEXT_CHARS", "200")
+        _default_span_max_text_chars.cache_clear()
+        second = _default_span_max_text_chars()
+        assert second == 200
+
+        _default_span_max_text_chars.cache_clear()  # clean up
+
+    def test_explicit_max_chars_overrides_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit max_chars parameter overrides env var."""
+        from evaluatorq.redteam.tracing import _default_span_max_text_chars, truncate_for_span
+
+        monkeypatch.setenv("EVALUATORQ_SPAN_MAX_TEXT_CHARS", "10")
+        _default_span_max_text_chars.cache_clear()
+        try:
+            text = "x" * 100
+            # explicit max_chars=50 must win over env=10
+            result = truncate_for_span(text, max_chars=50)
+            assert len(result) == 50
+        finally:
+            _default_span_max_text_chars.cache_clear()
+
+    def test_env_invalid_emits_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Non-integer env value emits a warning before falling back to unlimited."""
+        import logging
+
+        from evaluatorq.redteam.tracing import _default_span_max_text_chars
+
+        monkeypatch.setenv("EVALUATORQ_SPAN_MAX_TEXT_CHARS", "not_a_number")
+        _default_span_max_text_chars.cache_clear()
+        try:
+            with caplog.at_level(logging.WARNING):
+                result = _default_span_max_text_chars()
+            # Function must return None (unlimited) and not raise
+            assert result is None
+        finally:
+            _default_span_max_text_chars.cache_clear()
+
+    def test_env_invalid_warning_message_contains_value(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warning message includes the offending env value."""
+        import logging
+
+        from evaluatorq.redteam.tracing import _default_span_max_text_chars
+
+        monkeypatch.setenv("EVALUATORQ_SPAN_MAX_TEXT_CHARS", "bad_value")
+        _default_span_max_text_chars.cache_clear()
+        try:
+            with caplog.at_level(logging.WARNING):
+                _default_span_max_text_chars()
+            # Either loguru or stdlib warning should contain the bad value
+            # (loguru propagates to stdlib by default in test environments)
+            all_messages = " ".join(caplog.messages)
+            # If loguru doesn't propagate, the function still returns None correctly
+            assert _default_span_max_text_chars.cache_info().currsize >= 1
+        finally:
+            _default_span_max_text_chars.cache_clear()

--- a/packages/evaluatorq-py/uv.lock
+++ b/packages/evaluatorq-py/uv.lock
@@ -539,6 +539,7 @@ version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "loguru" },
     { name = "pydantic" },
     { name = "rich" },
 ]
@@ -549,7 +550,6 @@ all = [
     { name = "kaleido" },
     { name = "langchain" },
     { name = "langgraph" },
-    { name = "loguru" },
     { name = "openai" },
     { name = "openai-agents" },
     { name = "opentelemetry-api" },
@@ -585,7 +585,6 @@ otel = [
 ]
 redteam = [
     { name = "huggingface-hub" },
-    { name = "loguru" },
     { name = "openai" },
     { name = "python-dotenv" },
     { name = "typer" },
@@ -606,7 +605,6 @@ dev = [
     { name = "langchain-core" },
     { name = "langchain-openai" },
     { name = "langgraph" },
-    { name = "loguru" },
     { name = "openai" },
     { name = "openai-agents" },
     { name = "opentelemetry-api" },
@@ -630,7 +628,7 @@ requires-dist = [
     { name = "kaleido", marker = "extra == 'export'", specifier = ">=0.2.1" },
     { name = "langchain", marker = "extra == 'langchain'", specifier = ">=1.0.0,<2.0.0" },
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=0.2.0" },
-    { name = "loguru", marker = "extra == 'redteam'", specifier = ">=0.6.0" },
+    { name = "loguru", specifier = ">=0.6.0" },
     { name = "openai", marker = "extra == 'redteam'", specifier = ">=1.0.0,<3.0.0" },
     { name = "openai", marker = "extra == 'simulation'", specifier = ">=1.0.0,<3.0.0" },
     { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.1.0" },
@@ -656,7 +654,6 @@ dev = [
     { name = "langchain-core", specifier = ">=0.3.0" },
     { name = "langchain-openai", specifier = ">=0.3.0" },
     { name = "langgraph", specifier = ">=0.2.0" },
-    { name = "loguru" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "openai-agents", specifier = ">=0.1.0" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },


### PR DESCRIPTION
## Summary

Stacked on top of #114. Trace-side improvements that fell out of the RES-715 work but ship independently.

- Aggregate spans now expose `gen_ai.usage.calls` so per-attack call counts are visible in traces alongside token counts.
- Span text payloads are truncatable via `EVALUATORQ_SPAN_MAX_TEXT_CHARS` (default unlimited; cached read; invalid values warn-and-ignore) for callers that hit OTLP attribute size limits.
- `total_tokens` override only applies when `raw_total > 0` so provider breakdowns (cached/reasoning/audio tokens) aren't silently corrupted.
- Promotes `loguru` from the `redteam` extra to a core dependency since `tracing.py` now imports it.

## Test plan

- [ ] `bunx nx test evaluatorq-py` passes
- [ ] `test_truncate_for_span` covers: unlimited default, positive cap, zero = unlimited, invalid value warn+ignore, marker shape
- [ ] Manual: run an attack with `EVALUATORQ_SPAN_MAX_TEXT_CHARS=512` set, inspect span attributes for truncation marker

## Note for reviewers

Base is `bauke/res-715-token-tracking` (#114). Will retarget to `main` once #114 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)