### PR TITLE
feat(evaluatorq-py): port OTel tracing to agent simulation module (RES-782)

### DIFF
--- a/packages/evaluatorq-py/scripts/simulation_tracing_smoke.py
+++ b/packages/evaluatorq-py/scripts/simulation_tracing_smoke.py
@@ -1,0 +1,152 @@
+"""Live tracing smoke test for the simulation module.
+
+Runs a tiny 1-datapoint simulation against the Orq router with OTel tracing
+enabled, then prints the trace ID(s) so you can look them up in the dashboard.
+
+Requires ORQ_API_KEY in the environment (loaded from repo-root .env).
+
+Usage:
+    cd packages/evaluatorq-py
+    uv run python scripts/simulation_tracing_smoke.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from typing import Any, Sequence
+
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".env"))
+
+
+# A tap processor that records every span we emit so we can print a tree
+# locally and surface the trace ID(s).
+class _TapProcessor:
+    def __init__(self) -> None:
+        self.spans: list[Any] = []
+
+    def on_start(self, span: Any, parent_context: Any | None = None) -> None:
+        return None
+
+    def on_end(self, span: Any) -> None:
+        self.spans.append(span)
+
+    def shutdown(self) -> None:
+        return None
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        return True
+
+
+def _print_tree(spans: Sequence[Any]) -> None:
+    by_id: dict[int, Any] = {s.context.span_id: s for s in spans}
+    children: dict[int | None, list[Any]] = {}
+    for s in spans:
+        parent_id = s.parent.span_id if s.parent else None
+        children.setdefault(parent_id, []).append(s)
+
+    def _print(node: Any, depth: int) -> None:
+        attrs = dict(node.attributes or {})
+        hint_keys = (
+            "orq.simulation.turn",
+            "orq.simulation.terminated_by",
+            "gen_ai.operation.name",
+            "orq.simulation.llm_purpose",
+            "gen_ai.usage.total_tokens",
+        )
+        hints = " ".join(
+            f"{k.split('.')[-1]}={attrs[k]}" for k in hint_keys if k in attrs
+        )
+        print(f"{'  ' * depth}- {node.name}" + (f"  [{hints}]" if hints else ""))
+        for child in children.get(node.context.span_id, []):
+            _print(child, depth + 1)
+
+    for root in children.get(None, []):
+        _print(root, 0)
+
+
+async def main() -> None:
+    api_key = os.environ.get("ORQ_API_KEY")
+    if not api_key:
+        print("ERROR: ORQ_API_KEY not set")
+        sys.exit(1)
+
+    from evaluatorq.simulation import (
+        CommunicationStyle,
+        Persona,
+        Scenario,
+        simulate,
+    )
+    from evaluatorq.tracing.setup import init_tracing_if_needed
+
+    print("=== Simulation tracing smoke test ===\n")
+
+    # Initialize OTel tracing first so we can attach our local tap processor
+    # alongside the OTLP exporter that init creates.
+    initialized = await init_tracing_if_needed()
+    print(f"Tracing initialized: {initialized}")
+
+    tap = _TapProcessor()
+    if initialized:
+        from opentelemetry import trace
+
+        provider = trace.get_tracer_provider()
+        # TracerProvider.add_span_processor exists on the SDK provider
+        if hasattr(provider, "add_span_processor"):
+            provider.add_span_processor(tap)  # type: ignore[attr-defined]
+            print("Local tap processor attached.\n")
+        else:
+            print("Provider has no add_span_processor; skipping local tap.\n")
+
+    persona = Persona(
+        name="Curious shopper",
+        patience=0.6,
+        assertiveness=0.5,
+        politeness=0.7,
+        technical_level=0.4,
+        communication_style=CommunicationStyle.casual,
+        background="Browsing for a new gadget",
+    )
+
+    scenario = Scenario(
+        name="Product inquiry",
+        goal="Ask one question about available products and get a useful answer",
+        context="Quick chat about what the company offers",
+    )
+
+    print("Running simulate(): 1 persona x 1 scenario, max_turns=2 ...\n")
+    results = await simulate(
+        evaluation_name="tracing-smoke",
+        agent_key="deployment_chat_reply",
+        personas=[persona],
+        scenarios=[scenario],
+        max_turns=2,
+        model="azure/gpt-4o-mini",
+        evaluator_names=["goal_achieved"],
+    )
+
+    r = results[0]
+    print(f"Result: terminated_by={r.terminated_by.value} turns={r.turn_count} "
+          f"tokens={r.token_usage.total_tokens}")
+
+    # Print the local span tree
+    print("\n=== Local span tree (from tap) ===")
+    _print_tree(tap.spans)
+    print(f"=== {len(tap.spans)} spans captured locally ===\n")
+
+    # Surface trace IDs (hex) so they can be searched in the dashboard
+    trace_ids = sorted({format(s.context.trace_id, "032x") for s in tap.spans})
+    print("Trace ID(s):")
+    for tid in trace_ids:
+        print(f"  {tid}")
+    print(
+        "\nLook these up in the Orq dashboard (Traces tab) or via the API "
+        "/v2/traces?trace_id=<id>."
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/agents/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/agents/base.py
@@ -14,6 +14,12 @@ from typing import TYPE_CHECKING, Any
 
 from evaluatorq.contracts import LLMCallConfig
 from evaluatorq.simulation._client import build_simulation_client, extract_responses_output
+from evaluatorq.simulation.tracing import (
+    get_trace_context_headers,
+    record_llm_input,
+    record_llm_response,
+    with_llm_span,
+)
 from evaluatorq.simulation.types import DEFAULT_MODEL, ChatMessage, TokenUsage
 from evaluatorq.simulation.utils.retry import with_retry
 
@@ -109,6 +115,7 @@ class BaseAgent(ABC):
         temperature: float | None = None,
         max_tokens: int | None = None,
         timeout: float | None = None,
+        llm_purpose: str | None = None,
     ) -> str:
         """Generate a text response for a conversation."""
         result = await self._call_llm(
@@ -116,6 +123,7 @@ class BaseAgent(ABC):
             temperature=temperature,
             max_tokens=max_tokens,
             timeout=timeout,
+            llm_purpose=llm_purpose,
         )
         if not result.content:
             raise RuntimeError(
@@ -169,6 +177,7 @@ class BaseAgent(ABC):
         max_tokens: int | None = None,
         timeout: float | None = None,
         tools: list[dict[str, Any]] | None = None,
+        llm_purpose: str | None = None,
     ) -> LLMResult:
         """Call the LLM with retry logic, dispatching to chat or responses API.
 
@@ -182,6 +191,7 @@ class BaseAgent(ABC):
                 max_tokens=max_tokens,
                 timeout=timeout,
                 tools=tools,
+                llm_purpose=llm_purpose,
             )
         return await self._call_chat_completions(
             messages,
@@ -189,6 +199,7 @@ class BaseAgent(ABC):
             max_tokens=max_tokens,
             timeout=timeout,
             tools=tools,
+            llm_purpose=llm_purpose,
         )
 
     async def _call_chat_completions(
@@ -199,6 +210,7 @@ class BaseAgent(ABC):
         max_tokens: int | None = None,
         timeout: float | None = None,
         tools: list[dict[str, Any]] | None = None,
+        llm_purpose: str | None = None,
     ) -> LLMResult:
         """Call the LLM via the Chat Completions API with retry logic."""
         temp = temperature if temperature is not None else 0.7
@@ -221,34 +233,57 @@ class BaseAgent(ABC):
             params["tools"] = tools
             params["tool_choice"] = "auto"
 
