### PR TITLE
feat(vercel-provider): add OrqAiImageModel with /images/generations +…

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@orq-ai/orqkit",
@@ -24,7 +25,7 @@
     },
     "packages/cli": {
       "name": "@orq-ai/cli",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "bin": {
         "orq": "./dist/bin/cli.js",
       },
@@ -39,7 +40,7 @@
     },
     "packages/evaluatorq": {
       "name": "@orq-ai/evaluatorq",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "chalk": "^5.4.1",
         "effect": "^3.17.4",
@@ -108,7 +109,7 @@
     },
     "packages/evaluators": {
       "name": "@orq-ai/evaluators",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "openai": "^5.12.2",
         "tslib": "^2.3.0",
@@ -119,7 +120,7 @@
     },
     "packages/n8n-nodes-orq": {
       "name": "@orq-ai/n8n-nodes-orq",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "devDependencies": {
         "@n8n/node-cli": "^0.23.1",
         "@orq-ai/node": "4.7.7",
@@ -131,11 +132,11 @@
     },
     "packages/tiny-di": {
       "name": "@orq-ai/tiny-di",
-      "version": "1.3.0",
+      "version": "1.3.1",
     },
     "packages/vercel-provider": {
       "name": "@orq-ai/vercel-provider",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^2.0.0",
         "@ai-sdk/provider": "^3.0.0",
@@ -143,6 +144,7 @@
       },
       "peerDependencies": {
         "ai": "^6.0.0",
+        "zod": "^3.25.76 || ^4.1.8",
       },
     },
   },
@@ -153,9 +155,9 @@
 
     "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@2.0.35", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-g3wA57IAQFb+3j4YuFndgkUdXyRETZVvbfAWM+UX7bZSxA3xjes0v3XKgIdKdekPtDGsh4ZX2byHD0gJIMPfiA=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.13", "", { "dependencies": { "@ai-sdk/provider": "3.0.7", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HHG72BN4d+OWTcq2NwTxOm/2qvk1duYsnhCDtsbYwn/h/4zeqURu1S0+Cn0nY2Ysq9a9HGKvrYuMn9bgFhR2Og=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.19", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg=="],
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
@@ -1893,11 +1895,11 @@
 
     "@ai-sdk/gateway/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
