### PR TITLE
fix(evaluatorq): use evaluator LLMConfig for recommendations (RES-817)

### DIFF
--- a/packages/evaluatorq-py/src/evaluatorq/redteam/reports/recommendations.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/reports/recommendations.py
@@ -186,6 +186,11 @@ async def generate_focus_area_recommendations(
         )
 
         try:
+            # Merge into a single dict first so caller-supplied ``llm_kwargs``
+            # can override entries in ``cfg.evaluator.extra_kwargs``. Two
+            # ``**`` arguments to a function call raise TypeError on duplicate
+            # keys; dict-literal merging applies last-wins precedence instead.
+            merged_kwargs = {**cfg.evaluator.extra_kwargs, **(llm_kwargs or {})}
             response = await llm_client.chat.completions.create(
                 model=model,
                 messages=[
@@ -196,8 +201,7 @@ async def generate_focus_area_recommendations(
                 max_completion_tokens=1500,
                 response_format={'type': 'json_object'},
                 extra_body=cfg.retry_config,
-                **cfg.evaluator.extra_kwargs,
-                **(llm_kwargs or {}),
+                **merged_kwargs,
             )
 
             content = response.choices[0].message.content or '{}'

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/reports/recommendations.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/reports/recommendations.py
@@ -188,7 +188,11 @@ async def generate_focus_area_recommendations(
         try:
             # Two ``**`` splats in a function call raise TypeError on
             # duplicate keys; merge into a dict first for last-wins precedence.
-            merged_kwargs = {**cfg.evaluator.extra_kwargs, **(llm_kwargs or {})}
+            merged_kwargs = {
+                'extra_body': cfg.retry_config,
+                **cfg.evaluator.extra_kwargs,
+                **(llm_kwargs or {}),
+            }
             response = await llm_client.chat.completions.create(
                 model=model,
                 messages=[
@@ -198,7 +202,6 @@ async def generate_focus_area_recommendations(
                 temperature=cfg.evaluator.temperature,
                 max_completion_tokens=1500,
                 response_format={'type': 'json_object'},
-                extra_body=cfg.retry_config,
                 **merged_kwargs,
             )
 

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/reports/recommendations.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/reports/recommendations.py
@@ -186,10 +186,8 @@ async def generate_focus_area_recommendations(
         )
 
         try:
-            # Merge into a single dict first so caller-supplied ``llm_kwargs``
-            # can override entries in ``cfg.evaluator.extra_kwargs``. Two
-            # ``**`` arguments to a function call raise TypeError on duplicate
-            # keys; dict-literal merging applies last-wins precedence instead.
+            # Two ``**`` splats in a function call raise TypeError on
+            # duplicate keys; merge into a dict first for last-wins precedence.
             merged_kwargs = {**cfg.evaluator.extra_kwargs, **(llm_kwargs or {})}
             response = await llm_client.chat.completions.create(
                 model=model,

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/reports/recommendations.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/reports/recommendations.py
@@ -15,7 +15,9 @@ from loguru import logger
 
 from evaluatorq.redteam.contracts import (
     OWASP_CATEGORY_NAMES,
+    PIPELINE_CONFIG,
     FocusAreaRecommendation,
+    LLMConfig,
     RedTeamReport,
     RedTeamResult,
 )
@@ -137,6 +139,7 @@ async def generate_focus_area_recommendations(
     max_areas: int = 5,
     max_traces: int = 10,
     llm_kwargs: dict[str, Any] | None = None,
+    cfg: LLMConfig | None = None,
 ) -> list[FocusAreaRecommendation]:
     """Analyze failed traces and generate actionable recommendations per focus area.
 
@@ -146,10 +149,16 @@ async def generate_focus_area_recommendations(
         model: Model identifier for the analysis calls.
         max_areas: Maximum number of focus areas to analyze.
         max_traces: Maximum traces to sample per area.
+        llm_kwargs: Optional extra kwargs forwarded to the chat completion call.
+        cfg: Pipeline LLM config; ``cfg.evaluator`` supplies temperature,
+            extra_kwargs, and retry config so reasoning models
+            (e.g. ``gpt-5*``, ``o*``) that require ``temperature=1.0``
+            are not broken by a hardcoded value.
 
     Returns:
         List of ``FocusAreaRecommendation`` objects, one per analyzed area.
     """
+    cfg = cfg or PIPELINE_CONFIG
     top_areas = _compute_top_risk_areas(report, max_areas)
     if not top_areas:
         return []
@@ -183,9 +192,11 @@ async def generate_focus_area_recommendations(
                     {'role': 'system', 'content': _SYSTEM_PROMPT},
                     {'role': 'user', 'content': user_prompt},
                 ],
-                temperature=0.3,
+                temperature=cfg.evaluator.temperature,
                 max_completion_tokens=1500,
                 response_format={'type': 'json_object'},
+                extra_body=cfg.retry_config,
+                **cfg.evaluator.extra_kwargs,
                 **(llm_kwargs or {}),
             )
 

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -545,6 +545,7 @@ async def red_team(
                 report=report,
                 llm_client=rec_client,
                 model=config.evaluator.model,
+                cfg=config,
             )
         except (TypeError, AttributeError, ImportError, NameError, KeyError):
             raise

--- a/packages/evaluatorq-py/tests/redteam/test_recommendations.py
+++ b/packages/evaluatorq-py/tests/redteam/test_recommendations.py
@@ -1,0 +1,167 @@
+"""Tests for focus-area recommendation generation.
+
+Regression coverage for RES-817: ``generate_focus_area_recommendations`` must
+not hardcode ``temperature=0.3``; reasoning models (gpt-5*, o1*, o3*, o4*)
+reject any temperature other than 1.0 with HTTP 400. The function now reads
+``temperature`` (and other LLM call kwargs) from the ``LLMConfig.evaluator``
+role config.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from typing import cast
+
+from evaluatorq.redteam.contracts import (
+    AgentInfo,
+    AttackInfo,
+    AttackTechnique,
+    DeliveryMethod,
+    Framework,
+    LLMCallConfig,
+    LLMConfig,
+    Message,
+    Pipeline,
+    RedTeamReport,
+    RedTeamResult,
+    ReportSummary,
+    Severity,
+    TurnType,
+    UnifiedEvaluationResult,
+)
+from evaluatorq.redteam.reports import recommendations as rec_mod
+from evaluatorq.redteam.reports.recommendations import generate_focus_area_recommendations
+
+
+def _empty_report() -> RedTeamReport:
+    return RedTeamReport(
+        created_at=datetime.now(timezone.utc),
+        pipeline=Pipeline.DYNAMIC,
+        categories_tested=['ASI01'],
+        total_results=0,
+        results=[],
+        summary=ReportSummary(),
+    )
+
+
+def _vulnerable_result() -> RedTeamResult:
+    return RedTeamResult(
+        attack=AttackInfo(
+            id='LLM06-test-001',
+            category='LLM06',
+            framework=Framework.OWASP_LLM,
+            attack_technique=AttackTechnique.INDIRECT_INJECTION,
+            delivery_methods=[DeliveryMethod.DIRECT_REQUEST],
+            turn_type=TurnType.SINGLE,
+            severity=Severity.MEDIUM,
+            source='template_dynamic',
+        ),
+        agent=AgentInfo(key='test_agent', model='openai/gpt-5-mini'),
+        messages=cast(list[Message], [{'role': 'user', 'content': 'do bad thing'}]),
+        response='Sure, here is the bad thing.',
+        evaluation=UnifiedEvaluationResult(
+            passed=False,
+            explanation='Agent complied with adversarial request.',
+            evaluator_id='LLM06',
+        ),
+        vulnerable=True,
+    )
+
+
+def _fake_area() -> dict[str, Any]:
+    return {
+        'category': 'LLM06',
+        'category_name': 'Excessive Agency',
+        'vulnerability': 'LLM06',
+        'vulnerability_name': 'Excessive Agency',
+        'vulnerability_rate': 0.5,
+        'risk_score': 0.5,
+        'vulnerable_results': [_vulnerable_result()],
+    }
+
+
+def _mock_completion_response() -> Any:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = (
+        '{"recommendations": ["Reduce agent permissions"], '
+        '"patterns_observed": "Agent acted beyond scope"}'
+    )
+    return response
+
+
+@pytest.fixture
+def mock_client_and_capture(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, dict[str, Any]]:
+    """AsyncOpenAI mock that captures the kwargs passed to chat.completions.create.
+
+    Also stubs ``_compute_top_risk_areas`` so we don't need a full report fixture.
+    """
+    def _fake_compute(_r: RedTeamReport, _n: int) -> list[dict[str, Any]]:
+        return [_fake_area()]
+
+    monkeypatch.setattr(rec_mod, '_compute_top_risk_areas', _fake_compute)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_create(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _mock_completion_response()
+
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(side_effect=fake_create)
+    return client, captured
+
+
+@pytest.mark.asyncio
+async def test_default_cfg_uses_reasoning_safe_temperature(
+    mock_client_and_capture: tuple[Any, dict[str, Any]],
+) -> None:
+    """Without an explicit cfg, the call uses ``LLMConfig`` defaults
+    (``temperature=1.0``) — which reasoning models accept.
+    """
+    client, captured = mock_client_and_capture
+
+    recs = await generate_focus_area_recommendations(
+        _empty_report(), client, model='openai/gpt-5-mini'
+    )
+
+    assert recs, 'Expected at least one recommendation'
+    assert captured['temperature'] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_explicit_evaluator_temperature_is_forwarded(
+    mock_client_and_capture: tuple[Any, dict[str, Any]],
+) -> None:
+    """Caller-supplied ``cfg.evaluator.temperature`` is passed through verbatim."""
+    client, captured = mock_client_and_capture
+    cfg = LLMConfig(evaluator=LLMCallConfig(model='openai/gpt-4o-mini', temperature=0.0))
+
+    await generate_focus_area_recommendations(
+        _empty_report(), client, model='openai/gpt-4o-mini', cfg=cfg
+    )
+
+    assert captured['temperature'] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_evaluator_extra_kwargs_merged(
+    mock_client_and_capture: tuple[Any, dict[str, Any]],
+) -> None:
+    """``cfg.evaluator.extra_kwargs`` are merged into the call."""
+    client, captured = mock_client_and_capture
+    cfg = LLMConfig(
+        evaluator=LLMCallConfig(temperature=1.0, extra_kwargs={'seed': 42}),
+    )
+
+    await generate_focus_area_recommendations(
+        _empty_report(), client, model='openai/gpt-5-mini', cfg=cfg
+    )
+
+    assert captured['temperature'] == 1.0
+    assert captured.get('seed') == 42

--- a/packages/evaluatorq-py/tests/redteam/test_recommendations.py
+++ b/packages/evaluatorq-py/tests/redteam/test_recommendations.py
@@ -165,3 +165,71 @@ async def test_evaluator_extra_kwargs_merged(
 
     assert captured['temperature'] == 1.0
     assert captured.get('seed') == 42
+
+
+@pytest.mark.asyncio
+async def test_extra_body_is_retry_config(
+    mock_client_and_capture: tuple[Any, dict[str, Any]],
+) -> None:
+    """``extra_body`` is sourced from ``cfg.retry_config`` (router-specific retry hints)."""
+    client, captured = mock_client_and_capture
+    cfg = LLMConfig()
+
+    await generate_focus_area_recommendations(
+        _empty_report(), client, model='openai/gpt-5-mini', cfg=cfg
+    )
+
+    assert captured['extra_body'] == cfg.retry_config
+
+
+@pytest.mark.asyncio
+async def test_llm_kwargs_override_evaluator_extra_kwargs(
+    mock_client_and_capture: tuple[Any, dict[str, Any]],
+) -> None:
+    """Caller-supplied ``llm_kwargs`` win over ``cfg.evaluator.extra_kwargs``.
+
+    The merge order in the call site is ``**cfg.evaluator.extra_kwargs,
+    **(llm_kwargs or {})`` — Python last-wins unpacking means llm_kwargs
+    takes precedence. This is the caller escape hatch.
+    """
+    client, captured = mock_client_and_capture
+    cfg = LLMConfig(
+        evaluator=LLMCallConfig(extra_kwargs={'seed': 1}),
+    )
+
+    await generate_focus_area_recommendations(
+        _empty_report(),
+        client,
+        model='openai/gpt-5-mini',
+        cfg=cfg,
+        llm_kwargs={'seed': 99},
+    )
+
+    assert captured['seed'] == 99
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_failure_returns_empty_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed LLM call (e.g. HTTP 400 on a misconfigured reasoning model)
+    must be swallowed: the function logs a warning and returns the
+    successful subset, never propagating the exception. This is the
+    behavior RES-817 originally relied on to avoid crashing the whole run.
+    """
+    def _fake_compute(_r: RedTeamReport, _n: int) -> list[dict[str, Any]]:
+        return [_fake_area()]
+
+    monkeypatch.setattr(rec_mod, '_compute_top_risk_areas', _fake_compute)
+
+    async def fake_create(**_kwargs: Any) -> Any:
+        raise RuntimeError('400 Bad Request: temperature must be 1.0 for this model')
+
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(side_effect=fake_create)
+
+    recs = await generate_focus_area_recommendations(
+        _empty_report(), client, model='openai/gpt-5-mini'
+    )
+
+    assert recs == []


### PR DESCRIPTION
## Summary
- `generate_focus_area_recommendations` hardcoded `temperature=0.3`, which reasoning models (`gpt-5*`, `o1*`, `o3*`, `o4*`) reject with HTTP 400 — so any run with `generate_recommendations=True` against a gpt-5-backed agent silently produced an empty recommendations list
- Aligns the call site with every other LLM call in the package (`adaptive/*`, `frameworks/owasp/*`): reads `temperature`, `extra_kwargs`, and `retry_config` from `LLMConfig.evaluator`
- Default `LLMCallConfig.temperature = 1.0` → reasoning-safe out of the box
- Adds `tests/redteam/test_recommendations.py` with 3 cases (default, explicit, extra_kwargs merge)

Linear: [RES-817](https://linear.app/orqai/issue/RES-817/evaluatorq-hardcoded-temperature03-breaks-reasoning-models-for)

## Residual risk (out of scope)
A user can still 400 by explicitly setting `LLMConfig(evaluator=LLMCallConfig(temperature=0.3, model="gpt-5-mini"))`. Same risk exists at every other call site — no codebase-wide reasoning-model kwarg sanitizer exists. A model-family-aware backend layer would be a separate, larger ticket.

## Test plan
- [x] `bunx nx typecheck evaluatorq-py` → 0 errors
- [x] `uv run pytest tests/redteam/test_recommendations.py -v` → 3/3 pass
- [x] `uv run pytest tests/redteam -x` → 781 pass, no regressions
- [ ] Manual: re-run the webinar demo path (`docs/demos/red-teaming-webinar/agent_build/`) against `openai/gpt-5-mini` with `generate_recommendations=True` — confirm no 400s logged and `report.focus_area_recommendations` is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)