-        async def _do_call() -> LLMResult:
-            response = await asyncio.wait_for(
-                self._client.chat.completions.create(**params),
-                timeout=timeout_s,
+        async with with_llm_span(
+            model=self._model,
+            operation="chat",
+            temperature=temp,
+            max_tokens=max_tok,
+            purpose=llm_purpose,
+        ) as span:
+            record_llm_input(
+                span,
+                [{"role": str(m["role"]), "content": str(m["content"])} for m in full_messages],
             )
 
-            choice = response.choices[0] if response.choices else None
-            if not choice:
-                raise RuntimeError(f"{self.name}: No choices in response")
+            # Inject W3C trace context so the router can link its spans to
+            # the current simulation trace. Active span and trace context
+            # don't change across retries — compute headers once.
+            trace_headers = await get_trace_context_headers()
 
-            message = choice.message
-
-            # Accumulate token usage
-            if response.usage:
-                self._usage.prompt_tokens += response.usage.prompt_tokens
-                self._usage.completion_tokens += response.usage.completion_tokens
-                self._usage.total_tokens += response.usage.total_tokens
-
-            content = message.content
-            tool_calls = list(message.tool_calls or [])
-            if not content and not tool_calls:
-                raise RuntimeError(
-                    f"{self.name}._call_chat_completions: LLM returned no text and no tool calls. "
-                    "Check model and prompt."
+            async def _do_call() -> LLMResult:
+                call_kwargs: dict[str, Any] = dict(params)
+                if trace_headers:
+                    call_kwargs["extra_headers"] = trace_headers
+                response = await asyncio.wait_for(
+                    self._client.chat.completions.create(**call_kwargs),
+                    timeout=timeout_s,
                 )
-            return LLMResult(content=content or "", tool_calls=tool_calls or None)
 
-        return await with_retry(_do_call, label=f"{self.name}._call_chat_completions")
+                choice = response.choices[0] if response.choices else None
+                if not choice:
+                    raise RuntimeError(f"{self.name}: No choices in response")
+
+                message = choice.message
+
+                # Record LLM response on the span (token usage, finish reason, etc.)
+                record_llm_response(span, response)
+
+                # Accumulate token usage
+                if response.usage:
+                    self._usage.prompt_tokens += response.usage.prompt_tokens
+                    self._usage.completion_tokens += response.usage.completion_tokens
+                    self._usage.total_tokens += response.usage.total_tokens
+
+                content = message.content
+                tool_calls = list(message.tool_calls or [])
+                if not content and not tool_calls:
+                    raise RuntimeError(
+                        f"{self.name}._call_chat_completions: LLM returned no text and no tool calls. "
+                        "Check model and prompt."
+                    )
+                return LLMResult(content=content or "", tool_calls=tool_calls or None)
+
+            return await with_retry(_do_call, label=f"{self.name}._call_chat_completions")
 
     async def _call_responses(
         self,
@@ -258,6 +293,7 @@ class BaseAgent(ABC):
         max_tokens: int | None = None,
         timeout: float | None = None,
         tools: list[dict[str, Any]] | None = None,
+        llm_purpose: str | None = None,
     ) -> LLMResult:
         """Call the LLM via the OpenAI Responses API with retry logic.
 
@@ -285,35 +321,53 @@ class BaseAgent(ABC):
         if max_tokens is not None:
             params["max_output_tokens"] = max_tokens
 
-        async def _do_call() -> LLMResult:
-            response = await asyncio.wait_for(
-                self._client.responses.create(**params),
-                timeout=timeout_s,
+        async with with_llm_span(
+            model=self._model,
+            operation="responses",
+            temperature=temperature,
+            max_tokens=max_tokens,
+            purpose=llm_purpose,
+        ) as span:
+            record_llm_input(
+                span,
+                [{"role": "system", "content": self.system_prompt}, *input_messages],
             )
+            trace_headers = await get_trace_context_headers()
 
-            output_items, usage = extract_responses_output(response)
-
-            # Accumulate token usage
-            self._usage.prompt_tokens += usage.prompt_tokens
-            self._usage.completion_tokens += usage.completion_tokens
-            self._usage.total_tokens += usage.total_tokens
-
-            # Separate text from tool-call items
-            text_items = [i for i in output_items if hasattr(i, "text")]
-            tool_call_items = [i for i in output_items if hasattr(i, "call_id")]
-
-            if not text_items and not tool_call_items:
-                # No text, no tool calls — warn but don't raise (redteam callers may handle empty)
-                logger.warning(
-                    "%s._call_responses: no text or tool calls in response (model=%s)",
-                    self.name,
-                    self.config.model,
+            async def _do_call() -> LLMResult:
+                call_kwargs: dict[str, Any] = dict(params)
+                if trace_headers:
+                    call_kwargs["extra_headers"] = trace_headers
+                response = await asyncio.wait_for(
+                    self._client.responses.create(**call_kwargs),
+                    timeout=timeout_s,
                 )
 
-            text = "".join(getattr(i, "text", "") for i in text_items)
-            result = LLMResult(content=text)
-            if tool_call_items:
-                result.tool_calls = tool_call_items
-            return result
+                output_items, usage = extract_responses_output(response)
 
-        return await with_retry(_do_call, label=f"{self.name}._call_responses")
+                record_llm_response(span, response)
+
+                # Accumulate token usage
+                self._usage.prompt_tokens += usage.prompt_tokens
+                self._usage.completion_tokens += usage.completion_tokens
+                self._usage.total_tokens += usage.total_tokens
+
+                # Separate text from tool-call items
+                text_items = [i for i in output_items if hasattr(i, "text")]
+                tool_call_items = [i for i in output_items if hasattr(i, "call_id")]
+
+                if not text_items and not tool_call_items:
+                    # No text, no tool calls — warn but don't raise (redteam callers may handle empty)
+                    logger.warning(
+                        "%s._call_responses: no text or tool calls in response (model=%s)",
+                        self.name,
+                        self.config.model,
+                    )
+
+                text = "".join(getattr(i, "text", "") for i in text_items)
+                result = LLMResult(content=text)
+                if tool_call_items:
+                    result.tool_calls = tool_call_items
+                return result
+
+            return await with_retry(_do_call, label=f"{self.name}._call_responses")

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/agents/judge.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/agents/judge.py
@@ -231,7 +231,9 @@ class JudgeAgent(BaseAgent):
             ),
         ]
 
-        result = await self._call_llm(eval_messages, temperature=0.0, tools=JUDGE_TOOLS)
+        result = await self._call_llm(
+            eval_messages, temperature=0.0, tools=JUDGE_TOOLS, llm_purpose="judge"
+        )
         return self._parse_judgment(result)
 
     # ---------------------------------------------------------------------------

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/agents/user_simulator.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/agents/user_simulator.py
@@ -80,7 +80,9 @@ class UserSimulatorAgent(BaseAgent):
                 content="Generate your first message to start the conversation. Remember your goal and persona.",
             )
         )
-        return await self.respond_async(prompt_messages, temperature=0.8)
+        return await self.respond_async(
+            prompt_messages, temperature=0.8, llm_purpose="first_message"
+        )
 
     def update_context(
         self,

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/api.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from evaluatorq.simulation.types import DEFAULT_MODEL
 
@@ -60,12 +60,67 @@ async def simulate(
         judge: Pre-constructed ``BaseAgent`` used to evaluate each turn.
             When omitted a default ``JudgeAgent`` is built from ``model``.
     """
+    from evaluatorq.simulation.tracing import with_simulation_span
+    from evaluatorq.tracing.setup import flush_tracing, init_tracing_if_needed
+
+    # Initialize OTel tracing (no-op if already initialized or not configured)
+    await init_tracing_if_needed()
+
+    try:
+        async with with_simulation_span(
+            "orq.simulation.pipeline",
+            {
+                "orq.simulation.evaluation_name": evaluation_name,
+                "orq.simulation.max_turns": max_turns,
+                "orq.simulation.parallelism": parallelism,
+            },
+        ) as pipeline_span:
+            return await _simulate_core(
+                evaluation_name=evaluation_name,
+                agent_key=agent_key,
+                target_callback=target_callback,
+                target=target,
+                personas=personas,
+                scenarios=scenarios,
+                datapoints=datapoints,
+                max_turns=max_turns,
+                model=model,
+                evaluator_names=evaluator_names,
+                parallelism=parallelism,
+                user_simulator=user_simulator,
+                judge=judge,
+                pipeline_span=pipeline_span,
+            )
+    finally:
+        # Flush pending spans to ensure they're exported before the process exits
+        await flush_tracing()
+
+
+async def _simulate_core(
+    *,
+    evaluation_name: str,
+    agent_key: str | None,
+    target_callback: Callable[[list[ChatMessage]], str | Awaitable[str]] | None,
+    target: Callable[[list[ChatMessage]], str | Awaitable[str]] | None,
+    personas: list[Persona] | None,
+    scenarios: list[Scenario] | None,
+    datapoints: list[Datapoint] | None,
+    max_turns: int,
+    model: str,
+    evaluator_names: list[str] | None,
+    parallelism: int,
+    user_simulator: BaseAgent | None,
+    judge: BaseAgent | None,
+    pipeline_span: Any,
+) -> list[SimulationResult]:
+    """Core simulation logic (runs inside the orq.simulation.pipeline span)."""
     from openai import AsyncOpenAI
 
     from evaluatorq.simulation.adapters import from_orq_deployment
     from evaluatorq.simulation.evaluators import get_evaluator
     from evaluatorq.simulation.generators import FirstMessageGenerator
     from evaluatorq.simulation.runner.simulation import SimulationRunner
+    from evaluatorq.simulation.tracing import record_token_usage, set_span_attrs
 
     # Validate evaluator names early
     resolved_evaluator_names = evaluator_names or ["goal_achieved", "criteria_met"]
@@ -118,6 +173,11 @@ async def simulate(
             "No datapoints to simulate — persona or scenario generation may have failed"
         )
 
+    set_span_attrs(
+        pipeline_span,
+        {"orq.simulation.datapoints_count": len(datapoints)},
+    )
+
     # Bridge agentKey to invoke() if no callback is provided.
     # ``target`` takes precedence over ``target_callback`` when both are given.
     resolved_callback = target or target_callback
@@ -152,6 +212,28 @@ async def simulate(
             result.metadata["evaluator_scores"] = scores
             if evaluation_name:
                 result.metadata["evaluation_name"] = evaluation_name
+
+        # Aggregate token usage onto the pipeline span
+        total_prompt = sum((r.token_usage.prompt_tokens or 0) for r in results)
+        total_completion = sum(
+            (r.token_usage.completion_tokens or 0) for r in results
+        )
+        total_total = sum((r.token_usage.total_tokens or 0) for r in results)
+        record_token_usage(
+            pipeline_span,
+            prompt_tokens=total_prompt,
+            completion_tokens=total_completion,
+            total_tokens=total_total,
+        )
+        set_span_attrs(
+            pipeline_span,
+            {
+                "orq.simulation.results_count": len(results),
+                "orq.simulation.goal_achieved_count": sum(
+                    1 for r in results if r.goal_achieved
+                ),
+            },
+        )
 
         return results
     finally:
@@ -188,6 +270,11 @@ async def generate_and_simulate(
 
     from evaluatorq.simulation.adapters import from_orq_deployment
     from evaluatorq.simulation.generators import PersonaGenerator, ScenarioGenerator
+    from evaluatorq.simulation.tracing import with_simulation_span
+    from evaluatorq.tracing.setup import flush_tracing, init_tracing_if_needed
+
+    # Initialize OTel tracing early so generation spans are captured
+    await init_tracing_if_needed()
 
     # Bridge agentKey to invoke() if no callback is provided
     resolved_callback = target_callback
@@ -205,34 +292,56 @@ async def generate_and_simulate(
             "ORQ_API_KEY environment variable is not set. Set it before calling generate_and_simulate()."
         )
 
-    shared_client = AsyncOpenAI(
-        api_key=api_key,
-        base_url=f"{os.environ.get('ORQ_BASE_URL', 'https://api.orq.ai')}/v2/router",
-    )
-
     try:
-        persona_gen = PersonaGenerator(model=model, client=shared_client)
-        scenario_gen = ScenarioGenerator(model=model, client=shared_client)
+        async with with_simulation_span(
+            "orq.simulation.pipeline",
+            {
+                "orq.simulation.evaluation_name": evaluation_name,
+                "orq.simulation.mode": "generate_and_simulate",
+                "orq.simulation.num_personas": num_personas,
+                "orq.simulation.num_scenarios": num_scenarios,
+                "orq.simulation.max_turns": max_turns,
+                "orq.simulation.parallelism": parallelism,
+            },
+        ) as pipeline_span:
+            shared_client = AsyncOpenAI(
+                api_key=api_key,
+                base_url=f"{os.environ.get('ORQ_BASE_URL', 'https://api.orq.ai')}/v2/router",
+            )
 
-        personas, scenarios = await asyncio.gather(
-            persona_gen.generate(
-                agent_description=agent_description, num_personas=num_personas
-            ),
-            scenario_gen.generate(
-                agent_description=agent_description, num_scenarios=num_scenarios
-            ),
-        )
+            try:
+                persona_gen = PersonaGenerator(model=model, client=shared_client)
+                scenario_gen = ScenarioGenerator(model=model, client=shared_client)
+
+                personas, scenarios = await asyncio.gather(
+                    persona_gen.generate(
+                        agent_description=agent_description,
+                        num_personas=num_personas,
+                    ),
+                    scenario_gen.generate(
+                        agent_description=agent_description,
+                        num_scenarios=num_scenarios,
+                    ),
+                )
+            finally:
+                await shared_client.close()
+
+            # Delegate to core (no duplicate pipeline span)
+            return await _simulate_core(
+                evaluation_name=evaluation_name,
+                agent_key=None,
+                target_callback=resolved_callback,
+                target=None,
+                personas=personas,
+                scenarios=scenarios,
+                datapoints=None,
+                max_turns=max_turns,
+                model=model,
+                evaluator_names=evaluator_names,
+                parallelism=parallelism,
+                user_simulator=None,
+                judge=None,
+                pipeline_span=pipeline_span,
+            )
     finally:
-        await shared_client.close()
-
-    # Run simulations
-    return await simulate(
-        evaluation_name=evaluation_name,
-        target_callback=resolved_callback,
-        personas=personas,
-        scenarios=scenarios,
-        max_turns=max_turns,
-        model=model,
-        evaluator_names=evaluator_names,
-        parallelism=parallelism,
-    )
+        await flush_tracing()

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/api.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/api.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from evaluatorq.simulation.types import DEFAULT_MODEL
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
+
+    from opentelemetry.trace import Span
 
     from evaluatorq.simulation.agents.base import BaseAgent
     from evaluatorq.simulation.generators import FirstMessageGenerator
@@ -111,7 +113,7 @@ async def _simulate_core(
     parallelism: int,
     user_simulator: BaseAgent | None,
     judge: BaseAgent | None,
-    pipeline_span: Any,
+    pipeline_span: Span | None,
 ) -> list[SimulationResult]:
     """Core simulation logic (runs inside the orq.simulation.pipeline span)."""
     from openai import AsyncOpenAI

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/api.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/api.py
@@ -245,9 +245,18 @@ async def _simulate_core(
 async def _generate_single_datapoint(
     gen: FirstMessageGenerator, persona: Persona, scenario: Scenario
 ) -> Datapoint:
+    from evaluatorq.simulation.tracing import with_simulation_span
     from evaluatorq.simulation.utils.prompt_builders import generate_datapoint
 
-    first_message = await gen.generate(persona, scenario)
+    async with with_simulation_span(
+        "orq.simulation.first_message_generation",
+        {
+            "orq.simulation.persona": persona.name,
+            "orq.simulation.scenario": scenario.name,
+            "orq.simulation.model": getattr(gen, "_model", None),
+        },
+    ):
+        first_message = await gen.generate(persona, scenario)
     return generate_datapoint(persona, scenario, first_message)
 
 

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/generators/first_message_generator.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/generators/first_message_generator.py
@@ -8,6 +8,12 @@ import re
 
 from openai import APIStatusError, AsyncOpenAI
 
+from evaluatorq.simulation.tracing import (
+    get_trace_context_headers,
+    record_llm_input,
+    record_llm_response,
+    with_llm_span,
+)
 from evaluatorq.simulation.types import DEFAULT_MODEL, Persona, Scenario
 from evaluatorq.simulation.utils.prompt_builders import (
     build_persona_system_prompt,
@@ -105,19 +111,41 @@ Generate the FIRST message this user would send to start the conversation.
 The message should immediately convey their goal and emotional state.
 Keep it natural - this is how they would actually open a conversation."""
 
+        messages = [
+            {"role": "system", "content": _FIRST_MESSAGE_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ]
+
         try:
-            response = await with_retry(
-                lambda: self._client.chat.completions.create(
-                    model=self._model,
-                    messages=[
-                        {"role": "system", "content": _FIRST_MESSAGE_PROMPT},
-                        {"role": "user", "content": user_prompt},
+            async with with_llm_span(
+                model=self._model,
+                operation="chat",
+                temperature=_TEMPERATURE_FIRST_MESSAGE,
+                max_tokens=500,
+                purpose="first_message",
+            ) as span:
+                record_llm_input(
+                    span,
+                    [
+                        {"role": str(m["role"]), "content": str(m["content"])}
+                        for m in messages
                     ],
-                    temperature=_TEMPERATURE_FIRST_MESSAGE,
-                    max_tokens=500,
-                ),
-                label="FirstMessageGenerator.generate",
-            )
+                )
+                trace_headers = await get_trace_context_headers()
+                extra: dict[str, object] = (
+                    {"extra_headers": trace_headers} if trace_headers else {}
+                )
+                response = await with_retry(
+                    lambda: self._client.chat.completions.create(
+                        model=self._model,
+                        messages=messages,
+                        temperature=_TEMPERATURE_FIRST_MESSAGE,
+                        max_tokens=500,
+                        **extra,
+                    ),
+                    label="FirstMessageGenerator.generate",
+                )
+                record_llm_response(span, response)
 
             message = response.choices[0].message.content if response.choices else ""
             message = re.sub(r'^["\']|["\']$', "", (message or "").strip())

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/generators/persona_generator.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/generators/persona_generator.py
@@ -281,15 +281,25 @@ Return ONLY a JSON array, no other text."""
             {"role": "user", "content": user_prompt},
         ]
 
-        parsed, raw = await generate_structured(
-            self._client,
-            model=self._model,
-            messages=messages,
-            response_format=PersonaListResponse,
-            temperature=_TEMPERATURE_BALANCED,
-            max_tokens=4000,
-            label="PersonaGenerator.generate_with_coverage",
-        )
+        from evaluatorq.simulation.tracing import with_simulation_span
+
+        async with with_simulation_span(
+            "orq.simulation.persona_generation",
+            {
+                "orq.simulation.num_personas": num_personas,
+                "orq.simulation.mode": "coverage",
+                "orq.simulation.model": self._model,
+            },
+        ):
+            parsed, raw = await generate_structured(
+                self._client,
+                model=self._model,
+                messages=messages,
+                response_format=PersonaListResponse,
+                temperature=_TEMPERATURE_BALANCED,
+                max_tokens=4000,
+                label="PersonaGenerator.generate_with_coverage",
+            )
         personas = parsed.personas if parsed is not None else self._parse_personas(raw or "[]")
 
         # Validate coverage and fill gaps

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/generators/persona_generator.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/generators/persona_generator.py
@@ -139,9 +139,18 @@ class PersonaGenerator:
         edge_case_percentage: float = 0.2,
     ) -> list[Persona]:
         """Generate personas for agent testing."""
-        num_edge_cases = int(num_personas * edge_case_percentage)
+        from evaluatorq.simulation.tracing import with_simulation_span
 
-        user_prompt = f"""Agent Description: {delimit(agent_description)}
+        async with with_simulation_span(
+            "orq.simulation.persona_generation",
+            {
+                "orq.simulation.num_personas": num_personas,
+                "orq.simulation.model": self._model,
+            },
+        ):
+            num_edge_cases = int(num_personas * edge_case_percentage)
+
+            user_prompt = f"""Agent Description: {delimit(agent_description)}
 
 Additional Context: {delimit(context or "None provided")}
 
@@ -152,29 +161,29 @@ Generate {num_personas} diverse personas for testing this agent.
 
 Return ONLY a JSON array, no other text."""
 
-        messages: list[dict[str, Any]] = [
-            {"role": "system", "content": _PERSONA_GENERATOR_PROMPT},
-            {"role": "user", "content": user_prompt},
-        ]
+            messages: list[dict[str, Any]] = [
+                {"role": "system", "content": _PERSONA_GENERATOR_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ]
 
-        parsed, raw = await generate_structured(
-            self._client,
-            model=self._model,
-            messages=messages,
-            response_format=PersonaListResponse,
-            temperature=_TEMPERATURE_CREATIVE,
-            max_tokens=4000,
-            label="PersonaGenerator.generate",
-        )
-        personas = parsed.personas if parsed is not None else self._parse_personas(raw or "[]")
-
-        if len(personas) < num_personas:
-            logger.warning(
-                "PersonaGenerator: requested %d personas but only %d were successfully parsed",
-                num_personas,
-                len(personas),
+            parsed, raw = await generate_structured(
+                self._client,
+                model=self._model,
+                messages=messages,
+                response_format=PersonaListResponse,
+                temperature=_TEMPERATURE_CREATIVE,
+                max_tokens=4000,
+                label="PersonaGenerator.generate",
             )
-        return personas
+            personas = parsed.personas if parsed is not None else self._parse_personas(raw or "[]")
+
+            if len(personas) < num_personas:
+                logger.warning(
+                    "PersonaGenerator: requested %d personas but only %d were successfully parsed",
+                    num_personas,
+                    len(personas),
+                )
+            return personas
 
     async def generate_with_coverage(
         self,

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/generators/persona_generator.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/generators/persona_generator.py
@@ -300,24 +300,28 @@ Return ONLY a JSON array, no other text."""
                 max_tokens=4000,
                 label="PersonaGenerator.generate_with_coverage",
             )
-        personas = parsed.personas if parsed is not None else self._parse_personas(raw or "[]")
-
-        # Validate coverage and fill gaps
-        personas = self._ensure_style_coverage(
-            personas, [CommunicationStyle(s) for s in styles]
-        )
-        self._log_trait_coverage_gaps(personas)
-
-        if len(personas) > num_personas:
-            personas = personas[:num_personas]
-
-        if len(personas) < num_personas:
-            logger.warning(
-                "PersonaGenerator: requested %d personas (with coverage) but only %d were successfully parsed",
-                num_personas,
-                len(personas),
+            personas = (
+                parsed.personas
+                if parsed is not None
+                else self._parse_personas(raw or "[]")
             )
-        return personas
+
+            # Validate coverage and fill gaps
+            personas = self._ensure_style_coverage(
+                personas, [CommunicationStyle(s) for s in styles]
+            )
+            self._log_trait_coverage_gaps(personas)
+
+            if len(personas) > num_personas:
+                personas = personas[:num_personas]
+
+            if len(personas) < num_personas:
+                logger.warning(
+                    "PersonaGenerator: requested %d personas (with coverage) but only %d were successfully parsed",
+                    num_personas,
+                    len(personas),
+                )
+            return personas
 
     @staticmethod
     def _ensure_style_coverage(

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/generators/scenario_generator.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/generators/scenario_generator.py
@@ -331,28 +331,28 @@ Return ONLY a JSON array, no other text."""
                     label="ScenarioGenerator.generate_with_coverage",
                 )
 
-            if parsed is not None:
-                scenarios = parsed.scenarios
-            else:
-                scenario_dicts = _parse_json_list(raw or "[]")
-                scenarios = _parse_scenarios(scenario_dicts)
+                if parsed is not None:
+                    scenarios = parsed.scenarios
+                else:
+                    scenario_dicts = _parse_json_list(raw or "[]")
+                    scenarios = _parse_scenarios(scenario_dicts)
 
-            # Validate coverage
-            scenarios = self._ensure_emotion_coverage(
-                scenarios, [StartingEmotion(e) for e in emotions]
-            )
-            scenarios = self._ensure_criteria_coverage(scenarios)
-
-            if len(scenarios) > num_scenarios:
-                scenarios = scenarios[:num_scenarios]
-
-            if len(scenarios) < num_scenarios:
-                logger.warning(
-                    "ScenarioGenerator: requested %d scenarios (with coverage) but only %d parsed",
-                    num_scenarios,
-                    len(scenarios),
+                # Validate coverage
+                scenarios = self._ensure_emotion_coverage(
+                    scenarios, [StartingEmotion(e) for e in emotions]
                 )
-            return scenarios
+                scenarios = self._ensure_criteria_coverage(scenarios)
+
+                if len(scenarios) > num_scenarios:
+                    scenarios = scenarios[:num_scenarios]
+
+                if len(scenarios) < num_scenarios:
+                    logger.warning(
+                        "ScenarioGenerator: requested %d scenarios (with coverage) but only %d parsed",
+                        num_scenarios,
+                        len(scenarios),
+                    )
+                return scenarios
         except json.JSONDecodeError:
             logger.warning(
                 "ScenarioGenerator: LLM response was not valid JSON — returning empty array"
@@ -412,23 +412,23 @@ Return ONLY a JSON array, no other text."""
                     label="ScenarioGenerator.generate_edge_cases",
                 )
 
-            if parsed is not None:
-                scenarios = [
-                    s.model_copy(update={"is_edge_case": True}) for s in parsed.scenarios
-                ]
-            else:
-                scenario_dicts = _parse_json_list(raw or "[]")
-                for s_dict in scenario_dicts:
-                    s_dict["is_edge_case"] = True
-                scenarios = _parse_scenarios(scenario_dicts)
+                if parsed is not None:
+                    scenarios = [
+                        s.model_copy(update={"is_edge_case": True}) for s in parsed.scenarios
+                    ]
+                else:
+                    scenario_dicts = _parse_json_list(raw or "[]")
+                    for s_dict in scenario_dicts:
+                        s_dict["is_edge_case"] = True
+                    scenarios = _parse_scenarios(scenario_dicts)
 
-            if len(scenarios) < num_edge_cases:
-                logger.warning(
-                    "ScenarioGenerator: requested %d edge cases but only %d parsed",
-                    num_edge_cases,
-                    len(scenarios),
-                )
-            return scenarios
+                if len(scenarios) < num_edge_cases:
+                    logger.warning(
+                        "ScenarioGenerator: requested %d edge cases but only %d parsed",
+                        num_edge_cases,
+                        len(scenarios),
+                    )
+                return scenarios
         except json.JSONDecodeError:
             logger.warning(
                 "ScenarioGenerator: LLM response was not valid JSON — returning empty array"
@@ -482,23 +482,23 @@ Return ONLY a JSON array, no other text."""
                     label="ScenarioGenerator.generate_boundary_scenarios",
                 )
 
-            if parsed is not None:
-                scenarios = [
-                    s.model_copy(update={"is_edge_case": True}) for s in parsed.scenarios
-                ]
-            else:
-                scenario_dicts = _parse_json_list(raw or "[]")
-                for s_dict in scenario_dicts:
-                    s_dict["is_edge_case"] = True
-                scenarios = _parse_scenarios(scenario_dicts)
+                if parsed is not None:
+                    scenarios = [
+                        s.model_copy(update={"is_edge_case": True}) for s in parsed.scenarios
+                    ]
+                else:
+                    scenario_dicts = _parse_json_list(raw or "[]")
+                    for s_dict in scenario_dicts:
+                        s_dict["is_edge_case"] = True
+                    scenarios = _parse_scenarios(scenario_dicts)
 
-            if len(scenarios) < num_scenarios:
-                logger.warning(
-                    "ScenarioGenerator: requested %d boundary scenarios but only %d parsed",
-                    num_scenarios,
-                    len(scenarios),
-                )
-            return scenarios
+                if len(scenarios) < num_scenarios:
+                    logger.warning(
+                        "ScenarioGenerator: requested %d boundary scenarios but only %d parsed",
+                        num_scenarios,
+                        len(scenarios),
+                    )
+                return scenarios
         except json.JSONDecodeError:
             logger.warning(
                 "ScenarioGenerator: LLM response was not valid JSON — returning empty array"
@@ -569,23 +569,23 @@ Return ONLY a JSON array, no other text."""
                     label="ScenarioGenerator.generate_security_scenarios",
                 )
 
-            if parsed is not None:
-                scenarios = [
-                    s.model_copy(update={"is_edge_case": True}) for s in parsed.scenarios
-                ]
-            else:
-                scenario_dicts = _parse_json_list(raw or "[]")
-                for s_dict in scenario_dicts:
-                    s_dict["is_edge_case"] = True
-                scenarios = _parse_scenarios(scenario_dicts)
+                if parsed is not None:
+                    scenarios = [
+                        s.model_copy(update={"is_edge_case": True}) for s in parsed.scenarios
+                    ]
+                else:
+                    scenario_dicts = _parse_json_list(raw or "[]")
+                    for s_dict in scenario_dicts:
+                        s_dict["is_edge_case"] = True
+                    scenarios = _parse_scenarios(scenario_dicts)
 
-            if len(scenarios) < num_scenarios:
-                logger.warning(
-                    "ScenarioGenerator: requested %d security scenarios but only %d parsed",
-                    num_scenarios,
-                    len(scenarios),
-                )
-            return scenarios
+                if len(scenarios) < num_scenarios:
+                    logger.warning(
+                        "ScenarioGenerator: requested %d security scenarios but only %d parsed",
+                        num_scenarios,
+                        len(scenarios),
+                    )
+                return scenarios
         except json.JSONDecodeError:
             logger.warning(
                 "ScenarioGenerator: LLM response was not valid JSON — returning empty array"

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/generators/scenario_generator.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/generators/scenario_generator.py
@@ -211,9 +211,18 @@ class ScenarioGenerator:
         edge_case_percentage: float = 0.3,
     ) -> list[Scenario]:
         """Generate scenarios for agent testing."""
-        num_edge_cases = int(num_scenarios * edge_case_percentage)
+        from evaluatorq.simulation.tracing import with_simulation_span
 
-        user_prompt = f"""Agent Description: {delimit(agent_description)}
+        async with with_simulation_span(
+            "orq.simulation.scenario_generation",
+            {
+                "orq.simulation.num_scenarios": num_scenarios,
+                "orq.simulation.model": self._model,
+            },
+        ):
+            num_edge_cases = int(num_scenarios * edge_case_percentage)
+
+            user_prompt = f"""Agent Description: {delimit(agent_description)}
 
 Additional Context: {delimit(context or "None provided")}
 
@@ -225,40 +234,40 @@ Generate {num_scenarios} diverse test scenarios for this agent.
 
 Return ONLY a JSON array, no other text."""
 
-        messages: list[dict[str, Any]] = [
-            {"role": "system", "content": _SCENARIO_GENERATOR_PROMPT},
-            {"role": "user", "content": user_prompt},
-        ]
+            messages: list[dict[str, Any]] = [
+                {"role": "system", "content": _SCENARIO_GENERATOR_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ]
 
-        try:
-            parsed, raw = await generate_structured(
-                self._client,
-                model=self._model,
-                messages=messages,
-                response_format=ScenarioListResponse,
-                temperature=_TEMPERATURE_CREATIVE,
-                max_tokens=6000,
-                label="ScenarioGenerator.generate",
-            )
-
-            if parsed is not None:
-                scenarios = parsed.scenarios
-            else:
-                scenario_dicts = _parse_json_list(raw or "[]")
-                scenarios = _parse_scenarios(scenario_dicts)
-
-            if len(scenarios) < num_scenarios:
-                logger.warning(
-                    "ScenarioGenerator: requested %d scenarios but only %d were successfully parsed",
-                    num_scenarios,
-                    len(scenarios),
+            try:
+                parsed, raw = await generate_structured(
+                    self._client,
+                    model=self._model,
+                    messages=messages,
+                    response_format=ScenarioListResponse,
+                    temperature=_TEMPERATURE_CREATIVE,
+                    max_tokens=6000,
+                    label="ScenarioGenerator.generate",
                 )
-            return scenarios
-        except json.JSONDecodeError:
-            logger.warning(
-                "ScenarioGenerator: LLM response was not valid JSON — returning empty array"
-            )
-            return []
+
+                if parsed is not None:
+                    scenarios = parsed.scenarios
+                else:
+                    scenario_dicts = _parse_json_list(raw or "[]")
+                    scenarios = _parse_scenarios(scenario_dicts)
+
+                if len(scenarios) < num_scenarios:
+                    logger.warning(
+                        "ScenarioGenerator: requested %d scenarios but only %d were successfully parsed",
+                        num_scenarios,
+                        len(scenarios),
+                    )
+                return scenarios
+            except json.JSONDecodeError:
+                logger.warning(
+                    "ScenarioGenerator: LLM response was not valid JSON — returning empty array"
+                )
+                return []
 
     async def generate_with_coverage(
         self,

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/generators/scenario_generator.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/generators/scenario_generator.py
@@ -213,16 +213,17 @@ class ScenarioGenerator:
         """Generate scenarios for agent testing."""
         from evaluatorq.simulation.tracing import with_simulation_span
 
-        async with with_simulation_span(
-            "orq.simulation.scenario_generation",
-            {
-                "orq.simulation.num_scenarios": num_scenarios,
-                "orq.simulation.model": self._model,
-            },
-        ):
-            num_edge_cases = int(num_scenarios * edge_case_percentage)
+        try:
+            async with with_simulation_span(
+                "orq.simulation.scenario_generation",
+                {
+                    "orq.simulation.num_scenarios": num_scenarios,
+                    "orq.simulation.model": self._model,
+                },
+            ):
+                num_edge_cases = int(num_scenarios * edge_case_percentage)
 
-            user_prompt = f"""Agent Description: {delimit(agent_description)}
+                user_prompt = f"""Agent Description: {delimit(agent_description)}
 
 Additional Context: {delimit(context or "None provided")}
 
@@ -234,12 +235,11 @@ Generate {num_scenarios} diverse test scenarios for this agent.
 
 Return ONLY a JSON array, no other text."""
 
-            messages: list[dict[str, Any]] = [
-                {"role": "system", "content": _SCENARIO_GENERATOR_PROMPT},
-                {"role": "user", "content": user_prompt},
-            ]
+                messages: list[dict[str, Any]] = [
+                    {"role": "system", "content": _SCENARIO_GENERATOR_PROMPT},
+                    {"role": "user", "content": user_prompt},
+                ]
 
-            try:
                 parsed, raw = await generate_structured(
                     self._client,
                     model=self._model,
@@ -263,11 +263,11 @@ Return ONLY a JSON array, no other text."""
                         len(scenarios),
                     )
                 return scenarios
-            except json.JSONDecodeError:
-                logger.warning(
-                    "ScenarioGenerator: LLM response was not valid JSON — returning empty array"
-                )
-                return []
+        except json.JSONDecodeError:
+            logger.warning(
+                "ScenarioGenerator: LLM response was not valid JSON — returning empty array"
+            )
+            return []
 
     async def generate_with_coverage(
         self,

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/generators/scenario_generator.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/generators/scenario_generator.py
@@ -310,16 +310,26 @@ Return ONLY a JSON array, no other text."""
             {"role": "user", "content": user_prompt},
         ]
 
+        from evaluatorq.simulation.tracing import with_simulation_span
+
         try:
-            parsed, raw = await generate_structured(
-                self._client,
-                model=self._model,
-                messages=messages,
-                response_format=ScenarioListResponse,
-                temperature=_TEMPERATURE_BALANCED,
-                max_tokens=6000,
-                label="ScenarioGenerator.generate_with_coverage",
-            )
+            async with with_simulation_span(
+                "orq.simulation.scenario_generation",
+                {
+                    "orq.simulation.num_scenarios": num_scenarios,
+                    "orq.simulation.mode": "coverage",
+                    "orq.simulation.model": self._model,
+                },
+            ):
+                parsed, raw = await generate_structured(
+                    self._client,
+                    model=self._model,
+                    messages=messages,
+                    response_format=ScenarioListResponse,
+                    temperature=_TEMPERATURE_BALANCED,
+                    max_tokens=6000,
+                    label="ScenarioGenerator.generate_with_coverage",
+                )
 
             if parsed is not None:
                 scenarios = parsed.scenarios
@@ -381,16 +391,26 @@ Return ONLY a JSON array, no other text."""
             {"role": "user", "content": user_prompt},
         ]
 
+        from evaluatorq.simulation.tracing import with_simulation_span
+
         try:
-            parsed, raw = await generate_structured(
-                self._client,
-                model=self._model,
-                messages=messages,
-                response_format=ScenarioListResponse,
-                temperature=_TEMPERATURE_EDGE_CASE,
-                max_tokens=4000,
-                label="ScenarioGenerator.generate_edge_cases",
-            )
+            async with with_simulation_span(
+                "orq.simulation.scenario_generation",
+                {
+                    "orq.simulation.num_scenarios": num_edge_cases,
+                    "orq.simulation.mode": "edge_cases",
+                    "orq.simulation.model": self._model,
+                },
+            ):
+                parsed, raw = await generate_structured(
+                    self._client,
+                    model=self._model,
+                    messages=messages,
+                    response_format=ScenarioListResponse,
+                    temperature=_TEMPERATURE_EDGE_CASE,
+                    max_tokens=4000,
+                    label="ScenarioGenerator.generate_edge_cases",
+                )
 
             if parsed is not None:
                 scenarios = [
@@ -441,16 +461,26 @@ Return ONLY a JSON array, no other text."""
             {"role": "user", "content": user_prompt},
         ]
 
+        from evaluatorq.simulation.tracing import with_simulation_span
+
         try:
-            parsed, raw = await generate_structured(
-                self._client,
-                model=self._model,
-                messages=messages,
-                response_format=ScenarioListResponse,
-                temperature=_TEMPERATURE_EDGE_CASE,
-                max_tokens=4000,
-                label="ScenarioGenerator.generate_boundary_scenarios",
-            )
+            async with with_simulation_span(
+                "orq.simulation.scenario_generation",
+                {
+                    "orq.simulation.num_scenarios": num_scenarios,
+                    "orq.simulation.mode": "boundary",
+                    "orq.simulation.model": self._model,
+                },
+            ):
+                parsed, raw = await generate_structured(
+                    self._client,
+                    model=self._model,
+                    messages=messages,
+                    response_format=ScenarioListResponse,
+                    temperature=_TEMPERATURE_EDGE_CASE,
+                    max_tokens=4000,
+                    label="ScenarioGenerator.generate_boundary_scenarios",
+                )
 
             if parsed is not None:
                 scenarios = [
@@ -518,16 +548,26 @@ Return ONLY a JSON array, no other text."""
             {"role": "user", "content": user_prompt},
         ]
 
+        from evaluatorq.simulation.tracing import with_simulation_span
+
         try:
-            parsed, raw = await generate_structured(
-                self._client,
-                model=self._model,
-                messages=messages,
-                response_format=ScenarioListResponse,
-                temperature=_TEMPERATURE_EDGE_CASE,
-                max_tokens=6000,
-                label="ScenarioGenerator.generate_security_scenarios",
-            )
+            async with with_simulation_span(
+                "orq.simulation.scenario_generation",
+                {
+                    "orq.simulation.num_scenarios": num_scenarios,
+                    "orq.simulation.mode": "security",
+                    "orq.simulation.model": self._model,
+                },
+            ):
+                parsed, raw = await generate_structured(
+                    self._client,
+                    model=self._model,
+                    messages=messages,
+                    response_format=ScenarioListResponse,
+                    temperature=_TEMPERATURE_EDGE_CASE,
+                    max_tokens=6000,
+                    label="ScenarioGenerator.generate_security_scenarios",
+                )
 
             if parsed is not None:
                 scenarios = [

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/runner/simulation.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/runner/simulation.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
-import os
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
-
-from openai import AsyncOpenAI
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from evaluatorq.simulation.agents.judge import JudgeAgent, JudgeAgentConfig
 from evaluatorq.simulation.agents.user_simulator import (
@@ -44,6 +41,7 @@ from evaluatorq.simulation.utils.prompt_builders import (
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+    from openai import AsyncOpenAI
     from opentelemetry.trace import Span
 
     from evaluatorq.simulation.agents.base import BaseAgent
@@ -249,16 +247,45 @@ class SimulationRunner:
                     "orq.simulation.model": self._model,
                 },
             ) as run_span:
-                return await self._run_inner(
-                    persona=persona,
-                    scenario=scenario,
-                    first_message=first_message,
-                    effective_max_turns=effective_max_turns,
-                    messages=messages,
-                    turn_metrics_list=turn_metrics_list,
-                    run_span=run_span,
-                    usage_holder=usage_holder,
-                )
+                try:
+                    return await self._run_inner(
+                        persona=persona,
+                        scenario=scenario,
+                        first_message=first_message,
+                        effective_max_turns=effective_max_turns,
+                        messages=messages,
+                        turn_metrics_list=turn_metrics_list,
+                        run_span=run_span,
+                        usage_holder=usage_holder,
+                    )
+                except Exception:
+                    get_total_usage = usage_holder.get("get_total_usage")
+                    try:
+                        usage = (
+                            get_total_usage()
+                            if get_total_usage
+                            else ZERO_USAGE.model_copy()
+                        )
+                    except Exception as usage_err:
+                        logger.warning("Failed to collect token usage: %s", usage_err)
+                        usage = ZERO_USAGE.model_copy()
+                    record_token_usage(
+                        run_span,
+                        prompt_tokens=usage.prompt_tokens,
+                        completion_tokens=usage.completion_tokens,
+                        total_tokens=usage.total_tokens,
+                    )
+                    set_span_attrs(
+                        run_span,
+                        {
+                            "orq.simulation.terminated_by": "error",
+                            "orq.simulation.goal_achieved": False,
+                            "orq.simulation.turn_count": sum(
+                                1 for m in messages if m.role == "assistant"
+                            ),
+                        },
+                    )
+                    raise
         except Exception as e:
             logger.error("SimulationRunner.run() failed: %s", e, exc_info=True)
             error_msg = str(e)

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/runner/simulation.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/runner/simulation.py
@@ -233,6 +233,9 @@ class SimulationRunner:
         effective_max_turns = max_turns or self._max_turns
         messages: list[Message] = []
         turn_metrics_list: list[TurnMetrics] = []
+        # Holder so the outer except can read partial token usage from agents
+        # created inside _run_inner (mirrors TS getTotalUsage closure).
+        usage_holder: dict[str, Callable[[], TokenUsage]] = {}
 
         try:
             async with with_simulation_span(
@@ -252,14 +255,16 @@ class SimulationRunner:
                     messages=messages,
                     turn_metrics_list=turn_metrics_list,
                     run_span=run_span,
+                    usage_holder=usage_holder,
                 )
         except Exception as e:
             logger.error("SimulationRunner.run() failed: %s", e, exc_info=True)
             error_msg = str(e)
+            get_total_usage = usage_holder.get("get_total_usage")
             try:
-                usage = ZERO_USAGE.model_copy()
-            except Exception as e:
-                logger.warning("Failed to get token usage: %s", e)
+                usage = get_total_usage() if get_total_usage else ZERO_USAGE.model_copy()
+            except Exception as usage_err:
+                logger.warning("Failed to collect token usage: %s", usage_err)
                 usage = ZERO_USAGE.model_copy()
 
             result = _error_result(error_msg, persona, scenario)
@@ -279,6 +284,7 @@ class SimulationRunner:
         messages: list[Message],
         turn_metrics_list: list[TurnMetrics],
         run_span: Any,
+        usage_holder: dict[str, Callable[[], TokenUsage]],
     ) -> SimulationResult:
         """Inner simulation body (runs inside the orq.simulation.run span)."""
         system_prompt = build_datapoint_system_prompt(persona, scenario)  # pyright: ignore[reportArgumentType]
@@ -338,6 +344,9 @@ class SimulationRunner:
                 + judge_usage.completion_tokens,
                 total_tokens=usage.total_tokens + judge_usage.total_tokens,
             )
+
+        # Expose to the outer run() except path so it can report partial usage.
+        usage_holder["get_total_usage"] = _get_total_usage
 
         def _build_turn_metrics(
             turn_num: int, judgment: Judgment, usage_before: TokenUsage

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/runner/simulation.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/runner/simulation.py
@@ -44,6 +44,8 @@ from evaluatorq.simulation.utils.prompt_builders import (
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+    from opentelemetry.trace import Span
+
     from evaluatorq.simulation.agents.base import BaseAgent
 
 logger = logging.getLogger(__name__)
@@ -283,7 +285,7 @@ class SimulationRunner:
         effective_max_turns: int,
         messages: list[Message],
         turn_metrics_list: list[TurnMetrics],
-        run_span: Any,
+        run_span: Span | None,
         usage_holder: dict[str, Callable[[], TokenUsage]],
     ) -> SimulationResult:
         """Inner simulation body (runs inside the orq.simulation.run span)."""

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/runner/simulation.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/runner/simulation.py
@@ -6,7 +6,7 @@ import asyncio
 import inspect
 import logging
 import os
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from openai import AsyncOpenAI
 
@@ -14,6 +14,13 @@ from evaluatorq.simulation.agents.judge import JudgeAgent, JudgeAgentConfig
 from evaluatorq.simulation.agents.user_simulator import (
     UserSimulatorAgent,
     UserSimulatorAgentConfig,
+)
+from evaluatorq.simulation.tracing import (
+    record_llm_input,
+    record_llm_output,
+    record_token_usage,
+    set_span_attrs,
+    with_simulation_span,
 )
 from evaluatorq.simulation.types import (
     DEFAULT_MODEL,
@@ -226,163 +233,31 @@ class SimulationRunner:
         effective_max_turns = max_turns or self._max_turns
         messages: list[Message] = []
         turn_metrics_list: list[TurnMetrics] = []
-        get_total_usage: Callable[[], TokenUsage] | None = None
 
         try:
-            system_prompt = build_datapoint_system_prompt(
-                persona, scenario
-            )  # type: ignore[arg-type]
-            client = self._get_shared_client()
-
-            if self._injected_user_simulator is not None:
-                user_simulator: UserSimulatorAgent = self._injected_user_simulator  # pyright: ignore[reportAssignmentType]
-                # Propagate per-simulation persona/scenario context to the injected
-                # agent so it stays grounded in the current datapoint's goal and
-                # persona traits (mirrors what the default agent receives via its
-                # system_prompt constructor arg).
-                if hasattr(user_simulator, "update_context"):
-                    try:
-                        user_simulator.update_context(
-                            persona_context=build_persona_system_prompt(persona)  # type: ignore[arg-type]
-                            if persona
-                            else None,
-                            scenario_context=build_scenario_user_context(scenario)  # type: ignore[arg-type]
-                            if scenario
-                            else None,
-                        )
-                    except Exception as ctx_err:
-                        raise RuntimeError(
-                            "Injected user_simulator.update_context() failed. "
-                            "Ensure it accepts persona_context and scenario_context kwargs."
-                        ) from ctx_err
-            else:
-                user_simulator = UserSimulatorAgent(
-                    UserSimulatorAgentConfig(
-                        model=self._model,
-                        client=client,
-                        system_prompt=system_prompt,
-                    )
+            async with with_simulation_span(
+                "orq.simulation.run",
+                {
+                    "orq.simulation.persona": persona.name if persona else None,
+                    "orq.simulation.scenario": scenario.name if scenario else None,
+                    "orq.simulation.max_turns": effective_max_turns,
+                    "orq.simulation.model": self._model,
+                },
+            ) as run_span:
+                return await self._run_inner(
+                    persona=persona,
+                    scenario=scenario,
+                    first_message=first_message,
+                    effective_max_turns=effective_max_turns,
+                    messages=messages,
+                    turn_metrics_list=turn_metrics_list,
+                    run_span=run_span,
                 )
-
-            if self._injected_judge is not None:
-                judge: JudgeAgent = self._injected_judge  # pyright: ignore[reportAssignmentType]
-            else:
-                judge = JudgeAgent(
-                    JudgeAgentConfig(
-                        model=self._model,
-                        client=client,
-                        goal=scenario.goal if scenario else "",
-                        criteria=list(scenario.criteria)
-                        if scenario and scenario.criteria
-                        else [],
-                        ground_truth=scenario.ground_truth or "" if scenario else "",
-                    )
-                )
-
-            def _get_total_usage() -> TokenUsage:
-                usage = user_simulator.get_usage()
-                judge_usage = judge.get_usage()
-                return TokenUsage(
-                    prompt_tokens=usage.prompt_tokens + judge_usage.prompt_tokens,
-                    completion_tokens=usage.completion_tokens
-                    + judge_usage.completion_tokens,
-                    total_tokens=usage.total_tokens + judge_usage.total_tokens,
-                )
-
-            get_total_usage = _get_total_usage
-
-            def _build_turn_metrics(
-                turn_num: int, judgment: Judgment, usage_before: TokenUsage
-            ) -> TurnMetrics:
-                usage_after = _get_total_usage()
-                return TurnMetrics(
-                    turn_number=turn_num,
-                    token_usage=TokenUsage(
-                        prompt_tokens=usage_after.prompt_tokens
-                        - usage_before.prompt_tokens,
-                        completion_tokens=usage_after.completion_tokens
-                        - usage_before.completion_tokens,
-                        total_tokens=usage_after.total_tokens
-                        - usage_before.total_tokens,
-                    ),
-                    response_quality=judgment.response_quality,
-                    hallucination_risk=judgment.hallucination_risk,
-                    tone_appropriateness=judgment.tone_appropriateness,
-                    factual_accuracy=judgment.factual_accuracy,
-                    judge_reason=judgment.reason,
-                )
-
-            # Generate or use first message
-            first_msg = first_message or await user_simulator.generate_first_message()
-            messages.append(Message(role="user", content=first_msg))
-
-            last_judgment: Judgment | None = None
-
-            for turn in range(effective_max_turns):
-                usage_before = _get_total_usage()
-
-                # 1. Target agent responds
-                agent_response = await self._get_target_response(
-                    [ChatMessage(role=m.role, content=m.content) for m in messages]
-                )
-                messages.append(Message(role="assistant", content=agent_response))
-
-                # 2. Judge evaluates
-                judgment = await judge.evaluate(
-                    [ChatMessage(role=m.role, content=m.content) for m in messages]
-                )
-
-                turn_metrics_list.append(
-                    _build_turn_metrics(turn + 1, judgment, usage_before)
-                )
-                last_judgment = judgment
-
-                if judgment.should_terminate:
-                    return SimulationResult(
-                        messages=messages,
-                        terminated_by=TerminatedBy.judge,
-                        reason=judgment.reason,
-                        goal_achieved=judgment.goal_achieved,
-                        goal_completion_score=judgment.goal_completion_score,
-                        rules_broken=judgment.rules_broken,
-                        turn_count=turn + 1,
-                        turn_metrics=turn_metrics_list,
-                        token_usage=_get_total_usage(),
-                        criteria_results=self._build_criteria_results(
-                            scenario, judgment
-                        )
-                        if scenario
-                        else None,  # type: ignore[arg-type]
-                        metadata={
-                            "persona": persona.name if persona else None,
-                            "scenario": scenario.name if scenario else None,
-                        },  # type: ignore[union-attr]
-                    )
-
-                # 3. User simulator continues (if not last turn)
-                if turn < effective_max_turns - 1:
-                    user_response = await user_simulator.respond_async(
-                        _invert_roles_for_simulator(messages),
-                    )
-                    messages.append(Message(role="user", content=user_response))
-
-            return _max_turns_result(
-                effective_max_turns,
-                messages,
-                turn_metrics_list,
-                _get_total_usage(),
-                persona,
-                scenario,
-                last_judgment,
-            )
-
         except Exception as e:
             logger.error("SimulationRunner.run() failed: %s", e, exc_info=True)
             error_msg = str(e)
             try:
-                usage = (
-                    get_total_usage() if get_total_usage else ZERO_USAGE.model_copy()
-                )
+                usage = ZERO_USAGE.model_copy()
             except Exception as e:
                 logger.warning("Failed to get token usage: %s", e)
                 usage = ZERO_USAGE.model_copy()
@@ -393,6 +268,237 @@ class SimulationRunner:
             result.turn_metrics = turn_metrics_list
             result.token_usage = usage
             return result
+
+    async def _run_inner(
+        self,
+        *,
+        persona: Persona | None,
+        scenario: Scenario | None,
+        first_message: str | None,
+        effective_max_turns: int,
+        messages: list[Message],
+        turn_metrics_list: list[TurnMetrics],
+        run_span: Any,
+    ) -> SimulationResult:
+        """Inner simulation body (runs inside the orq.simulation.run span)."""
+        system_prompt = build_datapoint_system_prompt(persona, scenario)  # pyright: ignore[reportArgumentType]
+        client = self._get_shared_client()
+
+        if self._injected_user_simulator is not None:
+            user_simulator: UserSimulatorAgent = self._injected_user_simulator  # pyright: ignore[reportAssignmentType]
+            # Propagate per-simulation persona/scenario context to the injected
+            # agent so it stays grounded in the current datapoint's goal and
+            # persona traits (mirrors what the default agent receives via its
+            # system_prompt constructor arg).
+            if hasattr(user_simulator, "update_context"):
+                try:
+                    user_simulator.update_context(
+                        persona_context=build_persona_system_prompt(persona)  # type: ignore[arg-type]
+                        if persona
+                        else None,
+                        scenario_context=build_scenario_user_context(scenario)  # type: ignore[arg-type]
+                        if scenario
+                        else None,
+                    )
+                except Exception as ctx_err:
+                    raise RuntimeError(
+                        "Injected user_simulator.update_context() failed. "
+                        "Ensure it accepts persona_context and scenario_context kwargs."
+                    ) from ctx_err
+        else:
+            user_simulator = UserSimulatorAgent(
+                UserSimulatorAgentConfig(
+                    model=self._model,
+                    client=client,
+                    system_prompt=system_prompt,
+                )
+            )
+
+        if self._injected_judge is not None:
+            judge: JudgeAgent = self._injected_judge  # pyright: ignore[reportAssignmentType]
+        else:
+            judge = JudgeAgent(
+                JudgeAgentConfig(
+                    model=self._model,
+                    client=client,
+                    goal=scenario.goal if scenario else "",
+                    criteria=list(scenario.criteria)
+                    if scenario and scenario.criteria
+                    else [],
+                    ground_truth=scenario.ground_truth or "" if scenario else "",
+                )
+            )
+
+        def _get_total_usage() -> TokenUsage:
+            usage = user_simulator.get_usage()
+            judge_usage = judge.get_usage()
+            return TokenUsage(
+                prompt_tokens=usage.prompt_tokens + judge_usage.prompt_tokens,
+                completion_tokens=usage.completion_tokens
+                + judge_usage.completion_tokens,
+                total_tokens=usage.total_tokens + judge_usage.total_tokens,
+            )
+
+        def _build_turn_metrics(
+            turn_num: int, judgment: Judgment, usage_before: TokenUsage
+        ) -> TurnMetrics:
+            usage_after = _get_total_usage()
+            return TurnMetrics(
+                turn_number=turn_num,
+                token_usage=TokenUsage(
+                    prompt_tokens=usage_after.prompt_tokens
+                    - usage_before.prompt_tokens,
+                    completion_tokens=usage_after.completion_tokens
+                    - usage_before.completion_tokens,
+                    total_tokens=usage_after.total_tokens
+                    - usage_before.total_tokens,
+                ),
+                response_quality=judgment.response_quality,
+                hallucination_risk=judgment.hallucination_risk,
+                tone_appropriateness=judgment.tone_appropriateness,
+                factual_accuracy=judgment.factual_accuracy,
+                judge_reason=judgment.reason,
+            )
+
+        # Generate or use first message
+        if first_message:
+            first_msg = first_message
+        else:
+            async with with_simulation_span(
+                "orq.simulation.first_message_generation",
+                {
+                    "orq.simulation.persona": persona.name if persona else None,
+                    "orq.simulation.scenario": scenario.name if scenario else None,
+                    "orq.simulation.model": self._model,
+                },
+            ):
+                first_msg = await user_simulator.generate_first_message()
+        messages.append(Message(role="user", content=first_msg))
+
+        last_judgment: Judgment | None = None
+
+        for turn in range(effective_max_turns):
+            usage_before = _get_total_usage()
+
+            async with with_simulation_span(
+                "orq.simulation.turn",
+                {
+                    "orq.simulation.turn": turn + 1,
+                    "orq.simulation.max_turns": effective_max_turns,
+                },
+            ) as turn_span:
+                # 1. Target agent responds
+                target_messages = [
+                    ChatMessage(role=m.role, content=m.content) for m in messages
+                ]
+                async with with_simulation_span(
+                    "orq.simulation.target_call", None
+                ) as target_span:
+                    record_llm_input(
+                        target_span,
+                        [{"role": m.role, "content": m.content} for m in target_messages],
+                    )
+                    agent_response = await self._get_target_response(target_messages)
+                    record_llm_output(target_span, agent_response)
+                messages.append(Message(role="assistant", content=agent_response))
+
+                # 2. Judge evaluates
+                async with with_simulation_span(
+                    "orq.simulation.judge_evaluation", None
+                ):
+                    judgment = await judge.evaluate(
+                        [ChatMessage(role=m.role, content=m.content) for m in messages]
+                    )
+
+                turn_metrics_list.append(
+                    _build_turn_metrics(turn + 1, judgment, usage_before)
+                )
+                last_judgment = judgment
+
+                set_span_attrs(
+                    turn_span,
+                    {
+                        "orq.simulation.goal_achieved": judgment.goal_achieved,
+                        "orq.simulation.goal_completion_score": judgment.goal_completion_score,
+                        "orq.simulation.should_terminate": judgment.should_terminate,
+                    },
+                )
+
+                # 3. User simulator continues (if not last turn and not terminated)
+                if not judgment.should_terminate and turn < effective_max_turns - 1:
+                    async with with_simulation_span(
+                        "orq.simulation.user_simulator_call", None
+                    ):
+                        user_response = await user_simulator.respond_async(
+                            _invert_roles_for_simulator(messages),
+                            llm_purpose="user_simulator",
+                        )
+                    messages.append(Message(role="user", content=user_response))
+
+            if last_judgment and last_judgment.should_terminate:
+                final_usage = _get_total_usage()
+                record_token_usage(
+                    run_span,
+                    prompt_tokens=final_usage.prompt_tokens,
+                    completion_tokens=final_usage.completion_tokens,
+                    total_tokens=final_usage.total_tokens,
+                )
+                set_span_attrs(
+                    run_span,
+                    {
+                        "orq.simulation.terminated_by": "judge",
+                        "orq.simulation.goal_achieved": last_judgment.goal_achieved,
+                        "orq.simulation.turn_count": turn + 1,
+                    },
+                )
+                return SimulationResult(
+                    messages=messages,
+                    terminated_by=TerminatedBy.judge,
+                    reason=last_judgment.reason,
+                    goal_achieved=last_judgment.goal_achieved,
+                    goal_completion_score=last_judgment.goal_completion_score,
+                    rules_broken=last_judgment.rules_broken,
+                    turn_count=turn + 1,
+                    turn_metrics=turn_metrics_list,
+                    token_usage=final_usage,
+                    criteria_results=self._build_criteria_results(
+                        scenario, last_judgment
+                    )
+                    if scenario
+                    else None,  # type: ignore[arg-type]
+                    metadata={
+                        "persona": persona.name if persona else None,
+                        "scenario": scenario.name if scenario else None,
+                    },  # type: ignore[union-attr]
+                )
+
+        # Max turns reached
+        final_usage = _get_total_usage()
+        record_token_usage(
+            run_span,
+            prompt_tokens=final_usage.prompt_tokens,
+            completion_tokens=final_usage.completion_tokens,
+            total_tokens=final_usage.total_tokens,
+        )
+        set_span_attrs(
+            run_span,
+            {
+                "orq.simulation.terminated_by": "max_turns",
+                "orq.simulation.goal_achieved": last_judgment.goal_achieved
+                if last_judgment
+                else False,
+                "orq.simulation.turn_count": effective_max_turns,
+            },
+        )
+        return _max_turns_result(
+            effective_max_turns,
+            messages,
+            turn_metrics_list,
+            final_usage,
+            persona,
+            scenario,
+            last_judgment,
+        )
 
     async def run_batch(
         self,

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/runner/simulation.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/runner/simulation.py
@@ -258,7 +258,7 @@ class SimulationRunner:
                         run_span=run_span,
                         usage_holder=usage_holder,
                     )
-                except Exception:
+                except BaseException:
                     get_total_usage = usage_holder.get("get_total_usage")
                     try:
                         usage = (

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/tracing.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/tracing.py
@@ -359,6 +359,12 @@ def record_llm_response(span: Span | None, response: Any) -> None:
             reason = getattr(choice, "finish_reason", None)
             if reason:
                 finish_reasons.append(reason)
+    else:
+        # Responses API uses response.status (e.g. "completed", "failed",
+        # "incomplete") in place of choices[*].finish_reason.
+        status = getattr(response, "status", None)
+        if isinstance(status, str) and status:
+            finish_reasons.append(status)
     if finish_reasons:
         span.set_attribute("gen_ai.response.finish_reasons", finish_reasons)
 

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/tracing.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/tracing.py
@@ -75,7 +75,11 @@ async def with_simulation_span(  # noqa: RUF029
         try:
             yield span
             span.set_status(Status(StatusCode.OK))
-        except Exception as e:
+        except BaseException as e:
+            # Catch BaseException so asyncio.CancelledError (used by
+            # asyncio.wait_for / timeouts) is recorded on the span instead
+            # of leaving it with UNSET status. KeyboardInterrupt / SystemExit
+            # are also surfaced — desirable for trace visibility.
             span.set_status(Status(StatusCode.ERROR, str(e)))
             span.record_exception(e)
             span.set_attribute("error.type", type(e).__name__)
@@ -138,7 +142,9 @@ async def with_llm_span(  # noqa: RUF029
         try:
             yield span
             span.set_status(Status(StatusCode.OK))
-        except Exception as e:
+        except BaseException as e:
+            # See with_simulation_span for why BaseException (asyncio
+            # cancellation visibility on timeout).
             span.set_status(Status(StatusCode.ERROR, str(e)))
             span.record_exception(e)
             span.set_attribute("error.type", type(e).__name__)

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/tracing.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/tracing.py
@@ -274,12 +274,12 @@ def record_llm_response(span: Span | None, response: Any) -> None:
 
     usage = getattr(response, "usage", None)
     if usage is not None:
-        prompt = getattr(usage, "prompt_tokens", None) or getattr(
-            usage, "input_tokens", None
-        )
-        completion = getattr(usage, "completion_tokens", None) or getattr(
-            usage, "output_tokens", None
-        )
+        prompt = getattr(usage, "prompt_tokens", None)
+        if prompt is None:
+            prompt = getattr(usage, "input_tokens", None)
+        completion = getattr(usage, "completion_tokens", None)
+        if completion is None:
+            completion = getattr(usage, "output_tokens", None)
         total = getattr(usage, "total_tokens", None)
         details = getattr(usage, "prompt_tokens_details", None)
         cache_read = getattr(details, "cached_tokens", None) if details else None
@@ -302,16 +302,34 @@ def record_llm_response(span: Span | None, response: Any) -> None:
                     role = getattr(message, "role", None) or "assistant"
                     output_messages.append({"role": role, "content": content})
         else:
-            # Responses API: response.output is a list of items with .text
-            output_items = getattr(response, "output", None)
-            if output_items:
-                text = "".join(
-                    getattr(item, "text", "") or ""
-                    for item in output_items
-                    if hasattr(item, "text")
+            # Responses API: response.output is a list of typed items.
+            # Prefer the SDK helper response.output_text when available,
+            # else descend into item.content[*].text for "message" items
+            # and fall back to a flat .text attribute for older shapes.
+            output_text = getattr(response, "output_text", None)
+            if isinstance(output_text, str) and output_text:
+                output_messages.append(
+                    {"role": "assistant", "content": output_text}
                 )
-                if text:
-                    output_messages.append({"role": "assistant", "content": text})
+            else:
+                output_items = getattr(response, "output", None) or []
+                parts: list[str] = []
+                for item in output_items:
+                    content = getattr(item, "content", None)
+                    if content:
+                        for part in content:
+                            text = getattr(part, "text", None)
+                            if isinstance(text, str) and text:
+                                parts.append(text)
+                    else:
+                        text = getattr(item, "text", None)
+                        if isinstance(text, str) and text:
+                            parts.append(text)
+                joined = "".join(parts)
+                if joined:
+                    output_messages.append(
+                        {"role": "assistant", "content": joined}
+                    )
 
         if output_messages:
             serialized = _serialize_messages(output_messages)

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/tracing.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/tracing.py
@@ -205,18 +205,28 @@ def _truncate(text: str) -> str:
     return f"{text[:MAX_CONTENT_LEN]}…"
 
 
-def _serialize_messages(messages: list[dict[str, str]]) -> str:
+def _serialize_messages(messages: list[dict[str, Any]]) -> str:
     return json.dumps(
-        [{"role": m["role"], "content": _truncate(m["content"])} for m in messages]
+        [
+            {
+                "role": str(m.get("role", "")),
+                "content": _truncate(str(m.get("content") or "")),
+            }
+            for m in messages
+        ]
     )
 
 
 def _capture_message_content() -> bool:
     """Honor ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` env flag.
 
-    The OTel GenAI semconv classifies ``gen_ai.input.messages`` and
-    ``gen_ai.output.messages`` as opt-in because they may carry PII. Default
-    is ``True`` so the platform UI keeps working.
+    Deliberate deviation from the OTel GenAI semconv: the spec classifies
+    ``gen_ai.input.messages`` and ``gen_ai.output.messages`` as opt-in
+    (default ``false``) due to PII risk. We default to ``True`` to match
+    the TypeScript implementation (RES-595) so the Orq dashboard's input/
+    output panels keep rendering. Set
+    ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=false`` to opt out
+    if traces will be exported to a third-party backend.
     """
     flag = os.environ.get("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT")
     if flag is None:
@@ -337,9 +347,9 @@ def record_llm_response(span: Span | None, response: Any) -> None:
             span.set_attribute("output", serialized)
 
     finish_reasons: list[str] = []
-    choices = getattr(response, "choices", None)
-    if choices:
-        for choice in choices:
+    finish_choices = getattr(response, "choices", None)
+    if finish_choices:
+        for choice in finish_choices:
             reason = getattr(choice, "finish_reason", None)
             if reason:
                 finish_reasons.append(reason)

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/tracing.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/tracing.py
@@ -223,6 +223,47 @@ def _serialize_messages(messages: list[dict[str, Any]]) -> str:
     )
 
 
+def _serialize_tool_call_content(tool_calls: list[dict[str, Any]]) -> str:
+    """Render tool-call-only outputs into assistant content for trace display."""
+    return json.dumps({"tool_calls": tool_calls}, ensure_ascii=False)
+
+
+def _extract_chat_tool_call_payloads(tool_calls: Any) -> list[dict[str, str]]:
+    payloads: list[dict[str, str]] = []
+    for tool_call in tool_calls or []:
+        function = getattr(tool_call, "function", None)
+        name = getattr(function, "name", None) or getattr(tool_call, "name", None)
+        arguments = getattr(function, "arguments", None) or getattr(
+            tool_call, "arguments", None
+        )
+        payload: dict[str, str] = {}
+        if name:
+            payload["name"] = str(name)
+        if arguments is not None:
+            payload["arguments"] = str(arguments)
+        if payload:
+            payloads.append(payload)
+    return payloads
+
+
+def _extract_response_tool_call_payloads(output_items: list[Any]) -> list[dict[str, str]]:
+    payloads: list[dict[str, str]] = []
+    for item in output_items:
+        call_id = getattr(item, "call_id", None)
+        name = getattr(item, "name", None)
+        arguments = getattr(item, "arguments", None)
+        if call_id or name or arguments is not None:
+            payload: dict[str, str] = {}
+            if call_id:
+                payload["call_id"] = str(call_id)
+            if name:
+                payload["name"] = str(name)
+            if arguments is not None:
+                payload["arguments"] = str(arguments)
+            payloads.append(payload)
+    return payloads
+
+
 def _capture_message_content() -> bool:
     """Honor ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` env flag.
 
@@ -317,6 +358,18 @@ def record_llm_response(span: Span | None, response: Any) -> None:
                 if content:
                     role = getattr(message, "role", None) or "assistant"
                     output_messages.append({"role": role, "content": content})
+                    continue
+                tool_payloads = _extract_chat_tool_call_payloads(
+                    getattr(message, "tool_calls", None) if message else None
+                )
+                if tool_payloads:
+                    role = getattr(message, "role", None) or "assistant"
+                    output_messages.append(
+                        {
+                            "role": role,
+                            "content": _serialize_tool_call_content(tool_payloads),
+                        }
+                    )
         else:
             # Responses API: response.output is a list of typed items.
             # Prefer the SDK helper response.output_text when available,
@@ -346,6 +399,15 @@ def record_llm_response(span: Span | None, response: Any) -> None:
                     output_messages.append(
                         {"role": "assistant", "content": joined}
                     )
+                else:
+                    tool_payloads = _extract_response_tool_call_payloads(output_items)
+                    if tool_payloads:
+                        output_messages.append(
+                            {
+                                "role": "assistant",
+                                "content": _serialize_tool_call_content(tool_payloads),
+                            }
+                        )
 
         if output_messages:
             serialized = _serialize_messages(output_messages)

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/tracing.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/tracing.py
@@ -1,0 +1,378 @@
+"""OpenTelemetry tracing utilities for the agent simulation module.
+
+Provides span creation helpers that mirror the TypeScript simulation module's
+tracing patterns. All functions gracefully degrade to no-ops when tracing is
+not enabled.
+
+Span hierarchy:
+    orq.simulation.pipeline (root)
+      ├── orq.simulation.run (per datapoint)
+      │   ├── orq.simulation.first_message_generation
+      │   └── orq.simulation.turn (per turn)
+      │       ├── orq.simulation.target_call
+      │       ├── orq.simulation.judge_evaluation
+      │       └── orq.simulation.user_simulator_call
+      └── chat/responses {model}  (LLM client spans, GenAI semconv)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+from evaluatorq.tracing.setup import get_tracer
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from opentelemetry.trace import Span
+
+
+AttrValue = str | int | float | bool
+AttrMap = dict[str, AttrValue | None]
+
+# Max content length per message to avoid oversized spans (matches TS).
+MAX_CONTENT_LEN = 2000
+
+
+# ---------------------------------------------------------------------------
+# Internal span: orq.simulation.*
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def with_simulation_span(  # noqa: RUF029
+    name: str,
+    attributes: AttrMap | None = None,
+) -> AsyncGenerator[Span | None, None]:
+    """Execute a block within a simulation span (SpanKind.INTERNAL).
+
+    Yields ``None`` when tracing is not enabled. Records exceptions and sets
+    span status automatically.
+    """
+    tracer = get_tracer()
+    if tracer is None:
+        yield None
+        return
+
+    try:
+        from opentelemetry.trace import SpanKind, Status, StatusCode
+    except ImportError:
+        yield None
+        return
+
+    clean_attrs: dict[str, AttrValue] = {
+        k: v for k, v in (attributes or {}).items() if v is not None
+    }
+
+    with tracer.start_as_current_span(
+        name,
+        kind=SpanKind.INTERNAL,
+        attributes=clean_attrs,
+    ) as span:
+        try:
+            yield span
+            span.set_status(Status(StatusCode.OK))
+        except Exception as e:
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            span.record_exception(e)
+            span.set_attribute("error.type", type(e).__name__)
+            raise
+
+
+# ---------------------------------------------------------------------------
+# LLM span: GenAI semantic conventions (SpanKind.CLIENT)
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def with_llm_span(  # noqa: RUF029
+    *,
+    model: str,
+    operation: str = "chat",
+    provider: str | None = None,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    purpose: str | None = None,
+) -> AsyncGenerator[Span | None, None]:
+    """Execute a block within a GenAI LLM span (SpanKind.CLIENT).
+
+    Follows OTel GenAI semantic conventions for client inference spans. Span
+    name is ``"{operation} {model}"``. Use ``operation="chat"`` for Chat
+    Completions and ``operation="responses"`` for the OpenAI Responses API.
+    """
+    tracer = get_tracer()
+    if tracer is None:
+        yield None
+        return
+
+    try:
+        from opentelemetry.trace import SpanKind, Status, StatusCode
+    except ImportError:
+        yield None
+        return
+
+    resolved_provider = provider or _derive_provider(model)
+    span_name = f"{operation} {model}"
+
+    attrs: dict[str, AttrValue] = {
+        "gen_ai.operation.name": operation,
+        "gen_ai.system": resolved_provider,
+        "gen_ai.provider.name": resolved_provider,
+        "gen_ai.request.model": model,
+    }
+    if temperature is not None:
+        attrs["gen_ai.request.temperature"] = temperature
+    if max_tokens is not None:
+        attrs["gen_ai.request.max_tokens"] = max_tokens
+    if purpose:
+        attrs["orq.simulation.llm_purpose"] = purpose
+
+    with tracer.start_as_current_span(
+        span_name,
+        kind=SpanKind.CLIENT,
+        attributes=attrs,
+    ) as span:
+        try:
+            yield span
+            span.set_status(Status(StatusCode.OK))
+        except Exception as e:
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            span.record_exception(e)
+            span.set_attribute("error.type", type(e).__name__)
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Token usage recording
+# ---------------------------------------------------------------------------
+
+
+def record_token_usage(
+    span: Span | None,
+    *,
+    prompt_tokens: int | None = None,
+    completion_tokens: int | None = None,
+    total_tokens: int | None = None,
+    cache_read_input_tokens: int | None = None,
+    cache_creation_input_tokens: int | None = None,
+) -> None:
+    """Record token usage attributes on a span.
+
+    Sets both OTel GenAI names and bare attribute keys for platform
+    compatibility (matches TS dual-naming convention).
+    """
+    if span is None:
+        return
+
+    prompt = prompt_tokens or 0
+    completion = completion_tokens or 0
+    total = total_tokens if total_tokens is not None else prompt + completion
+
+    span.set_attribute("gen_ai.usage.input_tokens", prompt)
+    span.set_attribute("gen_ai.usage.output_tokens", completion)
+    span.set_attribute("gen_ai.usage.total_tokens", total)
+
+    if cache_read_input_tokens is not None:
+        span.set_attribute(
+            "gen_ai.usage.cache_read.input_tokens", cache_read_input_tokens
+        )
+    if cache_creation_input_tokens is not None:
+        span.set_attribute(
+            "gen_ai.usage.cache_creation.input_tokens", cache_creation_input_tokens
+        )
+
+    # Aliases for platform compatibility
+    span.set_attribute("gen_ai.usage.prompt_tokens", prompt)
+    span.set_attribute("gen_ai.usage.completion_tokens", completion)
+    span.set_attribute("prompt_tokens", prompt)
+    span.set_attribute("completion_tokens", completion)
+    span.set_attribute("input_tokens", prompt)
+    span.set_attribute("output_tokens", completion)
+    span.set_attribute("total_tokens", total)
+
+
+# ---------------------------------------------------------------------------
+# Message recording (gen_ai.input/output.messages)
+# ---------------------------------------------------------------------------
+
+
+def _truncate(text: str) -> str:
+    if len(text) <= MAX_CONTENT_LEN:
+        return text
+    return f"{text[:MAX_CONTENT_LEN]}…"
+
+
+def _serialize_messages(messages: list[dict[str, str]]) -> str:
+    return json.dumps(
+        [{"role": m["role"], "content": _truncate(m["content"])} for m in messages]
+    )
+
+
+def _capture_message_content() -> bool:
+    """Honor ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` env flag.
+
+    The OTel GenAI semconv classifies ``gen_ai.input.messages`` and
+    ``gen_ai.output.messages`` as opt-in because they may carry PII. Default
+    is ``True`` so the platform UI keeps working.
+    """
+    flag = os.environ.get("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT")
+    if flag is None:
+        return True
+    return flag.lower() == "true" or flag == "1"
+
+
+def record_llm_input(
+    span: Span | None, messages: list[dict[str, str]]
+) -> None:
+    """Record LLM input messages on a span.
+
+    Sets both ``gen_ai.input.messages`` (OTel GenAI convention) and ``input``
+    (platform fallback). Suppressed when
+    ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=false``.
+    """
+    if span is None or not messages:
+        return
+    if not _capture_message_content():
+        return
+
+    serialized = _serialize_messages(messages)
+    span.set_attribute("gen_ai.input.messages", serialized)
+    span.set_attribute("input", serialized)
+
+
+def record_llm_output(span: Span | None, output: str) -> None:
+    """Record a single LLM output string on a span."""
+    if span is None or not output:
+        return
+    if not _capture_message_content():
+        return
+
+    serialized = _serialize_messages([{"role": "assistant", "content": output}])
+    span.set_attribute("gen_ai.output.messages", serialized)
+    span.set_attribute("output", serialized)
+
+
+def record_llm_response(span: Span | None, response: Any) -> None:
+    """Record LLM response attributes on a span from an OpenAI response.
+
+    Handles both Chat Completions and Responses API objects (duck-typed).
+    Sets ``gen_ai.output.messages``, ``output``, token usage, finish reasons,
+    and response metadata.
+    """
+    if span is None:
+        return
+
+    response_id = getattr(response, "id", None)
+    if response_id:
+        span.set_attribute("gen_ai.response.id", response_id)
+    response_model = getattr(response, "model", None)
+    if response_model:
+        span.set_attribute("gen_ai.response.model", response_model)
+
+    usage = getattr(response, "usage", None)
+    if usage is not None:
+        prompt = getattr(usage, "prompt_tokens", None) or getattr(
+            usage, "input_tokens", None
+        )
+        completion = getattr(usage, "completion_tokens", None) or getattr(
+            usage, "output_tokens", None
+        )
+        total = getattr(usage, "total_tokens", None)
+        details = getattr(usage, "prompt_tokens_details", None)
+        cache_read = getattr(details, "cached_tokens", None) if details else None
+        record_token_usage(
+            span,
+            prompt_tokens=prompt,
+            completion_tokens=completion,
+            total_tokens=total,
+            cache_read_input_tokens=cache_read,
+        )
+
+    if _capture_message_content():
+        output_messages: list[dict[str, str]] = []
+        choices = getattr(response, "choices", None)
+        if choices:
+            for choice in choices:
+                message = getattr(choice, "message", None)
+                content = getattr(message, "content", None) if message else None
+                if content:
+                    role = getattr(message, "role", None) or "assistant"
+                    output_messages.append({"role": role, "content": content})
+        else:
+            # Responses API: response.output is a list of items with .text
+            output_items = getattr(response, "output", None)
+            if output_items:
+                text = "".join(
+                    getattr(item, "text", "") or ""
+                    for item in output_items
+                    if hasattr(item, "text")
+                )
+                if text:
+                    output_messages.append({"role": "assistant", "content": text})
+
+        if output_messages:
+            serialized = _serialize_messages(output_messages)
+            span.set_attribute("gen_ai.output.messages", serialized)
+            span.set_attribute("output", serialized)
+
+    finish_reasons: list[str] = []
+    choices = getattr(response, "choices", None)
+    if choices:
+        for choice in choices:
+            reason = getattr(choice, "finish_reason", None)
+            if reason:
+                finish_reasons.append(reason)
+    if finish_reasons:
+        span.set_attribute("gen_ai.response.finish_reasons", finish_reasons)
+
+
+# ---------------------------------------------------------------------------
+# Attribute helpers
+# ---------------------------------------------------------------------------
+
+
+def set_span_attrs(span: Span | None, attrs: AttrMap) -> None:
+    """Batch set multiple attributes on a span. Skips ``None`` values."""
+    if span is None:
+        return
+    for key, value in attrs.items():
+        if value is not None:
+            span.set_attribute(key, value)
+
+
+async def get_trace_context_headers() -> dict[str, str]:  # noqa: RUF029
+    """Get W3C trace context headers for the current active span.
+
+    Returns an empty dict when tracing is not available. Used to propagate
+    trace context into outgoing HTTP requests so the router can create child
+    spans under the current simulation span.
+    """
+    try:
+        from opentelemetry import context, propagate
+    except ImportError:
+        return {}
+
+    headers: dict[str, str] = {}
+    propagate.inject(headers, context=context.get_current())
+    return headers
+
+
+# ---------------------------------------------------------------------------
+# Provider derivation
+# ---------------------------------------------------------------------------
+
+# OTel GenAI semconv ``gen_ai.system`` enum aliases. The router uses prefixes
+# like "azure/" that don't map 1:1 to the spec — translate the known ones.
+_PROVIDER_ALIASES: dict[str, str] = {
+    "azure": "azure.ai.openai",
+}
+
+
+def _derive_provider(model: str) -> str:
+    if "/" in model:
+        prefix = model.split("/", 1)[0]
+        return _PROVIDER_ALIASES.get(prefix, prefix)
+    return "openai"

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/utils/structured_output.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/utils/structured_output.py
@@ -14,6 +14,12 @@ from typing import Any, TypeVar, cast
 from openai import APIStatusError, AsyncOpenAI
 from pydantic import BaseModel
 
+from evaluatorq.simulation.tracing import (
+    get_trace_context_headers,
+    record_llm_input,
+    record_llm_response,
+    with_llm_span,
+)
 from evaluatorq.simulation.utils.retry import with_retry
 
 logger = logging.getLogger(__name__)
@@ -42,49 +48,67 @@ async def generate_structured(
     # TypedDict union just doesn't type-narrow from dict[str, Any].
     typed_messages = cast("Any", messages)
 
-    # 1. Try structured output via parse()
-    try:
-        response = await with_retry(
-            lambda: client.chat.completions.parse(
+    async with with_llm_span(
+        model=model,
+        operation="chat",
+        temperature=temperature,
+        max_tokens=max_tokens,
+        purpose=label,
+    ) as span:
+        record_llm_input(
+            span,
+            [{"role": str(m["role"]), "content": str(m["content"])} for m in messages],
+        )
+        trace_headers = await get_trace_context_headers()
+        extra: dict[str, Any] = {"extra_headers": trace_headers} if trace_headers else {}
+
+        # 1. Try structured output via parse()
+        try:
+            response = await with_retry(
+                lambda: client.chat.completions.parse(
+                    model=model,
+                    messages=typed_messages,
+                    response_format=response_format,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    **extra,
+                ),
+                label=label,
+            )
+            record_llm_response(span, response)
+            message = response.choices[0].message
+            refusal = getattr(message, "refusal", None)
+            if refusal:
+                raise RuntimeError(f"{label}: model refused to generate: {refusal}")
+            parsed = message.parsed
+            if parsed is not None:
+                return parsed, ""
+            logger.debug("%s: parse() returned None, falling back to json_object", label)
+        except APIStatusError as e:
+            if e.status_code != 400:
+                raise
+            # Only fall back if this looks like a schema-support issue
+            err_body = str(getattr(e, "body", None) or getattr(e, "message", "") or "").lower()
+            schema_keywords = ("structured", "response_format", "json_schema", "not supported")
+            if not any(kw in err_body for kw in schema_keywords):
+                raise
+            logger.debug(
+                "%s: structured output not supported by model, falling back to json_object",
+                label,
+            )
+
+        # 2. Fallback: json_object mode
+        fallback_response = await with_retry(
+            lambda: client.chat.completions.create(
                 model=model,
                 messages=typed_messages,
-                response_format=response_format,
                 temperature=temperature,
                 max_tokens=max_tokens,
+                response_format={"type": "json_object"},
+                **extra,
             ),
-            label=label,
+            label=f"{label} (fallback)",
         )
-        message = response.choices[0].message
-        refusal = getattr(message, "refusal", None)
-        if refusal:
-            raise RuntimeError(f"{label}: model refused to generate: {refusal}")
-        parsed = message.parsed
-        if parsed is not None:
-            return parsed, ""
-        logger.debug("%s: parse() returned None, falling back to json_object", label)
-    except APIStatusError as e:
-        if e.status_code != 400:
-            raise
-        # Only fall back if this looks like a schema-support issue
-        err_body = str(getattr(e, "body", None) or getattr(e, "message", "") or "").lower()
-        schema_keywords = ("structured", "response_format", "json_schema", "not supported")
-        if not any(kw in err_body for kw in schema_keywords):
-            raise
-        logger.debug(
-            "%s: structured output not supported by model, falling back to json_object",
-            label,
-        )
-
-    # 2. Fallback: json_object mode
-    fallback_response = await with_retry(
-        lambda: client.chat.completions.create(
-            model=model,
-            messages=typed_messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            response_format={"type": "json_object"},
-        ),
-        label=f"{label} (fallback)",
-    )
-    content = fallback_response.choices[0].message.content if fallback_response.choices else ""
-    return None, content or ""
+        record_llm_response(span, fallback_response)
+        content = fallback_response.choices[0].message.content if fallback_response.choices else ""
+        return None, content or ""

--- a/packages/evaluatorq-py/tests/simulation/test_tracing.py
+++ b/packages/evaluatorq-py/tests/simulation/test_tracing.py
@@ -1,0 +1,481 @@
+"""Integration test verifying OTel span output for the simulation module.
+
+Uses an in-memory span exporter to capture real spans and validate names,
+attributes, and hierarchy of the simulation tracing helpers.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Sequence
+from unittest.mock import patch
+
+import pytest
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
+
+
+class _CollectingExporter(SpanExporter):
+    """Minimal in-memory exporter that collects finished spans."""
+
+    def __init__(self) -> None:
+        self.spans: list[ReadableSpan] = []
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        pass
+
+
+@pytest.fixture()
+def span_collector():
+    """Set up an in-memory OTel TracerProvider; patch the simulation tracer."""
+    exporter = _CollectingExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("evaluatorq-simulation-test")
+
+    with patch(
+        "evaluatorq.simulation.tracing.get_tracer", return_value=tracer
+    ):
+        yield exporter
+
+    provider.shutdown()
+
+
+def _attrs(span: ReadableSpan) -> dict[str, Any]:
+    return dict(span.attributes or {})
+
+
+def _find(exporter: _CollectingExporter, name: str) -> ReadableSpan:
+    for s in exporter.spans:
+        if s.name == name:
+            return s
+    raise AssertionError(f"span {name!r} not found; got {[s.name for s in exporter.spans]}")
+
+
+# ---------------------------------------------------------------------------
+# with_simulation_span
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_simulation_span_creates_span_with_attrs(
+    span_collector: _CollectingExporter,
+):
+    from evaluatorq.simulation.tracing import with_simulation_span
+
+    async with with_simulation_span(
+        "orq.simulation.run",
+        {"orq.simulation.persona": "alice", "orq.simulation.max_turns": 5},
+    ) as span:
+        assert span is not None
+
+    s = _find(span_collector, "orq.simulation.run")
+    a = _attrs(s)
+    assert a["orq.simulation.persona"] == "alice"
+    assert a["orq.simulation.max_turns"] == 5
+
+
+@pytest.mark.asyncio
+async def test_simulation_span_skips_none_attrs(
+    span_collector: _CollectingExporter,
+):
+    from evaluatorq.simulation.tracing import with_simulation_span
+
+    async with with_simulation_span(
+        "orq.simulation.run", {"orq.simulation.persona": None, "kept": "yes"}
+    ):
+        pass
+
+    s = _find(span_collector, "orq.simulation.run")
+    a = _attrs(s)
+    assert "orq.simulation.persona" not in a
+    assert a["kept"] == "yes"
+
+
+@pytest.mark.asyncio
+async def test_simulation_span_records_exception(
+    span_collector: _CollectingExporter,
+):
+    from evaluatorq.simulation.tracing import with_simulation_span
+
+    with pytest.raises(RuntimeError):
+        async with with_simulation_span("orq.simulation.run", None):
+            raise RuntimeError("boom")
+
+    s = _find(span_collector, "orq.simulation.run")
+    a = _attrs(s)
+    assert a["error.type"] == "RuntimeError"
+    # span ended with ERROR status (status set by helper)
+    assert s.status.status_code.name == "ERROR"
+
+
+# ---------------------------------------------------------------------------
+# with_llm_span
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_llm_span_name_and_attrs(span_collector: _CollectingExporter):
+    from evaluatorq.simulation.tracing import with_llm_span
+
+    async with with_llm_span(
+        model="azure/gpt-4o-mini",
+        operation="chat",
+        temperature=0.7,
+        max_tokens=512,
+        purpose="judge",
+    ) as span:
+        assert span is not None
+
+    s = _find(span_collector, "chat azure/gpt-4o-mini")
+    a = _attrs(s)
+    assert a["gen_ai.operation.name"] == "chat"
+    assert a["gen_ai.system"] == "azure.ai.openai"
+    assert a["gen_ai.provider.name"] == "azure.ai.openai"
+    assert a["gen_ai.request.model"] == "azure/gpt-4o-mini"
+    assert a["gen_ai.request.temperature"] == 0.7
+    assert a["gen_ai.request.max_tokens"] == 512
+    assert a["orq.simulation.llm_purpose"] == "judge"
+
+
+@pytest.mark.asyncio
+async def test_llm_span_responses_operation(span_collector: _CollectingExporter):
+    from evaluatorq.simulation.tracing import with_llm_span
+
+    async with with_llm_span(model="openai/gpt-4o", operation="responses"):
+        pass
+
+    s = _find(span_collector, "responses openai/gpt-4o")
+    assert _attrs(s)["gen_ai.operation.name"] == "responses"
+
+
+# ---------------------------------------------------------------------------
+# Recording helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_token_usage_sets_genai_and_aliases(
+    span_collector: _CollectingExporter,
+):
+    from evaluatorq.simulation.tracing import record_token_usage, with_llm_span
+
+    async with with_llm_span(model="openai/gpt-4o") as span:
+        record_token_usage(
+            span, prompt_tokens=10, completion_tokens=20, total_tokens=30
+        )
+
+    a = _attrs(_find(span_collector, "chat openai/gpt-4o"))
+    assert a["gen_ai.usage.input_tokens"] == 10
+    assert a["gen_ai.usage.output_tokens"] == 20
+    assert a["gen_ai.usage.total_tokens"] == 30
+    # Platform aliases
+    assert a["prompt_tokens"] == 10
+    assert a["completion_tokens"] == 20
+    assert a["total_tokens"] == 30
+
+
+@pytest.mark.asyncio
+async def test_record_llm_input_serializes_messages(
+    span_collector: _CollectingExporter,
+):
+    from evaluatorq.simulation.tracing import record_llm_input, with_llm_span
+
+    async with with_llm_span(model="openai/gpt-4o") as span:
+        record_llm_input(
+            span, [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}]
+        )
+
+    a = _attrs(_find(span_collector, "chat openai/gpt-4o"))
+    assert "gen_ai.input.messages" in a
+    parsed = json.loads(a["gen_ai.input.messages"])
+    assert parsed == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "yo"},
+    ]
+    # Platform fallback alias
+    assert a["input"] == a["gen_ai.input.messages"]
+
+
+@pytest.mark.asyncio
+async def test_record_llm_input_truncates_long_content(
+    span_collector: _CollectingExporter,
+):
+    from evaluatorq.simulation.tracing import record_llm_input, with_llm_span
+
+    long_content = "x" * 5000
+    async with with_llm_span(model="openai/gpt-4o") as span:
+        record_llm_input(span, [{"role": "user", "content": long_content}])
+
+    a = _attrs(_find(span_collector, "chat openai/gpt-4o"))
+    serialized = a["gen_ai.input.messages"]
+    parsed = json.loads(serialized)
+    # Content gets truncated to MAX_CONTENT_LEN (2000) + ellipsis
+    assert len(parsed[0]["content"]) <= 2001
+    assert parsed[0]["content"].endswith("…")
+
+
+@pytest.mark.asyncio
+async def test_record_llm_response_chat_completions(
+    span_collector: _CollectingExporter,
+):
+    """recordLLMResponse with a Chat Completions-shaped object."""
+    from evaluatorq.simulation.tracing import record_llm_response, with_llm_span
+
+    class _Usage:
+        prompt_tokens = 7
+        completion_tokens = 11
+        total_tokens = 18
+        prompt_tokens_details = None
+
+    class _Msg:
+        role = "assistant"
+        content = "hello"
+
+    class _Choice:
+        finish_reason = "stop"
+        message = _Msg()
+
+    class _Resp:
+        id = "resp-123"
+        model = "azure/gpt-4o-mini"
+        usage = _Usage()
+        choices = [_Choice()]
+
+    async with with_llm_span(model="azure/gpt-4o-mini") as span:
+        record_llm_response(span, _Resp())
+
+    a = _attrs(_find(span_collector, "chat azure/gpt-4o-mini"))
+    assert a["gen_ai.response.id"] == "resp-123"
+    assert a["gen_ai.response.model"] == "azure/gpt-4o-mini"
+    assert a["gen_ai.usage.input_tokens"] == 7
+    assert a["gen_ai.usage.output_tokens"] == 11
+    assert a["gen_ai.response.finish_reasons"] == ("stop",)
+    parsed = json.loads(a["gen_ai.output.messages"])
+    assert parsed == [{"role": "assistant", "content": "hello"}]
+
+
+# ---------------------------------------------------------------------------
+# Hierarchy: nested simulation spans share the same trace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nested_spans_share_trace(span_collector: _CollectingExporter):
+    from evaluatorq.simulation.tracing import with_llm_span, with_simulation_span
+
+    async with with_simulation_span("orq.simulation.pipeline", None):
+        async with with_simulation_span("orq.simulation.run", None):
+            async with with_simulation_span("orq.simulation.turn", None):
+                async with with_llm_span(model="openai/gpt-4o", purpose="target"):
+                    pass
+
+    pipeline = _find(span_collector, "orq.simulation.pipeline")
+    run = _find(span_collector, "orq.simulation.run")
+    turn = _find(span_collector, "orq.simulation.turn")
+    llm = _find(span_collector, "chat openai/gpt-4o")
+
+    # All four spans share the same trace_id
+    trace_ids = {pipeline.context.trace_id, run.context.trace_id, turn.context.trace_id, llm.context.trace_id}
+    assert len(trace_ids) == 1
+
+    # Parent chain: llm → turn → run → pipeline → root
+    assert llm.parent.span_id == turn.context.span_id
+    assert turn.parent.span_id == run.context.span_id
+    assert run.parent.span_id == pipeline.context.span_id
+    assert pipeline.parent is None
+
+
+# ---------------------------------------------------------------------------
+# get_tracer is None (tracing disabled): helpers degrade to no-ops
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_simulation_produces_full_span_tree(
+    span_collector: _CollectingExporter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """End-to-end smoke test: run a 2-turn simulation with mocks and verify
+    the full span hierarchy is produced (pipeline → run → turn → leaf calls).
+
+    Prints the captured span tree to stdout for visual inspection (run with
+    ``-s`` to see).
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    monkeypatch.setenv("ORQ_API_KEY", "test-key")
+
+    from evaluatorq.simulation.runner.simulation import SimulationRunner
+    from evaluatorq.simulation.tracing import with_simulation_span
+    from evaluatorq.simulation.types import (
+        ChatMessage,
+        CommunicationStyle,
+        Datapoint,
+        Persona,
+        Scenario,
+        TokenUsage,
+    )
+
+    # Build mock judge: should_terminate after the 2nd turn
+    def _judgment(*, terminate: bool) -> MagicMock:
+        j = MagicMock()
+        j.should_terminate = terminate
+        j.goal_achieved = terminate
+        j.goal_completion_score = 1.0 if terminate else 0.5
+        j.rules_broken = []
+        j.reason = "done" if terminate else "keep going"
+        j.response_quality = 0.9
+        j.hallucination_risk = 0.1
+        j.tone_appropriateness = 0.9
+        j.factual_accuracy = 0.9
+        return j
+
+    judge = MagicMock()
+    judge.evaluate = AsyncMock(side_effect=[_judgment(terminate=False), _judgment(terminate=True)])
+    judge.get_usage = MagicMock(return_value=TokenUsage())
+
+    user_sim = MagicMock()
+    user_sim.generate_first_message = AsyncMock(return_value="Hi, I need help.")
+    user_sim.respond_async = AsyncMock(return_value="ok thanks")
+    user_sim.get_usage = MagicMock(return_value=TokenUsage())
+
+    target_calls: list[int] = []
+
+    async def target_cb(messages: list[ChatMessage]) -> str:
+        target_calls.append(len(messages))
+        return f"agent reply #{len(target_calls)}"
+
+    runner = SimulationRunner(
+        target_callback=target_cb,
+        model="azure/gpt-4o-mini",
+        max_turns=3,
+        user_simulator=user_sim,
+        judge=judge,
+    )
+
+    persona = Persona(
+        name="Tester",
+        patience=0.5,
+        assertiveness=0.5,
+        politeness=0.5,
+        technical_level=0.5,
+        communication_style=CommunicationStyle.casual,
+        background="A test user",
+    )
+    scenario = Scenario(name="Smoke", goal="Get help")
+    dp = Datapoint(
+        id="dp-smoke",
+        persona=persona,
+        scenario=scenario,
+        user_system_prompt="sys",
+        first_message="Hi, I need help.",
+    )
+
+    # Wrap the run() in an outer pipeline span so the smoke output mirrors
+    # what simulate() would produce.
+    async with with_simulation_span(
+        "orq.simulation.pipeline",
+        {"orq.simulation.evaluation_name": "smoke", "orq.simulation.max_turns": 3},
+    ):
+        result = await runner.run(datapoint=dp)
+
+    assert result.terminated_by.value == "judge"
+    assert result.turn_count == 2
+    assert target_calls == [1, 3]
+
+    names = [s.name for s in span_collector.spans]
+    # Required spans
+    assert "orq.simulation.pipeline" in names
+    assert "orq.simulation.run" in names
+    assert names.count("orq.simulation.turn") == 2
+    assert names.count("orq.simulation.target_call") == 2
+    assert names.count("orq.simulation.judge_evaluation") == 2
+    # User simulator only fires when not the last turn AND not terminated:
+    # turn 1 (not terminated, not last) -> 1 call; turn 2 (terminated) -> 0
+    assert names.count("orq.simulation.user_simulator_call") == 1
+
+    # Hierarchy: each turn span is a child of run, which is a child of pipeline
+    pipeline = _find(span_collector, "orq.simulation.pipeline")
+    run = _find(span_collector, "orq.simulation.run")
+    assert run.parent.span_id == pipeline.context.span_id
+
+    turn_spans = [s for s in span_collector.spans if s.name == "orq.simulation.turn"]
+    for t in turn_spans:
+        assert t.parent.span_id == run.context.span_id
+
+    # target_call spans are children of their turn
+    for tc in [s for s in span_collector.spans if s.name == "orq.simulation.target_call"]:
+        assert any(tc.parent.span_id == t.context.span_id for t in turn_spans)
+
+    # Run span carries termination + token usage attrs
+    run_attrs = _attrs(run)
+    assert run_attrs["orq.simulation.terminated_by"] == "judge"
+    assert run_attrs["orq.simulation.turn_count"] == 2
+    assert "gen_ai.usage.total_tokens" in run_attrs
+
+    # Pretty-print the span tree for visual inspection
+    print("\n=== Captured span tree (smoke test) ===")
+    by_id = {s.context.span_id: s for s in span_collector.spans}
+    children: dict[int | None, list[ReadableSpan]] = {}
+    for s in span_collector.spans:
+        parent_id = s.parent.span_id if s.parent else None
+        children.setdefault(parent_id, []).append(s)
+
+    def _print(node: ReadableSpan, depth: int) -> None:
+        attrs = _attrs(node)
+        # Show a couple of high-signal attrs inline
+        hint_keys = (
+            "orq.simulation.turn",
+            "orq.simulation.terminated_by",
+            "gen_ai.operation.name",
+            "orq.simulation.llm_purpose",
+            "gen_ai.usage.total_tokens",
+        )
+        hints = " ".join(
+            f"{k.split('.')[-1]}={attrs[k]}" for k in hint_keys if k in attrs
+        )
+        print(f"{'  ' * depth}- {node.name}" + (f"  [{hints}]" if hints else ""))
+        for child in children.get(node.context.span_id, []):
+            _print(child, depth + 1)
+
+    for root in children.get(None, []):
+        _print(root, 0)
+    print(f"=== {len(span_collector.spans)} spans total ===\n")
+
+
+@pytest.mark.asyncio
+async def test_helpers_noop_when_tracing_disabled():
+    from evaluatorq.simulation.tracing import (
+        get_trace_context_headers,
+        record_llm_input,
+        record_llm_response,
+        record_token_usage,
+        with_llm_span,
+        with_simulation_span,
+    )
+
+    with patch("evaluatorq.simulation.tracing.get_tracer", return_value=None):
+        async with with_simulation_span("orq.simulation.run", {"x": "y"}) as span:
+            assert span is None
+
+        async with with_llm_span(model="openai/gpt-4o") as span:
+            assert span is None
+
+        # Recorder helpers must accept None without raising
+        record_token_usage(None, prompt_tokens=1, completion_tokens=2, total_tokens=3)
+        record_llm_input(None, [{"role": "user", "content": "x"}])
+        record_llm_response(None, object())
+
+        headers = await get_trace_context_headers()
+        # propagator may still inject something even without a tracer; just
+        # assert it returns a dict
+        assert isinstance(headers, dict)

--- a/packages/evaluatorq-py/tests/simulation/test_tracing.py
+++ b/packages/evaluatorq-py/tests/simulation/test_tracing.py
@@ -925,6 +925,81 @@ async def test_run_span_records_error_metadata_and_usage(
 
 
 @pytest.mark.asyncio
+async def test_run_span_records_cancellation_metadata_and_usage(
+    span_collector: _CollectingExporter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import asyncio
+
+    from unittest.mock import AsyncMock, MagicMock
+
+    monkeypatch.setenv("ORQ_API_KEY", "test-key")
+
+    from evaluatorq.simulation.runner.simulation import SimulationRunner
+    from evaluatorq.simulation.tracing import with_simulation_span
+    from evaluatorq.simulation.types import (
+        ChatMessage,
+        CommunicationStyle,
+        Datapoint,
+        Persona,
+        Scenario,
+        TokenUsage,
+    )
+
+    judge = MagicMock()
+    judge.evaluate = AsyncMock(side_effect=asyncio.CancelledError())
+    judge.get_usage = MagicMock(
+        return_value=TokenUsage(prompt_tokens=5, completion_tokens=7, total_tokens=12)
+    )
+
+    user_sim = MagicMock()
+    user_sim.get_usage = MagicMock(
+        return_value=TokenUsage(prompt_tokens=2, completion_tokens=3, total_tokens=5)
+    )
+    user_sim.generate_first_message = AsyncMock(return_value="hello")
+
+    async def target_cb(messages: list[ChatMessage]) -> str:
+        return "agent reply"
+
+    runner = SimulationRunner(
+        target_callback=target_cb,
+        model="test",
+        max_turns=1,
+        user_simulator=user_sim,
+        judge=judge,
+    )
+
+    persona = Persona(
+        name="Tester",
+        patience=0.5,
+        assertiveness=0.5,
+        politeness=0.5,
+        technical_level=0.5,
+        communication_style=CommunicationStyle.casual,
+        background="A test user",
+    )
+    scenario = Scenario(name="Cancelled", goal="Get help")
+    dp = Datapoint(
+        id="dp-cancelled",
+        persona=persona,
+        scenario=scenario,
+        user_system_prompt="sys",
+        first_message="Hello",
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        async with with_simulation_span("orq.simulation.pipeline", None):
+            await runner.run(datapoint=dp)
+
+    run = _find(span_collector, "orq.simulation.run")
+    attrs = _attrs(run)
+    assert attrs["orq.simulation.terminated_by"] == "error"
+    assert attrs["orq.simulation.turn_count"] == 1
+    assert attrs["gen_ai.usage.total_tokens"] == 17
+    assert attrs["error.type"] == "CancelledError"
+
+
+@pytest.mark.asyncio
 async def test_concurrent_runs_share_pipeline_parent(
     span_collector: _CollectingExporter,
 ):

--- a/packages/evaluatorq-py/tests/simulation/test_tracing.py
+++ b/packages/evaluatorq-py/tests/simulation/test_tracing.py
@@ -316,6 +316,49 @@ async def test_simulation_span_records_asyncio_cancellation(
 
 
 @pytest.mark.asyncio
+async def test_llm_span_records_asyncio_cancellation(
+    span_collector: _CollectingExporter,
+):
+    """Mirror of the with_simulation_span cancellation test for the LLM
+    span path (timed-out LLM calls must record as ERROR on the span)."""
+    import asyncio
+
+    from evaluatorq.simulation.tracing import with_llm_span
+
+    with pytest.raises(asyncio.CancelledError):
+        async with with_llm_span(model="openai/gpt-4o"):
+            raise asyncio.CancelledError()
+
+    s = _find(span_collector, "chat openai/gpt-4o")
+    assert s.status.status_code.name == "ERROR"
+    assert _attrs(s)["error.type"] == "CancelledError"
+
+
+@pytest.mark.asyncio
+async def test_record_llm_response_responses_api_finish_reason(
+    span_collector: _CollectingExporter,
+):
+    """gen_ai.response.finish_reasons must be set from response.status when
+    the response has no .choices (Responses API shape)."""
+    from evaluatorq.simulation.tracing import record_llm_response, with_llm_span
+
+    class _Resp:
+        id = "resp_x"
+        model = "openai/gpt-4o"
+        usage = None
+        status = "completed"
+        # No .choices
+
+    async with with_llm_span(
+        model="openai/gpt-4o", operation="responses"
+    ) as span:
+        record_llm_response(span, _Resp())
+
+    a = _attrs(_find(span_collector, "responses openai/gpt-4o"))
+    assert a["gen_ai.response.finish_reasons"] == ("completed",)
+
+
+@pytest.mark.asyncio
 async def test_llm_span_records_exception(span_collector: _CollectingExporter):
     """Exceptions inside with_llm_span are recorded with ERROR status."""
     from evaluatorq.simulation.tracing import with_llm_span

--- a/packages/evaluatorq-py/tests/simulation/test_tracing.py
+++ b/packages/evaluatorq-py/tests/simulation/test_tracing.py
@@ -296,6 +296,46 @@ async def test_record_llm_response_responses_api_shape(
 
 
 @pytest.mark.asyncio
+async def test_record_llm_response_tool_call_only_chat_output(
+    span_collector: _CollectingExporter,
+):
+    from evaluatorq.simulation.tracing import record_llm_response, with_llm_span
+
+    class _Function:
+        name = "finish_conversation"
+        arguments = '{"reason":"done"}'
+
+    class _ToolCall:
+        function = _Function()
+
+    class _Message:
+        role = "assistant"
+        content = None
+        tool_calls = [_ToolCall()]
+
+    class _Choice:
+        finish_reason = "tool_calls"
+        message = _Message()
+
+    class _Resp:
+        id = "resp_tool"
+        model = "openai/gpt-4o"
+        usage = None
+        choices = [_Choice()]
+
+    async with with_llm_span(model="openai/gpt-4o") as span:
+        record_llm_response(span, _Resp())
+
+    a = _attrs(_find(span_collector, "chat openai/gpt-4o"))
+    parsed = json.loads(a["gen_ai.output.messages"])
+    assert parsed[0]["role"] == "assistant"
+    payload = json.loads(parsed[0]["content"])
+    assert payload["tool_calls"] == [
+        {"name": "finish_conversation", "arguments": '{"reason":"done"}'}
+    ]
+
+
+@pytest.mark.asyncio
 async def test_simulation_span_records_asyncio_cancellation(
     span_collector: _CollectingExporter,
 ):
@@ -666,6 +706,222 @@ async def test_traceparent_injected_into_chat_completions_call(
     headers = captured.get("extra_headers")
     assert isinstance(headers, dict)
     assert "traceparent" in headers, f"expected traceparent in {headers}"
+
+
+@pytest.mark.asyncio
+async def test_traceparent_injected_into_first_message_generation_call(
+    span_collector: _CollectingExporter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from unittest.mock import AsyncMock, MagicMock
+
+    monkeypatch.setenv("ORQ_API_KEY", "test-key")
+
+    captured: dict[str, object] = {}
+
+    class _Choice:
+        finish_reason = "stop"
+
+        class message:  # noqa: N801
+            content = "Need help with my order"
+            role = "assistant"
+
+    class _Usage:
+        prompt_tokens = 2
+        completion_tokens = 3
+        total_tokens = 5
+        prompt_tokens_details = None
+
+    class _Resp:
+        id = "fm_1"
+        model = "test"
+        usage = _Usage()
+        choices = [_Choice()]
+
+    async def fake_create(**kwargs: object) -> _Resp:
+        captured.update(kwargs)
+        return _Resp()
+
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(side_effect=fake_create)
+
+    from evaluatorq.simulation.generators.first_message_generator import (
+        FirstMessageGenerator,
+    )
+    from evaluatorq.simulation.tracing import with_simulation_span
+    from evaluatorq.simulation.types import (
+        CommunicationStyle,
+        Persona,
+        Scenario,
+    )
+
+    persona = Persona(
+        name="Tester",
+        patience=0.5,
+        assertiveness=0.5,
+        politeness=0.5,
+        technical_level=0.5,
+        communication_style=CommunicationStyle.casual,
+        background="A test user",
+    )
+    scenario = Scenario(name="Order", goal="Get order help")
+    gen = FirstMessageGenerator(model="test", client=fake_client)
+
+    async with with_simulation_span("orq.simulation.first_message_generation", None):
+        message = await gen.generate(persona, scenario)
+
+    assert message == "Need help with my order"
+    headers = captured.get("extra_headers")
+    assert isinstance(headers, dict)
+    assert "traceparent" in headers, f"expected traceparent in {headers}"
+    llm = _find(span_collector, "chat test")
+    parent = _find(span_collector, "orq.simulation.first_message_generation")
+    assert llm.parent.span_id == parent.context.span_id
+
+
+@pytest.mark.asyncio
+async def test_generated_datapoint_first_message_has_simulation_span(
+    span_collector: _CollectingExporter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from unittest.mock import AsyncMock, MagicMock
+
+    monkeypatch.setenv("ORQ_API_KEY", "test-key")
+
+    class _Choice:
+        finish_reason = "stop"
+
+        class message:  # noqa: N801
+            content = "Hello there"
+            role = "assistant"
+
+    class _Usage:
+        prompt_tokens = 1
+        completion_tokens = 1
+        total_tokens = 2
+        prompt_tokens_details = None
+
+    class _Resp:
+        id = "dp_1"
+        model = "test"
+        usage = _Usage()
+        choices = [_Choice()]
+
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(return_value=_Resp())
+
+    from evaluatorq.simulation.api import _generate_single_datapoint
+    from evaluatorq.simulation.generators.first_message_generator import (
+        FirstMessageGenerator,
+    )
+    from evaluatorq.simulation.tracing import with_simulation_span
+    from evaluatorq.simulation.types import (
+        CommunicationStyle,
+        Persona,
+        Scenario,
+    )
+
+    persona = Persona(
+        name="Tester",
+        patience=0.5,
+        assertiveness=0.5,
+        politeness=0.5,
+        technical_level=0.5,
+        communication_style=CommunicationStyle.casual,
+        background="A test user",
+    )
+    scenario = Scenario(name="Billing", goal="Fix a billing issue")
+    gen = FirstMessageGenerator(model="test", client=fake_client)
+
+    async with with_simulation_span("orq.simulation.pipeline", None):
+        datapoint = await _generate_single_datapoint(gen, persona, scenario)
+
+    assert datapoint.first_message == "Hello there"
+    pipeline = _find(span_collector, "orq.simulation.pipeline")
+    first_msg = _find(span_collector, "orq.simulation.first_message_generation")
+    llm = _find(span_collector, "chat test")
+    assert first_msg.parent.span_id == pipeline.context.span_id
+    assert llm.parent.span_id == first_msg.context.span_id
+
+
+@pytest.mark.asyncio
+async def test_run_span_records_error_metadata_and_usage(
+    span_collector: _CollectingExporter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from unittest.mock import AsyncMock, MagicMock
+
+    monkeypatch.setenv("ORQ_API_KEY", "test-key")
+
+    from evaluatorq.simulation.runner.simulation import SimulationRunner
+    from evaluatorq.simulation.tracing import with_simulation_span
+    from evaluatorq.simulation.types import (
+        ChatMessage,
+        CommunicationStyle,
+        Datapoint,
+        Persona,
+        Scenario,
+        TokenUsage,
+        TerminatedBy,
+    )
+
+    judge = MagicMock()
+    judge.evaluate = AsyncMock(side_effect=RuntimeError("judge failed"))
+    judge.get_usage = MagicMock(
+        return_value=TokenUsage(prompt_tokens=5, completion_tokens=7, total_tokens=12)
+    )
+
+    user_sim = MagicMock()
+    user_sim.get_usage = MagicMock(
+        return_value=TokenUsage(prompt_tokens=2, completion_tokens=3, total_tokens=5)
+    )
+    user_sim.generate_first_message = AsyncMock(return_value="hello")
+
+    async def target_cb(messages: list[ChatMessage]) -> str:
+        return "agent reply"
+
+    runner = SimulationRunner(
+        target_callback=target_cb,
+        model="test",
+        max_turns=1,
+        user_simulator=user_sim,
+        judge=judge,
+    )
+
+    persona = Persona(
+        name="Tester",
+        patience=0.5,
+        assertiveness=0.5,
+        politeness=0.5,
+        technical_level=0.5,
+        communication_style=CommunicationStyle.casual,
+        background="A test user",
+    )
+    scenario = Scenario(name="Failure", goal="Get help")
+    dp = Datapoint(
+        id="dp-error",
+        persona=persona,
+        scenario=scenario,
+        user_system_prompt="sys",
+        first_message="Hello",
+    )
+
+    async with with_simulation_span("orq.simulation.pipeline", None):
+        result = await runner.run(datapoint=dp)
+
+    assert result.terminated_by == TerminatedBy.error
+    assert result.turn_count == 1
+    assert result.token_usage.total_tokens == 17
+
+    run = _find(span_collector, "orq.simulation.run")
+    attrs = _attrs(run)
+    assert attrs["orq.simulation.terminated_by"] == "error"
+    assert attrs["orq.simulation.turn_count"] == 1
+    assert attrs["gen_ai.usage.total_tokens"] == 17
 
 
 @pytest.mark.asyncio

--- a/packages/evaluatorq-py/tests/simulation/test_tracing.py
+++ b/packages/evaluatorq-py/tests/simulation/test_tracing.py
@@ -224,6 +224,92 @@ async def test_record_llm_input_truncates_long_content(
 
 
 @pytest.mark.asyncio
+async def test_record_token_usage_preserves_zero_prompt_tokens(
+    span_collector: _CollectingExporter,
+):
+    """Zero prompt_tokens (e.g. fully-cached request) must not fall back to
+    input_tokens. Regression guard for the falsy-or chain bug."""
+    from evaluatorq.simulation.tracing import record_llm_response, with_llm_span
+
+    class _Usage:
+        prompt_tokens = 0
+        completion_tokens = 5
+        total_tokens = 5
+        input_tokens = 99  # would be selected if `prompt_tokens or input_tokens`
+        output_tokens = 99
+        prompt_tokens_details = None
+
+    class _Resp:
+        id = "r"
+        model = "m"
+        usage = _Usage()
+        choices = []
+
+    async with with_llm_span(model="openai/gpt-4o") as span:
+        record_llm_response(span, _Resp())
+
+    a = _attrs(_find(span_collector, "chat openai/gpt-4o"))
+    assert a["gen_ai.usage.input_tokens"] == 0
+    assert a["gen_ai.usage.output_tokens"] == 5
+
+
+@pytest.mark.asyncio
+async def test_record_llm_response_responses_api_shape(
+    span_collector: _CollectingExporter,
+):
+    """recordLLMResponse with a Responses API-shaped object: output items
+    have content[].text, not flat .text on the item."""
+    from evaluatorq.simulation.tracing import record_llm_response, with_llm_span
+
+    class _ContentPart:
+        text = "hello world"
+
+    class _OutputItem:
+        # No .text on the item itself; SDK shape uses .content[*].text
+        content = [_ContentPart()]
+
+    class _Usage:
+        input_tokens = 4
+        output_tokens = 2
+        total_tokens = 6
+        prompt_tokens_details = None
+
+    class _Resp:
+        id = "resp_1"
+        model = "openai/gpt-4o"
+        usage = _Usage()
+        # No .choices; this is the Responses API shape
+        output = [_OutputItem()]
+
+    async with with_llm_span(
+        model="openai/gpt-4o", operation="responses"
+    ) as span:
+        record_llm_response(span, _Resp())
+
+    a = _attrs(_find(span_collector, "responses openai/gpt-4o"))
+    assert "gen_ai.output.messages" in a
+    parsed = json.loads(a["gen_ai.output.messages"])
+    assert parsed == [{"role": "assistant", "content": "hello world"}]
+    # Falls back from .input_tokens since prompt_tokens is absent
+    assert a["gen_ai.usage.input_tokens"] == 4
+    assert a["gen_ai.usage.output_tokens"] == 2
+
+
+@pytest.mark.asyncio
+async def test_llm_span_records_exception(span_collector: _CollectingExporter):
+    """Exceptions inside with_llm_span are recorded with ERROR status."""
+    from evaluatorq.simulation.tracing import with_llm_span
+
+    with pytest.raises(ValueError, match="boom"):
+        async with with_llm_span(model="openai/gpt-4o"):
+            raise ValueError("boom")
+
+    s = _find(span_collector, "chat openai/gpt-4o")
+    assert _attrs(s)["error.type"] == "ValueError"
+    assert s.status.status_code.name == "ERROR"
+
+
+@pytest.mark.asyncio
 async def test_record_llm_response_chat_completions(
     span_collector: _CollectingExporter,
 ):
@@ -450,6 +536,100 @@ async def test_end_to_end_simulation_produces_full_span_tree(
     for root in children.get(None, []):
         _print(root, 0)
     print(f"=== {len(span_collector.spans)} spans total ===\n")
+
+
+@pytest.mark.asyncio
+async def test_traceparent_injected_into_chat_completions_call(
+    span_collector: _CollectingExporter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When tracing is enabled, _call_chat_completions should inject
+    traceparent into the OpenAI client request via extra_headers."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    monkeypatch.setenv("ORQ_API_KEY", "test-key")
+
+    captured: dict[str, object] = {}
+
+    class _Choice:
+        finish_reason = "stop"
+
+        class message:  # noqa: N801
+            content = "ok"
+            tool_calls = None
+            role = "assistant"
+
+    class _Usage:
+        prompt_tokens = 1
+        completion_tokens = 1
+        total_tokens = 2
+        prompt_tokens_details = None
+
+    class _Resp:
+        id = "r"
+        model = "test"
+        usage = _Usage()
+        choices = [_Choice()]
+
+    async def fake_create(**kwargs: object) -> _Resp:
+        captured.update(kwargs)
+        return _Resp()
+
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(side_effect=fake_create)
+
+    from evaluatorq.contracts import LLMCallConfig
+    from evaluatorq.simulation.agents.base import BaseAgent
+    from evaluatorq.simulation.tracing import with_simulation_span
+    from evaluatorq.simulation.types import ChatMessage
+
+    class _A(BaseAgent):
+        @property
+        def name(self) -> str:
+            return "T"
+
+        @property
+        def system_prompt(self) -> str:
+            return "sys"
+
+    a = _A(LLMCallConfig(model="test", client=fake_client))
+
+    # Wrap in an outer span so traceparent is meaningful to inject.
+    async with with_simulation_span("orq.simulation.run", None):
+        await a._call_chat_completions([ChatMessage(role="user", content="hi")])
+
+    headers = captured.get("extra_headers")
+    assert isinstance(headers, dict)
+    assert "traceparent" in headers, f"expected traceparent in {headers}"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_runs_share_pipeline_parent(
+    span_collector: _CollectingExporter,
+):
+    """Two concurrent simulation spans started under one pipeline span both
+    have the pipeline as their parent — confirms asyncio.gather doesn't leak
+    OTel context across tasks."""
+    import asyncio
+
+    from evaluatorq.simulation.tracing import with_simulation_span
+
+    async def _sub(name: str) -> None:
+        async with with_simulation_span(name, None):
+            await asyncio.sleep(0)
+
+    async with with_simulation_span("orq.simulation.pipeline", None):
+        await asyncio.gather(
+            _sub("orq.simulation.run"), _sub("orq.simulation.run")
+        )
+
+    pipeline = _find(span_collector, "orq.simulation.pipeline")
+    runs = [s for s in span_collector.spans if s.name == "orq.simulation.run"]
+    assert len(runs) == 2
+    for r in runs:
+        assert r.parent.span_id == pipeline.context.span_id
 
 
 @pytest.mark.asyncio

--- a/packages/evaluatorq-py/tests/simulation/test_tracing.py
+++ b/packages/evaluatorq-py/tests/simulation/test_tracing.py
@@ -296,6 +296,26 @@ async def test_record_llm_response_responses_api_shape(
 
 
 @pytest.mark.asyncio
+async def test_simulation_span_records_asyncio_cancellation(
+    span_collector: _CollectingExporter,
+):
+    """asyncio.CancelledError (a BaseException, not Exception) must be
+    recorded on the span — otherwise timed-out simulations end with UNSET
+    status and look like normal completions in the dashboard."""
+    import asyncio
+
+    from evaluatorq.simulation.tracing import with_simulation_span
+
+    with pytest.raises(asyncio.CancelledError):
+        async with with_simulation_span("orq.simulation.run", None):
+            raise asyncio.CancelledError()
+
+    s = _find(span_collector, "orq.simulation.run")
+    assert s.status.status_code.name == "ERROR"
+    assert _attrs(s)["error.type"] == "CancelledError"
+
+
+@pytest.mark.asyncio
 async def test_llm_span_records_exception(span_collector: _CollectingExporter):
     """Exceptions inside with_llm_span are recorded with ERROR status."""
     from evaluatorq.simulation.tracing import with_llm_span


### PR DESCRIPTION
## Summary

Mirrors the TypeScript simulation tracing landed in [RES-595 (PR #90)](https://github.com/orq-ai/orqkit/pull/90) to the Python `evaluatorq-py` package, so simulations show up as a single unified trace in the Orq dashboard with a per-turn breakdown.

**Stacks on** [#117 (`bauke/sim-orq-responses-support`)](https://github.com/orq-ai/orqkit/pull/117) — based off Bauke's branch so the new chat-completions vs. responses dispatch in `BaseAgent` is instrumented at both leaves. Once #117 merges, GitHub will auto-retarget this PR's base to `main`.

Linear: [RES-782](https://linear.app/orqai/issue/RES-782/port-otel-tracing-implementation-from-ts-to-python-simulation-module)

## What's instrumented

```
orq.simulation.pipeline
├── orq.simulation.persona_generation        (alt method also emits with mode=coverage)
├── orq.simulation.scenario_generation       (alt methods also emit with mode={coverage, edge_cases, boundary, security})
└── orq.simulation.run                       (per datapoint)
    ├── orq.simulation.first_message_generation
    └── orq.simulation.turn                  (per turn)
        ├── orq.simulation.target_call       (input/output messages captured)
        ├── orq.simulation.judge_evaluation
        │   └── chat <model>                 (GenAI client span)
        └── orq.simulation.user_simulator_call
            └── chat <model>                 (GenAI client span)
```

LLM client spans follow OTel GenAI semconv (`gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.{input,output,total}_tokens`, `gen_ai.response.finish_reasons`, etc.) plus the platform aliases the Orq router expects. Both `_call_chat_completions` (operation `\"chat\"`) and `_call_responses` (operation `\"responses\"`) are wrapped, with W3C `traceparent` injected into the OpenAI client via `extra_headers` so router-side spans link as children. `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` env flag honored.

## Files

- `simulation/tracing.py` (new) — `with_simulation_span`, `with_llm_span`, `record_llm_input/output/response`, `record_token_usage`, `set_span_attrs`, `get_trace_context_headers`
- `simulation/agents/base.py` — wrap both LLM leaves, thread `llm_purpose`, inject `traceparent`
- `simulation/agents/judge.py`, `agents/user_simulator.py` — pass `llm_purpose`
- `simulation/runner/simulation.py` — pipeline/run/turn/leaf spans; aggregate token usage and termination attrs on the run span; usage holder so the outer except can report partial tokens on errors
- `simulation/api.py` — `init_tracing_if_needed` + `flush_tracing`; `_simulate_core` extracted so `generate_and_simulate` doesn't double-create the pipeline span
- `simulation/generators/{persona,scenario}_generator.py` — wrap `generate*` with simulation spans (mode attribute matches TS)
- `simulation/utils/structured_output.py` — wrap `generate_structured` with `with_llm_span` so generator LLM calls show as GenAI client spans (covers all generators in one place)
- `tests/simulation/test_tracing.py` (new) — 17 tests including hierarchy, exception paths, zero-token regression, Responses API shape, `traceparent` injection, asyncio concurrency context isolation, full end-to-end smoke
- `scripts/simulation_tracing_smoke.py` (new) — live smoke runner that prints the captured tree and trace IDs

## Verification

Two internal review passes (correctness + TS-parity, failure-mode + edge-cases) caught 3 bugs and 2 parity gaps; all addressed in 80b51fa.

Live against the Orq router (trace bd15b852556fa1283f2c6bd69982d8b9):

```
- orq.simulation.pipeline                   15.5s
  - orq.simulation.run                      14.0s  total_tokens=3167
    - orq.simulation.turn (turn=1)
      - orq.simulation.target_call                ← input/output captured
      - orq.simulation.judge_evaluation
        - chat (gpt-4o-mini)                      finish=tool_calls, 1186 tokens
      - orq.simulation.user_simulator_call
        - chat (gpt-4o-mini)                      finish=stop, 533 tokens
    - orq.simulation.turn (turn=2)
      - orq.simulation.target_call
      - orq.simulation.judge_evaluation
        - chat (gpt-4o-mini)                      1448 tokens
```

11 spans landed in the Orq backend, parent links + token rollup + billing all correct.

## Test plan

- [x] uv run pytest tests/simulation/test_tracing.py — 17/17 pass
- [x] uv run pytest tests/simulation/ -m 'not integration' — 162 pass, 1 pre-existing failure (test_base_agent_lacking_generate_first_message_raises_type_error, unrelated)
- [x] uv run basedpyright src/evaluatorq/simulation/ — 0 errors
- [x] Live smoke test against Orq router: trace bd15b852556fa1283f2c6bd69982d8b9 indexed correctly
- [ ] CI on PR

## Out of scope (flagged for follow-up)

- _invert_roles_for_simulator divergence vs TS (pre-existing on the base branch, not tracing)
- Timeout state preservation regression (pre-existing on the base branch)
- generate_and_simulate doesn't accept user_simulator / judge injection (pre-existing)
- TS → Python mirror back (RES-599) — separate ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)