+    "@ai-sdk/openai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw=="],
+
+    "@ai-sdk/openai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.13", "", { "dependencies": { "@ai-sdk/provider": "3.0.7", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HHG72BN4d+OWTcq2NwTxOm/2qvk1duYsnhCDtsbYwn/h/4zeqURu1S0+Cn0nY2Ysq9a9HGKvrYuMn9bgFhR2Og=="],
+
     "@ai-sdk/openai/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "@ai-sdk/openai-compatible/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
-
-    "@ai-sdk/openai-compatible/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.19", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg=="],
 
     "@ai-sdk/openai-compatible/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -2022,6 +2024,8 @@
     "@orq-ai/evaluators/openai": ["openai@5.12.2", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ=="],
 
     "@orq-ai/n8n-nodes-orq/@orq-ai/node": ["@orq-ai/node@4.7.7", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-8mcUtWq39yS8X9Ax6xZGsudteV/8rrNN3mquMNvZa8OV5fuOzyIYNQjc7IQ3tjzVmMdPZQCTN3+bC/Y457dimw=="],
+
+    "@orq-ai/vercel-provider/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 

--- a/packages/vercel-provider/package.json
+++ b/packages/vercel-provider/package.json
@@ -49,7 +49,8 @@
     "@ai-sdk/provider-utils": "^4.0.0"
   },
   "peerDependencies": {
-    "ai": "^6.0.0"
+    "ai": "^6.0.0",
+    "zod": "^3.25.76 || ^4.1.8"
   },
   "peerDependenciesMeta": {
     "ai": {

--- a/packages/vercel-provider/src/lib/orq-ai-image-model.ts
+++ b/packages/vercel-provider/src/lib/orq-ai-image-model.ts
@@ -1,0 +1,305 @@
+import type {
+  ImageModelV3,
+  ImageModelV3File,
+  SharedV3ProviderOptions,
+  SharedV3Warning,
+} from "@ai-sdk/provider";
+import {
+  combineHeaders,
+  convertBase64ToUint8Array,
+  convertToFormData,
+  convertUint8ArrayToBase64,
+  createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  downloadBlob,
+  type FetchFunction,
+  postFormDataToApi,
+  postJsonToApi,
+} from "@ai-sdk/provider-utils";
+import { z } from "zod/v4";
+
+// Inline copy of `defaultOpenAICompatibleErrorStructure` from
+// `@ai-sdk/openai-compatible/src/openai-compatible-error.ts`. That module
+// does not re-export the value (only the type), so we replicate the schema
+// here. Orq's proxy returns OpenAI-shaped error envelopes, so this matches.
+const orqAiErrorDataSchema = z.object({
+  error: z.object({
+    message: z.string(),
+    type: z.string().nullish(),
+    param: z.any().nullish(),
+    code: z.union([z.string(), z.number()]).nullish(),
+  }),
+});
+type OrqAiErrorData = z.infer<typeof orqAiErrorDataSchema>;
+
+const defaultOrqAiErrorStructure = {
+  errorSchema: orqAiErrorDataSchema,
+  errorToMessage: (data: OrqAiErrorData) => data.error.message,
+};
+
+export type OrqAiImageModelConfig = {
+  provider: string;
+  headers: () => Record<string, string | undefined>;
+  url: (options: { modelId: string; path: string }) => string;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+};
+
+/**
+ * Image model for the Orq AI proxy.
+ *
+ * Why this exists rather than reusing `OpenAICompatibleImageModel`:
+ * - `OpenAICompatibleImageModel` hardcodes `response_format: "b64_json"` in
+ *   the request body. Newer OpenAI image models (gpt-image-1+) reject the
+ *   parameter with "Unknown parameter: 'response_format'" and the Orq proxy
+ *   forwards that error verbatim. Omitting the field works on every
+ *   upstream because they all default to returning the image inline.
+ * - Different upstreams Orq routes to return the image under different
+ *   shapes: OpenAI / Google return `b64_json`, while fal / Leonardo / others
+ *   return a data URI under `url`. Some providers may eventually return an
+ *   http(s) URL. This class accepts all three shapes and normalizes to a
+ *   base64 string.
+ */
+export class OrqAiImageModel implements ImageModelV3 {
+  readonly specificationVersion = "v3";
+  readonly maxImagesPerCall = 10;
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  private get providerOptionsKey(): string {
+    // `config.provider` is always set by `createOrqAiProvider` to
+    // `"orq.ai.<modelType>"`, so split[0] is "orq". Keep the optional
+    // chain + fallback to satisfy the linter without changing behavior.
+    return this.config.provider.split(".")[0]?.trim() ?? "orq";
+  }
+
+  constructor(
+    readonly modelId: string,
+    private readonly config: OrqAiImageModelConfig,
+  ) {}
+
+  /**
+   * Extract user-supplied extra body fields from `providerOptions.orq`.
+   *
+   * These are spread into the request body AFTER `model/prompt/n/size` so
+   * users can override defaults intentionally (e.g. `quality`, `style`).
+   * This mirrors the upstream `OpenAICompatibleImageModel` contract.
+   */
+  private getArgs(
+    providerOptions: SharedV3ProviderOptions,
+  ): Record<string, unknown> {
+    return {
+      ...providerOptions[this.providerOptionsKey],
+    };
+  }
+
+  async doGenerate({
+    prompt,
+    n,
+    size,
+    aspectRatio,
+    seed,
+    providerOptions,
+    headers,
+    abortSignal,
+    files,
+    mask,
+  }: Parameters<ImageModelV3["doGenerate"]>[0]): Promise<
+    Awaited<ReturnType<ImageModelV3["doGenerate"]>>
+  > {
+    const warnings: Array<SharedV3Warning> = [];
+
+    if (aspectRatio != null) {
+      warnings.push({
+        type: "unsupported",
+        feature: "aspectRatio",
+        details:
+          "This model does not support aspect ratio. Use `size` instead.",
+      });
+    }
+    if (seed != null) {
+      warnings.push({ type: "unsupported", feature: "seed" });
+    }
+    if (mask != null) {
+      warnings.push({
+        type: "unsupported",
+        feature: "image inpainting (mask parameter)",
+        details:
+          "The Orq AI image-edits endpoint does not accept a `mask` field.",
+      });
+    }
+
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const args = this.getArgs(providerOptions);
+
+    const failedResponseHandler = createJsonErrorResponseHandler(
+      defaultOrqAiErrorStructure,
+    );
+    const successfulResponseHandler = createJsonResponseHandler(
+      orqAiImageResponseSchema,
+    );
+
+    // Image editing branch: multipart form-data to /images/edits.
+    // Orq's edit endpoint schema (see orq-node `CreateImageEditRequestBody`)
+    // does not include a `mask` field, so it is dropped here even if provided.
+    let response: z.infer<typeof orqAiImageResponseSchema>;
+    let responseHeaders: Record<string, string> | undefined;
+
+    if (files != null && files.length > 0) {
+      const formResult = await postFormDataToApi({
+        url: this.config.url({
+          path: "/images/edits",
+          modelId: this.modelId,
+        }),
+        headers: combineHeaders(this.config.headers(), headers),
+        formData: convertToFormData<OrqAiFormDataInput>({
+          model: this.modelId,
+          prompt,
+          image: await Promise.all(files.map((file) => fileToFormPart(file))),
+          n,
+          size,
+          ...args,
+        }),
+        failedResponseHandler,
+        successfulResponseHandler,
+        abortSignal,
+        fetch: this.config.fetch,
+      });
+      response = formResult.value;
+      responseHeaders = formResult.responseHeaders;
+    } else {
+      const jsonResult = await postJsonToApi({
+        url: this.config.url({
+          path: "/images/generations",
+          modelId: this.modelId,
+        }),
+        headers: combineHeaders(this.config.headers(), headers),
+        body: {
+          model: this.modelId,
+          prompt,
+          n,
+          size,
+          ...args,
+        },
+        failedResponseHandler,
+        successfulResponseHandler,
+        abortSignal,
+        fetch: this.config.fetch,
+      });
+      response = jsonResult.value;
+      responseHeaders = jsonResult.responseHeaders;
+    }
+
+    const images = await Promise.all(
+      response.data.map((item) =>
+        normalizeImageEntry(item, this.config.fetch ?? globalThis.fetch),
+      ),
+    );
+
+    const usage = response.usage
+      ? {
+          inputTokens: response.usage.input_tokens,
+          outputTokens: response.usage.output_tokens,
+          totalTokens: response.usage.total_tokens,
+        }
+      : undefined;
+
+    return {
+      images,
+      warnings,
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+      },
+      usage,
+    };
+  }
+}
+
+type OrqAiFormDataInput = {
+  model: string;
+  prompt: string | undefined;
+  image: File | File[];
+  n: number | undefined;
+  size: `${number}x${number}` | undefined;
+  [key: string]: unknown;
+};
+
+// Orq's `/images/edits` rejects parts with no recognizable filename
+// extension (returns `unsupported_file_mimetype` for application/octet-stream).
+// Wrap the payload in a `File` so the multipart part carries both a filename
+// with extension AND the correct mime type.
+const MEDIA_TYPE_TO_EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/webp": "webp",
+};
+
+async function fileToFormPart(file: ImageModelV3File): Promise<File> {
+  if (file.type === "url") {
+    const blob = await downloadBlob(file.url);
+    const mediaType = blob.type || "image/png";
+    const ext = MEDIA_TYPE_TO_EXT[mediaType] ?? "png";
+    const buf = new Uint8Array(await blob.arrayBuffer());
+    return new File([buf], `image.${ext}`, { type: mediaType });
+  }
+  const data =
+    file.data instanceof Uint8Array
+      ? file.data
+      : convertBase64ToUint8Array(file.data);
+  const mediaType = file.mediaType || "image/png";
+  const ext = MEDIA_TYPE_TO_EXT[mediaType] ?? "png";
+  return new File([data], `image.${ext}`, { type: mediaType });
+}
+
+const orqAiImageEntrySchema = z.object({
+  b64_json: z.string().optional(),
+  url: z.string().optional(),
+  revised_prompt: z.string().optional(),
+});
+
+const orqAiUsageSchema = z
+  .object({
+    input_tokens: z.number().optional(),
+    output_tokens: z.number().optional(),
+    total_tokens: z.number().optional(),
+  })
+  .optional();
+
+const orqAiImageResponseSchema = z.object({
+  data: z.array(orqAiImageEntrySchema),
+  usage: orqAiUsageSchema,
+});
+
+const DATA_URI_RE = /^data:([^;,]+)?;base64,(.*)$/i;
+
+async function normalizeImageEntry(
+  item: z.infer<typeof orqAiImageEntrySchema>,
+  fetchFn: typeof fetch,
+): Promise<string> {
+  if (item.b64_json) return item.b64_json;
+  if (!item.url) {
+    throw new Error(
+      "Orq AI image response contained neither `b64_json` nor `url`.",
+    );
+  }
+  const match = item.url.match(DATA_URI_RE);
+  if (match) {
+    // Data URI: strip the prefix and return the base64 payload as-is.
+    return match[2] ?? "";
+  }
+  // http(s) URL: fetch the bytes and encode.
+  const res = await fetchFn(item.url);
+  if (!res.ok) {
+    throw new Error(
+      `Failed to download image from ${item.url}: ${res.status} ${res.statusText}`,
+    );
+  }
+  return convertUint8ArrayToBase64(new Uint8Array(await res.arrayBuffer()));
+}

--- a/packages/vercel-provider/src/lib/orq-ai-sdk-provider.ts
+++ b/packages/vercel-provider/src/lib/orq-ai-sdk-provider.ts
@@ -2,7 +2,6 @@ import {
   OpenAICompatibleChatLanguageModel,
   OpenAICompatibleCompletionLanguageModel,
   OpenAICompatibleEmbeddingModel,
-  OpenAICompatibleImageModel,
 } from "@ai-sdk/openai-compatible";
 import type {
   EmbeddingModelV3,
@@ -14,6 +13,8 @@ import {
   type FetchFunction,
   withoutTrailingSlash,
 } from "@ai-sdk/provider-utils";
+
+import { OrqAiImageModel } from "./orq-ai-image-model.js";
 
 const DEFAULT_BASE_URL = "https://api.orq.ai/v2/proxy";
 
@@ -37,6 +38,9 @@ export interface OrqAiProvider extends ProviderV3 {
 export function createOrqAiProvider(
   options: OrqAiProviderSettings,
 ): OrqAiProvider {
+  if (!options.apiKey) {
+    throw new Error("createOrqAiProvider: `apiKey` is required.");
+  }
   const baseURL = withoutTrailingSlash(options.baseURL ?? DEFAULT_BASE_URL);
   const getHeaders = () => ({
     ...options.headers,
@@ -52,10 +56,7 @@ export function createOrqAiProvider(
 
   const getCommonModelConfig = (modelType: string): CommonModelConfig => ({
     provider: `orq.ai.${modelType}`,
-    url: ({ path }) => {
-      const url = new URL(`${baseURL}${path}`);
-      return url.toString();
-    },
+    url: ({ path }) => `${baseURL}${path}`,
     headers: getHeaders,
   });
 
@@ -79,7 +80,7 @@ export function createOrqAiProvider(
     );
 
   const createImageModel = (modelId: string) =>
-    new OpenAICompatibleImageModel(modelId, getCommonModelConfig("image"));
+    new OrqAiImageModel(modelId, getCommonModelConfig("image"));
 
   const provider = function (modelId: string) {
     if (new.target) {


### PR DESCRIPTION
… /images/edits support

Replace direct use of `OpenAICompatibleImageModel` for image generation with a dedicated `OrqAiImageModel` that targets the Orq AI proxy correctly across all upstream providers (OpenAI, fal, Google Imagen, Leonardo, etc).

Problems fixed
--------------
1. `OpenAICompatibleImageModel` hardcodes `response_format: "b64_json"` in the request body. Newer OpenAI image models (gpt-image-1 and later) reject this parameter with `Unknown parameter: 'response_format'`, and the Orq proxy forwards that error verbatim. Image generation through Orq was broken for any gpt-image-1+ model.

2. The upstream model's response schema only accepts `data[].b64_json`. Several Orq-routed upstreams (fal, Leonardo, dall-e-2 default) return the image under `data[].url` instead — either as a data URI or as an http URL. These responses failed schema validation with `AI_TypeValidationError: data[0].b64_json: Invalid input: expected string, received undefined`.

3. The upstream model did not support image editing via Orq. Calling `generateImage({ prompt: { images: [...] } })` had no effect and Orq's `/images/edits` endpoint was unreachable through this provider.

Changes
-------
- New `OrqAiImageModel` implementing `ImageModelV3` (specificationVersion `"v3"`, `maxImagesPerCall = 10`), wired up via `provider.imageModel(id)` in `createOrqAiProvider`.

- Request: drops `response_format` so each underlying upstream uses its own default — gpt-image-1 returns base64 inline, dall-e-* defaults to a URL, fal/Leonardo return data URIs. User-supplied extras (quality, style, background, etc.) pass through via `providerOptions.orq`.

- Response schema accepts every shape documented in orq-node's `CreateImageData` (`{ b64_json?, url?, revised_prompt? }`) and an optional `usage` envelope (`input_tokens`, `output_tokens`, `total_tokens`).

- `normalizeImageEntry` handles three response shapes uniformly:
    * `b64_json` field -> returned as-is
    * `url` data URI -> strips the prefix
    * `url` http(s) URL -> fetches and base64-encodes Always returns base64 strings, matching the `ImageModelV3` contract.

- New `/images/edits` branch (multipart form-data) activates when `files != null && files.length > 0`. Each file is converted to a `File` with a `.png` / `.jpg` / `.webp` filename so Orq's middleware doesn't reject the part as `application/octet-stream`. The `mask` parameter is dropped with a warning because Orq's edit schema does not carry a mask field.

- Inline copy of `defaultOpenAICompatibleErrorStructure` because `@ai-sdk/openai-compatible` exports the type but not the value. Orq's proxy returns OpenAI-shaped error envelopes, so the schema matches 1:1.

- `createOrqAiProvider` now throws if `apiKey` is empty, and the URL builder no longer wraps the path in a redundant `new URL(...)`.

Spec compliance verified against:
- `@ai-sdk/provider`'s `ImageModelV3` type (return shape: `images`, `warnings`, `response { timestamp, modelId, headers }`, optional `usage`).
- Upstream `OpenAICompatibleImageModel` in `vercel/ai` for body / schema / warning conventions.
- `orq-ai/orq-node`'s `CreateImageRequestBody`, `CreateImageEditRequestBody`, `CreateImageData`, and `CreateImageUsage` for body + response shapes.