### PR TITLE
docs: RES-808 plan/spec + RES-844 types-uml refresh

### DIFF
--- a/docs/superpowers/plans/2026-05-26-res-808-collapse-relocate-unify.md
+++ b/docs/superpowers/plans/2026-05-26-res-808-collapse-relocate-unify.md
@@ -1,0 +1,2493 @@
+# RES-808 Collapse / Relocate / Unify — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse 12 abstract types in `redteam/backends/base.py` to 2 ABCs (`AgentTarget`, `Backend`), relocate `AgentTarget` to `evaluatorq/contracts.py`, and unify `AgentTarget` + sim `TargetAgent` on a single `respond(messages) -> AgentResponse` method. Delivered as 3 stacked PRs.
+
+**Architecture:** Backend ABC owns target factory + memory cleanup + error mapping. `AgentTarget` ABC owns `respond` + `new` + optional `get_agent_context`. `OrqResponsesTarget` becomes stateless. `ORQAgentTarget` keeps its existing `orq_client.agents.responses.create` endpoint and `task_id` threading — only signature conforms. `ChatMessage` moves to `evaluatorq/contracts.py` and gains `developer` role.
+
+**Tech Stack:** Python 3.10+, `uv`, `pytest`, `pytest-asyncio`, `basedpyright`, `ruff`. Spec: `docs/superpowers/specs/2026-05-26-res-808-collapse-relocate-unify-design.md`.
+
+**Working directory:** `packages/evaluatorq-py/`. All `uv` commands assume this CWD.
+
+---
+
+## File map
+
+**PR1 — Collapse**
+
+- Modify: `src/evaluatorq/redteam/backends/base.py` (Protocol→ABC for `AgentTarget`, add `Backend` ABC, add `_BareTargetBackend`, drop 9 dead types)
+- Create: `src/evaluatorq/redteam/backends/_errors.py` (move `extract_status_code`, `extract_provider_error_code`)
+- Modify: `src/evaluatorq/redteam/backends/orq.py` (fold `ORQContextProvider`/`ORQTargetFactory`/`ORQMemoryCleanup`/`ORQErrorMapper` into `ORQBackend` + `ORQAgentTarget`)
+- Modify: `src/evaluatorq/redteam/backends/openai.py` (fold `OpenAIContextProvider`/`OpenAITargetFactory`/`OpenAIErrorMapper` into `OpenAIBackend` + `OpenAIModelTarget`)
+- Modify: `src/evaluatorq/redteam/backends/registry.py` (registry returns `Backend`, not `BackendBundle`)
+- Modify: `src/evaluatorq/redteam/runner.py` (replace BackendBundle accessors; fix `DefaultErrorMapper()` bug; use `_BareTargetBackend` for direct-target path)
+- Modify: `src/evaluatorq/redteam/adaptive/pipeline.py`, `src/evaluatorq/redteam/adaptive/orchestrator.py` (import path updates)
+- Modify: `src/evaluatorq/redteam/__init__.py` (remove `DirectTargetFactory`, 4 `Supports*`, `is_agent_target`)
+- Test: `tests/redteam/test_backend_abc.py` (new)
+- Test: `tests/redteam/test_bare_target_backend.py` (new)
+- Test: `tests/redteam/test_backends.py` (update import paths to `_errors`)
+- Test: `tests/redteam/e2e/conftest.py`, `tests/redteam/e2e/test_*.py` (replace `BackendBundle` with `Backend`)
+- Test: `tests/unit/test_tool_call_interception.py` (kept import `_coerce_to_agent_response` — verify still works)
+
+**PR2 — Relocate `AgentTarget` to `evaluatorq.contracts`**
+
+- Modify: `src/evaluatorq/contracts.py` (add `AgentTarget` ABC)
+- Modify: `src/evaluatorq/redteam/backends/base.py` (re-export `AgentTarget` from `contracts`; keep `Backend` here)
+- Modify: 14 importers — switch `from evaluatorq.redteam.backends.base import AgentTarget` → `from evaluatorq.contracts import AgentTarget`
+
+**PR3 — Unify on `respond(messages)`**
+
+- Modify: `src/evaluatorq/contracts.py` (add `ChatMessage`, add abstract `respond` + concrete `send_prompt` shim on `AgentTarget`)
+- Modify: `src/evaluatorq/simulation/types.py` (re-export shim for `ChatMessage`)
+- Modify: `src/evaluatorq/simulation/target.py` (drop `__call__`, drop `_previous_response_id`, implement stateless `respond`)
+- Modify: `src/evaluatorq/redteam/backends/orq.py` (`ORQAgentTarget.respond(messages)` — keeps endpoint, keeps task_id, takes only last user message)
+- Modify: `src/evaluatorq/redteam/backends/openai.py` (`OpenAIModelTarget.respond`)
+- Modify: `src/evaluatorq/integrations/{langgraph,callable,vercel_ai_sdk,openai_agents}_integration/target.py` (each implements `respond`)
+- Modify: `src/evaluatorq/simulation/runner/simulation.py` (delete local `TargetAgent` Protocol; import `AgentTarget` from contracts; dispatch via `.respond`)
+- Modify: `src/evaluatorq/simulation/api.py` (auto-route `target=AgentTarget` → target_agent path)
+- Test: `tests/redteam/test_orq_responses_target_as_agent_target.py` (rewrite — drop `TestCallDoesNotCorruptAgentTargetState`, add `TestRespondIsStateless`)
+- Test: `tests/integration/test_sim_redteam_target_roundtrip.py` (new)
+
+---
+
+# PR1 — Collapse
+
+## Task 1.1: Add `Backend` ABC stub to `backends/base.py`
+
+**Files:**
+- Modify: `src/evaluatorq/redteam/backends/base.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/redteam/test_backend_abc.py`:
+
+```python
+"""Tests for Backend ABC in redteam.backends.base."""
+from __future__ import annotations
+
+import pytest
+
+from evaluatorq.redteam.backends.base import Backend
+
+
+class _MinimalBackend(Backend):
+    def create_target(self, agent_key):
+        raise NotImplementedError
+
+    async def cleanup_memory(self, ctx, entity_ids):
+        return None
+
+
+def test_backend_is_abstract():
+    with pytest.raises(TypeError):
+        Backend("x")  # type: ignore[abstract]
+
+
+def test_backend_subclass_sets_name():
+    b = _MinimalBackend("orq")
+    assert b.name == "orq"
+
+
+def test_default_map_error_returns_target_error_tuple():
+    b = _MinimalBackend("orq")
+    code, msg = b.map_error(RuntimeError("boom"))
+    assert code == "target_error"
+    assert "RuntimeError" in msg
+    assert "boom" in msg
+```
+
+- [ ] **Step 2: Run test, expect ImportError**
+
+```bash
+uv run pytest tests/redteam/test_backend_abc.py -v
+```
+
+Expected: `ImportError: cannot import name 'Backend' from 'evaluatorq.redteam.backends.base'`.
+
+- [ ] **Step 3: Add `Backend` ABC**
+
+Append to `src/evaluatorq/redteam/backends/base.py` (do not delete existing content yet):
+
+```python
+from abc import ABC, abstractmethod
+
+
+class Backend(ABC):
+    """Backend ABC. Owns target construction, memory cleanup, and error mapping.
+
+    Subclasses must implement ``create_target`` and ``cleanup_memory``.
+    ``map_error`` has a sensible default; override for provider-specific
+    HTTP/status-code mapping.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    @abstractmethod
+    def create_target(self, agent_key: str) -> "AgentTarget":
+        """Create a new AgentTarget for the given agent key."""
+        ...
+
+    @abstractmethod
+    async def cleanup_memory(self, ctx: "AgentContext", entity_ids: list[str]) -> None:
+        """Delete memory entities created during a red teaming run."""
+        ...
+
+    def map_error(self, exc: Exception) -> tuple[str, str]:
+        """Return normalized ``(error_code, error_message)``."""
+        return "target_error", f"{type(exc).__name__}: {exc}"
+```
+
+- [ ] **Step 4: Run test, expect PASS**
+
+```bash
+uv run pytest tests/redteam/test_backend_abc.py -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/redteam/test_backend_abc.py src/evaluatorq/redteam/backends/base.py
+git commit -m "feat(redteam): add Backend ABC stub alongside existing types"
+```
+
+## Task 1.2: Extract HTTP/error helpers to `_errors.py`
+
+**Files:**
+- Create: `src/evaluatorq/redteam/backends/_errors.py`
+- Modify: `src/evaluatorq/redteam/backends/base.py`, `orq.py`, `openai.py`
+- Test: `tests/redteam/test_backends.py`
+
+- [ ] **Step 1: Create `_errors.py` with the verbatim bodies**
+
+`src/evaluatorq/redteam/backends/_errors.py`:
+
+```python
+"""Backend-internal exception extraction helpers.
+
+Module-private. Used by ``ORQBackend.map_error`` and ``OpenAIBackend.map_error``.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def extract_status_code(exc: Exception) -> int | None:
+    """Extract HTTP-like status code from structured exception fields or text."""
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None)
+    if isinstance(status_code, int) and 100 <= status_code <= 599:
+        return status_code
+
+    for attr in ("status_code", "status"):
+        value = getattr(exc, attr, None)
+        if isinstance(value, int) and 100 <= value <= 599:
+            return value
+
+    text = str(exc)
+    patterns = [
+        r"\bstatus(?:_code)?\s*[=:]\s*(\d{3})\b",
+        r"\bHTTP\s*(\d{3})\b",
+        r"\bcode\s*[=:]\s*(\d{3})\b",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if not match:
+            continue
+        code = int(match.group(1))
+        if 100 <= code <= 599:
+            return code
+    return None
+
+
+def extract_provider_error_code(exc: Exception) -> str | None:
+    """Extract provider-specific symbolic error code if present."""
+    for attr in ("code", "error_code", "type"):
+        value = getattr(exc, attr, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        error = body.get("error") if isinstance(body.get("error"), dict) else body
+        for key in ("code", "type", "error_code"):
+            value = error.get(key) if isinstance(error, dict) else None
+            if isinstance(value, str) and value.strip():
+                return value.strip().lower()
+
+    text = str(exc)
+    patterns = [
+        r'\b(?:error_)?code\s*[=:]\s*["\']?([a-z0-9_.-]+)["\']?',
+        r'\btype\s*[=:]\s*["\']?([a-z0-9_.-]+)["\']?',
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if match:
+            return match.group(1).strip().lower()
+    return None
+```
+
+- [ ] **Step 2: Update importers — `base.py`, `orq.py`, `openai.py`**
+
+In `src/evaluatorq/redteam/backends/orq.py`, change:
+
+```python
+from evaluatorq.redteam.backends.base import extract_provider_error_code, extract_status_code
+```
+
+to:
+
+```python
+from evaluatorq.redteam.backends._errors import extract_provider_error_code, extract_status_code
+```
+
+Same change in `src/evaluatorq/redteam/backends/openai.py`.
+
+In `src/evaluatorq/redteam/backends/base.py`, delete the `extract_status_code` (lines ~236-264) and `extract_provider_error_code` (lines ~267-292) definitions plus the `import re` at top (line 10). Do NOT delete the `DefaultErrorMapper` yet — that goes in Task 1.8.
+
+- [ ] **Step 3: Update tests — `tests/redteam/test_backends.py`**
+
+In `tests/redteam/test_backends.py`, replace every:
+
+```python
+from evaluatorq.redteam.backends.base import extract_status_code
+```
+
+```python
+from evaluatorq.redteam.backends.base import extract_provider_error_code
+```
+
+with:
+
+```python
+from evaluatorq.redteam.backends._errors import extract_status_code
+```
+
+```python
+from evaluatorq.redteam.backends._errors import extract_provider_error_code
+```
+
+(replace_all — there are ~22 occurrences total).
+
+- [ ] **Step 4: Run affected tests**
+
+```bash
+uv run pytest tests/redteam/test_backends.py -v
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/evaluatorq/redteam/backends/_errors.py src/evaluatorq/redteam/backends/base.py src/evaluatorq/redteam/backends/orq.py src/evaluatorq/redteam/backends/openai.py tests/redteam/test_backends.py
+git commit -m "refactor(redteam): extract HTTP/error helpers to _errors.py"
+```
+
+## Task 1.3: Promote `AgentTarget` Protocol → ABC inside `base.py`
+
+**Files:**
+- Modify: `src/evaluatorq/redteam/backends/base.py`
+
+Per spec §6 PR1: `AgentTarget` stays in `base.py` for this PR but converts from `Protocol` to ABC. Relocate to `contracts.py` happens in PR2.
+
+- [ ] **Step 1: Replace the `AgentTarget` Protocol with an ABC**
+
+In `src/evaluatorq/redteam/backends/base.py`, replace the entire `class AgentTarget(Protocol):` block (currently lines ~22-49) with:
+
+```python
+class AgentTarget(ABC):
+    """Abstract base class for agent targets that can receive prompts.
+
+    Subclasses must implement ``send_prompt`` and ``new``. Targets that back a
+    server-side memory store override ``get_agent_context``; otherwise the
+    default minimal context is returned. ``memory_entity_id`` is an instance
+    attribute (set in ``__init__``) so subclasses can mutate it without
+    shadowing a class default.
+    """
+
+    def __init__(self, memory_entity_id: str | None = None) -> None:
+        self.memory_entity_id = memory_entity_id
+
+    @abstractmethod
+    async def send_prompt(self, prompt: str) -> "AgentResponse":
+        """Send a prompt; return the response."""
+        ...
+
+    @abstractmethod
+    def new(self) -> "AgentTarget":
+        """Return a fresh independent instance for a new attack."""
+        ...
+
+    async def get_agent_context(self) -> "AgentContext":
+        """Default: minimal context. Override for platform-backed targets."""
+        from evaluatorq.redteam.contracts import AgentContext
+        return AgentContext(key=getattr(self, "agent_key", "unknown"))
+```
+
+(`ABC`, `abstractmethod` already imported from Task 1.1. `Protocol` import stays for now — other Protocols in this file still use it.)
+
+- [ ] **Step 2: Update concrete targets to inherit `AgentTarget` and call `super().__init__`**
+
+In `src/evaluatorq/redteam/backends/orq.py`, change `class ORQAgentTarget:` to `class ORQAgentTarget(AgentTarget):` and prepend `super().__init__(memory_entity_id=memory_entity_id)` inside `__init__`. Move the `self.memory_entity_id = ...` line *after* the `super().__init__` call so the auto-generated default still applies — adapt the auto-gen block:
+
+```python
+def __init__(
+    self,
+    agent_key: str,
+    orq_client: Any,
+    memory_entity_id: str | None = None,
+    model: str | None = None,
+    timeout_ms: int | None = None,
+):
+    if memory_entity_id is None:
+        memory_entity_id = f'red-team-{uuid.uuid4().hex[:12]}'
+    super().__init__(memory_entity_id=memory_entity_id)
+    timeout_ms = timeout_ms or PIPELINE_CONFIG.target_agent_timeout_ms
+    self.agent_key = agent_key
+    self.orq_client = orq_client
+    self.model = model
+    self._timeout_ms = timeout_ms
+    self._task_id: str | None = None
+```
+
+Remove the `from evaluatorq.redteam.backends.base import AgentTarget` `TYPE_CHECKING` import (since concrete inherits now).
+
+Repeat for `src/evaluatorq/redteam/backends/openai.py`:
+
+```python
+class OpenAIModelTarget(AgentTarget):
+    def __init__(
+        self,
+        model: str,
+        system_prompt: str | None = None,
+        *,
+        client: AsyncOpenAI | None = None,
+        max_tokens: int | None = None,
+        timeout_ms: int | None = None,
+    ):
+        super().__init__(memory_entity_id=None)
+        ...
+```
+
+Drop the class-level `memory_entity_id: str | None = None` attribute declaration; it's now set via `super().__init__`.
+
+- [ ] **Step 3: Update integration targets**
+
+For each of the four integration target files:
+- `src/evaluatorq/integrations/langgraph_integration/target.py`
+- `src/evaluatorq/integrations/callable_integration/target.py`
+- `src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py`
+- `src/evaluatorq/integrations/openai_agents_integration/target.py`
+
+Change `class XxxTarget(AgentTarget):` (already inheriting) — add `super().__init__(memory_entity_id=<existing value or None>)` as first line of `__init__`. Drop any class-level `memory_entity_id: str | None = None` declarations. For `CallableTarget`, keep `memory_entity_id=None` in the super call (it has no entity).
+
+- [ ] **Step 4: Run integration target tests**
+
+```bash
+uv run pytest tests/redteam/test_orq_responses_target_as_agent_target.py tests/integrations -v
+```
+
+Expected: all green (or no integrations tests dir — skip then).
+
+```bash
+uv run pytest -m 'not integration' -x -q
+```
+
+Expected: full unit test suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/evaluatorq/redteam/backends/base.py src/evaluatorq/redteam/backends/orq.py src/evaluatorq/redteam/backends/openai.py src/evaluatorq/integrations
+git commit -m "refactor(redteam): promote AgentTarget Protocol to ABC"
+```
+
+## Task 1.4: Implement `ORQBackend`
+
+**Files:**
+- Modify: `src/evaluatorq/redteam/backends/orq.py`
+
+- [ ] **Step 1: Write failing test for ORQBackend.map_error**
+
+Append to `tests/redteam/test_backend_abc.py`:
+
+```python
+def test_orq_backend_map_error_includes_status_code():
+    from evaluatorq.redteam.backends.orq import ORQBackend
+
+    class _HTTPError(Exception):
+        def __init__(self):
+            super().__init__("boom")
+            self.status_code = 429
+
+    backend = ORQBackend(orq_client=object(), timeout_ms=1000)
+    code, _ = backend.map_error(_HTTPError())
+    assert code == "orq.http.429"
+```
+
+- [ ] **Step 2: Run test, expect ImportError**
+
+```bash
+uv run pytest tests/redteam/test_backend_abc.py::test_orq_backend_map_error_includes_status_code -v
+```
+
+Expected: `ImportError: cannot import name 'ORQBackend'`.
+
+- [ ] **Step 3: Add `ORQBackend` class**
+
+Append to `src/evaluatorq/redteam/backends/orq.py` (above `create_orq_agent_target`):
+
+```python
+from evaluatorq.redteam.backends.base import Backend
+
+
+class ORQBackend(Backend):
+    """Backend for ORQ-hosted agents.
+
+    Owns the ORQ SDK client. Creates ``ORQAgentTarget`` instances per job.
+    Performs memory cleanup via the SDK. Maps ORQ exceptions to a normalized
+    error taxonomy.
+    """
+
+    def __init__(self, *, orq_client: Any = None, timeout_ms: int | None = None) -> None:
+        super().__init__(name="orq")
+        timeout_ms = timeout_ms or PIPELINE_CONFIG.target_agent_timeout_ms
+        self._timeout_ms = timeout_ms
+        if orq_client is not None:
+            self._orq_client = orq_client
+        else:
+            if _orq_cls is None:
+                raise ImportError(
+                    "ORQ backend requires the orq-ai-sdk package. "
+                    "Install with: pip install evaluatorq[orq]"
+                )
+            self._orq_client = _orq_cls(
+                api_key=_get_orq_api_key(),
+                server_url=_get_orq_server_url(),
+                timeout_ms=self._timeout_ms,
+            )
+
+    def create_target(self, agent_key: str) -> ORQAgentTarget:
+        return ORQAgentTarget(
+            agent_key=agent_key,
+            orq_client=self._orq_client,
+            timeout_ms=self._timeout_ms,
+        )
+
+    async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
+        for ms in ctx.memory_stores:
+            if not ms.key:
+                logger.warning(f'Memory store {ms.id} has no key, skipping cleanup')
+                continue
+            for entity_id in entity_ids:
+                try:
+                    await asyncio.to_thread(
+                        self._orq_client.memory_stores.delete_memory,
+                        memory_store_key=ms.key,
+                        memory_entity_id=entity_id,
+                    )
+                    logger.debug(f'Deleted memory entity {entity_id} from store {ms.key}')
+                except Exception as e:  # noqa: PERF203
+                    if extract_status_code(e) == 404:
+                        continue
+                    logger.warning(f'Failed to cleanup memory entity {entity_id} from {ms.key}: {e}')
+
+    def map_error(self, exc: Exception) -> tuple[str, str]:
+        name = type(exc).__name__.lower()
+        text = str(exc).lower()
+        status_code = extract_status_code(exc)
+        provider_code = extract_provider_error_code(exc)
+
+        if status_code is not None:
+            return f'orq.http.{status_code}', f'{type(exc).__name__}: {exc}'
+        if provider_code:
+            return f'orq.code.{provider_code}', f'{type(exc).__name__}: {exc}'
+        if 'timeout' in name or 'timed out' in text:
+            return 'orq.timeout', f'{type(exc).__name__}: {exc}'
+        if 'auth' in name or 'unauthorized' in text or 'forbidden' in text:
+            return 'orq.auth', f'{type(exc).__name__}: {exc}'
+        if 'ratelimit' in name or '429' in text:
+            return 'orq.rate_limit', f'{type(exc).__name__}: {exc}'
+        return 'orq.unknown', f'{type(exc).__name__}: {exc}'
+```
+
+- [ ] **Step 4: Run test, expect PASS**
+
+```bash
+uv run pytest tests/redteam/test_backend_abc.py::test_orq_backend_map_error_includes_status_code -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/evaluatorq/redteam/backends/orq.py tests/redteam/test_backend_abc.py
+git commit -m "feat(redteam): add ORQBackend class"
+```
+
+## Task 1.5: Implement `OpenAIBackend`
+
+**Files:**
+- Modify: `src/evaluatorq/redteam/backends/openai.py`
+
+- [ ] **Step 1: Add failing test**
+
+Append to `tests/redteam/test_backend_abc.py`:
+
+```python
+def test_openai_backend_map_error_returns_openai_prefix():
+    from evaluatorq.redteam.backends.openai import OpenAIBackend
+
+    backend = OpenAIBackend(client=None, system_prompt=None)
+    code, _ = backend.map_error(TimeoutError("slow"))
+    assert code.startswith("openai.")
+```
+
+- [ ] **Step 2: Run, expect ImportError**
+
+```bash
+uv run pytest tests/redteam/test_backend_abc.py::test_openai_backend_map_error_returns_openai_prefix -v
+```
+
+- [ ] **Step 3: Add `OpenAIBackend`**
+
+Append to `src/evaluatorq/redteam/backends/openai.py`:
+
+```python
+from evaluatorq.redteam.backends.base import Backend
+
+
+class OpenAIBackend(Backend):
+    """Backend for direct OpenAI model targets.
+
+    Targets are stateless. ``cleanup_memory`` is a no-op (OpenAI models do not
+    own server-side memory).
+    """
+
+    def __init__(
+        self,
+        *,
+        client: AsyncOpenAI | None = None,
+        system_prompt: str | None = None,
+        max_tokens: int | None = None,
+        timeout_ms: int | None = None,
+    ) -> None:
+        super().__init__(name="openai")
+        self._client = client or create_async_llm_client()
+        self._system_prompt = system_prompt
+        self._max_tokens = max_tokens
+        self._timeout_ms = timeout_ms
+
+    def create_target(self, agent_key: str) -> OpenAIModelTarget:
+        return OpenAIModelTarget(
+            model=agent_key,
+            system_prompt=self._system_prompt,
+            client=self._client,
+            max_tokens=self._max_tokens,
+            timeout_ms=self._timeout_ms,
+        )
+
+    async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
+        logger.debug('OpenAI backend has no memory store; cleanup is a no-op')
+
+    def map_error(self, exc: Exception) -> tuple[str, str]:
+        name = type(exc).__name__.lower()
+        status_code = extract_status_code(exc)
+        provider_code = extract_provider_error_code(exc)
+
+        if status_code is not None:
+            return f'openai.http.{status_code}', f'{type(exc).__name__}: {exc}'
+        if provider_code:
+            return f'openai.code.{provider_code}', f'{type(exc).__name__}: {exc}'
+        if 'ratelimit' in name:
+            return 'openai.rate_limit', f'{type(exc).__name__}: {exc}'
+        if 'authentication' in name:
+            return 'openai.auth', f'{type(exc).__name__}: {exc}'
+        if 'timeout' in name:
+            return 'openai.timeout', f'{type(exc).__name__}: {exc}'
+        return 'openai.unknown', f'{type(exc).__name__}: {exc}'
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+uv run pytest tests/redteam/test_backend_abc.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/evaluatorq/redteam/backends/openai.py tests/redteam/test_backend_abc.py
+git commit -m "feat(redteam): add OpenAIBackend class"
+```
+
+## Task 1.6: Switch registry to return `Backend`
+
+**Files:**
+- Modify: `src/evaluatorq/redteam/backends/registry.py`
+
+- [ ] **Step 1: Rewrite `registry.py` factories**
+
+Replace the entire bottom half of `src/evaluatorq/redteam/backends/registry.py` (everything from `_BACKEND_REGISTRY` onward) with:
+
+```python
+_BACKEND_REGISTRY: dict[str, Callable[..., Backend]] = {}
+
+
+def register_backend(name: str, factory: Callable[..., Backend]) -> None:
+    """Register a backend factory for use with resolve_backend()."""
+    _BACKEND_REGISTRY[name.strip().lower()] = factory
+
+
+def resolve_backend(
+    backend: str = "orq",
+    *,
+    llm_client: AsyncOpenAI | None = None,
+    target_config: TargetConfig | None = None,
+    pipeline_config: LLMConfig | None = None,
+) -> Backend:
+    """Resolve a backend by name."""
+    normalized = backend.strip().lower()
+    factory = _BACKEND_REGISTRY.get(normalized)
+    if factory is None:
+        raise BackendError(
+            f"Unsupported backend: {backend!r}. Available: {sorted(_BACKEND_REGISTRY)}"
+        )
+    return factory(llm_client=llm_client, target_config=target_config, pipeline_config=pipeline_config)
+
+
+def _create_openai_backend(
+    llm_client: AsyncOpenAI | None = None,
+    target_config: TargetConfig | None = None,
+    **_: object,
+) -> Backend:
+    from evaluatorq.redteam.backends.openai import OpenAIBackend
+
+    system_prompt = target_config.system_prompt if target_config else None
+    return OpenAIBackend(client=llm_client, system_prompt=system_prompt)
+
+
+def _create_orq_backend(
+    llm_client: AsyncOpenAI | None = None,
+    target_config: TargetConfig | None = None,
+    pipeline_config: LLMConfig | None = None,
+    **_: object,
+) -> Backend:
+    try:
+        from evaluatorq.redteam.backends.orq import ORQBackend
+    except ImportError as exc:
+        raise BackendError("ORQ backend requested but ORQ dependencies are unavailable.") from exc
+
+    timeout_ms = pipeline_config.target_agent_timeout_ms if pipeline_config else None
+    return ORQBackend(timeout_ms=timeout_ms)
+
+
+register_backend("openai", _create_openai_backend)
+register_backend("orq", _create_orq_backend)
+```
+
+Update the top-of-file import block:
+
+```python
+from evaluatorq.redteam.backends.base import Backend
+from evaluatorq.redteam.exceptions import BackendError, CredentialError
+```
+
+Delete `from evaluatorq.redteam.backends.base import BackendBundle, NoopMemoryCleanup` and `from evaluatorq.redteam.backends.openai import (OpenAIContextProvider, OpenAIErrorMapper, OpenAITargetFactory)` import lines.
+
+- [ ] **Step 2: Run registry-touching tests**
+
+```bash
+uv run pytest tests/redteam/ -m 'not integration' -x -q
+```
+
+Expected: failures in `runner.py` callers (next task). Note them — they should disappear after Task 1.7.
+
+If failures occur ONLY in callers, proceed. If `tests/redteam/test_backends.py` or `test_backend_abc.py` fail, investigate before continuing.
+
+- [ ] **Step 3: Commit (red — caller fixes follow)**
+
+```bash
+git add src/evaluatorq/redteam/backends/registry.py
+git commit -m "refactor(redteam): registry returns Backend, not BackendBundle"
+```
+
+## Task 1.7: Update `runner.py` call-sites
+
+**Files:**
+- Modify: `src/evaluatorq/redteam/runner.py`
+
+- [ ] **Step 1: Replace BackendBundle accessors at the `_prepare_dynamic_target` site**
+
+In `src/evaluatorq/redteam/runner.py`, around lines 831-834, replace:
+
+```python
+backend_bundle = resolve_backend('orq', llm_client=llm_client, target_config=target_config, pipeline_config=pipeline_config)
+resolved_factory = backend_bundle.target_factory
+resolved_error_mapper = DefaultErrorMapper()
+resolved_memory_cleanup_t = backend_bundle.memory_cleanup
+```
+
+with:
+
+```python
+backend = resolve_backend('orq', llm_client=llm_client, target_config=target_config, pipeline_config=pipeline_config)
+```
+
+Then update line 841:
+
+```python
+agent_context = await backend_bundle.context_provider.get_agent_context(target_value)
+```
+
+becomes — but wait, we removed `context_provider`. Per spec §5.3, ORQ context retrieval moves to `ORQAgentTarget.get_agent_context()`. The runner can call it through a created target:
+
+```python
+probe_target = backend.create_target(target_value)
+agent_context = await probe_target.get_agent_context()
+```
+
+- [ ] **Step 2: Update `create_dynamic_redteam_job` call (lines 907-919)**
+
+Replace:
+
+```python
+dynamic_job = create_dynamic_redteam_job(
+    agent_key=target_value,
+    agent_context=agent_context,
+    red_team_model=attack_model,
+    max_turns=max_turns,
+    target_factory=resolved_factory,
+    error_mapper=resolved_error_mapper,
+    attack_llm_client=resolved_llm_client,
+    memory_entity_ids=memory_entity_ids,
+    attacker_instructions=attacker_instructions,
+    verbosity=verbosity,
+    pipeline_config=pipeline_config,
+)
+```
+
+with (note the new `backend` arg in place of `target_factory` + `error_mapper`):
+
+```python
+dynamic_job = create_dynamic_redteam_job(
+    agent_key=target_value,
+    agent_context=agent_context,
+    red_team_model=attack_model,
+    max_turns=max_turns,
+    backend=backend,
+    attack_llm_client=resolved_llm_client,
+    memory_entity_ids=memory_entity_ids,
+    attacker_instructions=attacker_instructions,
+    verbosity=verbosity,
+    pipeline_config=pipeline_config,
+)
+```
+
+`create_dynamic_redteam_job` signature update happens in Task 1.9.
+
+- [ ] **Step 3: Update bring-your-own-target path (lines 1320-1358)**
+
+In the `if resolved_agent_targets:` block, replace lines 1337-1357:
+
+```python
+at_factory = DirectTargetFactory(at)
+at_mapper = at if callable(getattr(at, 'map_error', None)) else DefaultErrorMapper()
+at_cleanup = at if callable(getattr(at, 'cleanup_memory', None)) else NoopMemoryCleanup()
+
+at_mem_ids: list[str] = []
+all_at_cleanup_info.append((at_ctx, at_mem_ids, at_cleanup))
+at_dyn_job = create_dynamic_redteam_job(
+    agent_key=at_label,
+    agent_context=at_ctx,
+    red_team_model=attack_model,
+    max_turns=max_turns,
+    target_factory=cast("AgentTargetFactory", at_factory),
+    error_mapper=cast("ErrorMapper", at_mapper),
+    attack_llm_client=at_llm_client,
+    memory_entity_ids=at_mem_ids,
+    attacker_instructions=attacker_instructions,
+    verbosity=verbosity,
+    pipeline_config=pipeline_config,
+)
+```
+
+with:
+
+```python
+from evaluatorq.redteam.backends.base import _BareTargetBackend
+
+at_backend = _BareTargetBackend(at)
+at_mem_ids: list[str] = []
+all_at_cleanup_info.append((at_ctx, at_mem_ids, at_backend))
+at_dyn_job = create_dynamic_redteam_job(
+    agent_key=at_label,
+    agent_context=at_ctx,
+    red_team_model=attack_model,
+    max_turns=max_turns,
+    backend=at_backend,
+    attack_llm_client=at_llm_client,
+    memory_entity_ids=at_mem_ids,
+    attacker_instructions=attacker_instructions,
+    verbosity=verbosity,
+    pipeline_config=pipeline_config,
+)
+```
+
+`_BareTargetBackend` is added in Task 1.9. `all_at_cleanup_info` tuple's third element changes from "cleanup-like object" to "Backend instance" — confirm the consumer downstream (search for `all_at_cleanup_info`).
+
+- [ ] **Step 4: Update memory cleanup consumer**
+
+Find the consumer of `all_at_cleanup_info`. Likely calls `at_cleanup.cleanup_memory(ctx, ids)`. Change call to `at_backend.cleanup_memory(ctx, ids)`. Backend exposes the same method.
+
+```bash
+grep -n "all_at_cleanup_info" src/evaluatorq/redteam/runner.py
+```
+
+For each call-site that does `for at_ctx, at_mem_ids, at_cleanup in all_at_cleanup_info:`, change loop variable to `at_backend` and adjust subsequent method calls — they remain `await at_backend.cleanup_memory(at_ctx, at_mem_ids)`.
+
+- [ ] **Step 5: Remove now-unused imports**
+
+In `src/evaluatorq/redteam/runner.py`, top-of-file imports, remove `DirectTargetFactory`, `NoopMemoryCleanup`, `DefaultErrorMapper`, `AgentTargetFactory`, `ErrorMapper` from `from evaluatorq.redteam.backends.base import (...)`. Add `Backend` if needed.
+
+- [ ] **Step 6: Run runner tests**
+
+```bash
+uv run pytest tests/redteam/ -m 'not integration' -x -q
+```
+
+Expected: green except `create_dynamic_redteam_job`-related failures (signature mismatch). Continue to Task 1.9.
+
+## Task 1.8: Update `adaptive/pipeline.py` and `adaptive/orchestrator.py`
+
+**Files:**
+- Modify: `src/evaluatorq/redteam/adaptive/pipeline.py`
+- Modify: `src/evaluatorq/redteam/adaptive/orchestrator.py`
+
+- [ ] **Step 1: Read current usage**
+
+```bash
+grep -n "DefaultErrorMapper\|ErrorMapper\|target_factory\|AgentTargetFactory" src/evaluatorq/redteam/adaptive/pipeline.py src/evaluatorq/redteam/adaptive/orchestrator.py
+```
+
+- [ ] **Step 2: Update `pipeline.py` — `create_dynamic_redteam_job` signature**
+
+In `src/evaluatorq/redteam/adaptive/pipeline.py`, locate `def create_dynamic_redteam_job(...)`. Replace parameters `target_factory: AgentTargetFactory, error_mapper: ErrorMapper, ...` with `backend: Backend, ...`. Inside the function body, replace every `target_factory.create_target(...)` with `backend.create_target(...)`, every `error_mapper.map_error(exc)` with `backend.map_error(exc)`.
+
+Update imports at the top of the file:
+
+```python
+# delete
+from evaluatorq.redteam.backends.base import DefaultErrorMapper, _coerce_to_agent_response
+
+# add
+from evaluatorq.redteam.backends.base import Backend, _coerce_to_agent_response
+```
+
+Delete TYPE_CHECKING block items `AgentTargetFactory`, `ErrorMapper`, `MemoryCleanup`.
+
+- [ ] **Step 3: Update `orchestrator.py`**
+
+In `src/evaluatorq/redteam/adaptive/orchestrator.py` line 23:
+
+```python
+# delete
+from evaluatorq.redteam.backends.base import AgentTarget, DefaultErrorMapper, ErrorMapper, _coerce_to_agent_response
+
+# add
+from evaluatorq.redteam.backends.base import AgentTarget, _coerce_to_agent_response
+```
+
+Then audit usage of `DefaultErrorMapper`/`ErrorMapper` inside the file. If a class field references them, change type hint to `Backend | None` and call `backend.map_error(...)`. If `DefaultErrorMapper()` is instantiated as a fallback, replace with a tiny local `_default_map_error(exc) -> tuple[str, str]` helper:
+
+```python
+def _default_map_error(exc: Exception) -> tuple[str, str]:
+    return "target_error", f"{type(exc).__name__}: {exc}"
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+uv run pytest tests/redteam/ -m 'not integration' -x -q
+```
+
+Expected: green except the `_BareTargetBackend` reference in runner.py (added in 1.9).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/evaluatorq/redteam/runner.py src/evaluatorq/redteam/adaptive/pipeline.py src/evaluatorq/redteam/adaptive/orchestrator.py
+git commit -m "refactor(redteam): runner+pipeline+orchestrator consume Backend ABC"
+```
+
+## Task 1.9: Add `_BareTargetBackend` adapter
+
+**Files:**
+- Modify: `src/evaluatorq/redteam/backends/base.py`
+- Test: `tests/redteam/test_bare_target_backend.py` (new)
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/redteam/test_bare_target_backend.py`:
+
+```python
+"""Tests for _BareTargetBackend adapter."""
+from __future__ import annotations
+
+import pytest
+
+from evaluatorq.redteam.backends.base import AgentTarget, _BareTargetBackend
+from evaluatorq.redteam.contracts import AgentContext, AgentResponse
+
+
+class _StubTarget(AgentTarget):
+    def __init__(self, memory_entity_id: str | None = None) -> None:
+        super().__init__(memory_entity_id=memory_entity_id)
+
+    async def send_prompt(self, prompt: str) -> AgentResponse:
+        return AgentResponse(text="ok")
+
+    def new(self) -> "_StubTarget":
+        return _StubTarget()
+
+
+class _TargetWithCleanup(_StubTarget):
+    def __init__(self):
+        super().__init__()
+        self.cleaned: list[str] = []
+
+    async def cleanup_memory(self, ctx, entity_ids):
+        self.cleaned.extend(entity_ids)
+
+
+class _TargetWithMapping(_StubTarget):
+    def map_error(self, exc):
+        return ("byo.error", str(exc))
+
+
+@pytest.mark.asyncio
+async def test_bare_backend_delegates_cleanup_when_target_supports_it():
+    target = _TargetWithCleanup()
+    backend = _BareTargetBackend(target)
+    await backend.cleanup_memory(AgentContext(key="x"), ["a", "b"])
+    assert target.cleaned == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_bare_backend_cleanup_noop_when_target_lacks_it():
+    backend = _BareTargetBackend(_StubTarget())
+    # Must not raise.
+    await backend.cleanup_memory(AgentContext(key="x"), ["a"])
+
+
+def test_bare_backend_delegates_map_error_when_target_supports_it():
+    target = _TargetWithMapping()
+    backend = _BareTargetBackend(target)
+    code, _ = backend.map_error(RuntimeError("boom"))
+    assert code == "byo.error"
+
+
+def test_bare_backend_create_target_returns_target_new():
+    target = _StubTarget()
+    backend = _BareTargetBackend(target)
+    fresh = backend.create_target("ignored-agent-key")
+    assert isinstance(fresh, _StubTarget)
+    assert fresh is not target
+```
+
+- [ ] **Step 2: Add `_BareTargetBackend` to `base.py`**
+
+Append to `src/evaluatorq/redteam/backends/base.py`:
+
+```python
+class _BareTargetBackend(Backend):
+    """Adapter wrapping a bare ``AgentTarget`` so it satisfies the ``Backend`` ABC.
+
+    Used by the runner's bring-your-own-target path. Absorbs the duck-typed
+    capability checks (``cleanup_memory``, ``map_error``) that used to scatter
+    across ``runner.py``.
+    """
+
+    def __init__(self, target: AgentTarget) -> None:
+        super().__init__(name=type(target).__name__)
+        self._target = target
+
+    def create_target(self, agent_key: str) -> AgentTarget:
+        fresh = self._target.new()
+        if fresh is None:  # pyright: ignore[reportUnnecessaryComparison]
+            raise TypeError(
+                f"{type(self._target).__name__}.new() returned None. "
+                "It must return a fresh AgentTarget instance."
+            )
+        return fresh
+
+    async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
+        cleanup = getattr(self._target, "cleanup_memory", None)
+        if callable(cleanup):
+            await cleanup(ctx, entity_ids)
+
+    def map_error(self, exc: Exception) -> tuple[str, str]:
+        mapper = getattr(self._target, "map_error", None)
+        if callable(mapper):
+            return mapper(exc)
+        return super().map_error(exc)
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+uv run pytest tests/redteam/test_bare_target_backend.py -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/evaluatorq/redteam/backends/base.py tests/redteam/test_bare_target_backend.py
+git commit -m "feat(redteam): add _BareTargetBackend adapter"
+```
+
+## Task 1.10: Delete dead types from `base.py`
+
+**Files:**
+- Modify: `src/evaluatorq/redteam/backends/base.py`
+
+- [ ] **Step 1: Remove dead types**
+
+In `src/evaluatorq/redteam/backends/base.py`, delete the following classes/functions in order:
+
+- `SupportsClone` Protocol
+- `SupportsTokenUsage` Protocol
+- `SupportsTargetMetadata` Protocol
+- `SupportsAgentContext` Protocol
+- `SupportsTargetFactory` Protocol
+- `SupportsMemoryCleanup` Protocol
+- `SupportsErrorMapping` Protocol
+- `is_agent_target` function
+- `DirectTargetFactory` class
+- `NoopMemoryCleanup` class
+- `AgentContextProvider` Protocol
+- `AgentTargetFactory` Protocol
+- `MemoryCleanup` Protocol
+- `ErrorMapper` Protocol
+- `BackendBundle` dataclass
+- `DefaultErrorMapper` class
+
+Keep:
+
+- `AgentTarget` ABC
+- `_coerce_to_agent_response`
+- `validate_agent_target`
+- `Backend` ABC
+- `_BareTargetBackend`
+
+Drop now-unused imports: `dataclass`, `Protocol`, `Any` if unreferenced.
+
+- [ ] **Step 2: Delete `ORQContextProvider`, `ORQTargetFactory`, `ORQMemoryCleanup`, `ORQErrorMapper` from `orq.py`**
+
+In `src/evaluatorq/redteam/backends/orq.py`:
+
+- Delete `class ORQContextProvider` (lines ~354-451 in current state)
+- Delete `class ORQTargetFactory` (lines ~454-490)
+- Delete `class ORQMemoryCleanup` (lines ~493-532)
+- Delete `class ORQErrorMapper` (lines ~535-555)
+- Delete `create_orq_backend` function at the bottom (now redundant with `ORQBackend`)
+
+Move `ORQContextProvider._enrich_knowledge_base`, `_enrich_memory_store`, and the body of `get_agent_context` *into* `ORQAgentTarget` as private methods. The existing `ORQAgentTarget.get_agent_context` at line 325-327 currently delegates — replace its body with the inlined fetching code:
+
+```python
+async def get_agent_context(self) -> AgentContext:
+    """Retrieve full agent context from ORQ API."""
+    if getattr(self, "_cached_context", None) is not None:
+        return self._cached_context
+    logger.debug(f'Retrieving agent context for: {self.agent_key}')
+    agent_data = await asyncio.to_thread(
+        self.orq_client.agents.retrieve,
+        agent_key=self.agent_key,
+    )
+
+    tools: list[ToolInfo] = []
+    settings = getattr(agent_data, 'settings', None)
+    if settings and hasattr(settings, 'tools') and settings.tools:
+        tools.extend(
+            ToolInfo(
+                name=getattr(tool, 'key', None) or getattr(tool, 'display_name', None) or tool.id,
+                description=getattr(tool, 'description', None),
+                parameters=None,
+            )
+            for tool in settings.tools
+        )
+
+    raw_kb_ids: list[str] = []
+    if hasattr(agent_data, 'knowledge_bases') and agent_data.knowledge_bases:
+        raw_kb_ids = [getattr(kb, 'knowledge_id', None) or str(kb) for kb in agent_data.knowledge_bases]
+
+    raw_ms_ids: list[str] = []
+    if hasattr(agent_data, 'memory_stores') and agent_data.memory_stores:
+        raw_ms_ids = [ms if isinstance(ms, str) else getattr(ms, 'key', str(ms)) for ms in agent_data.memory_stores]
+
+    enrichment_tasks: list[Any] = [self._enrich_knowledge_base(kb_id) for kb_id in raw_kb_ids]
+    enrichment_tasks.extend(self._enrich_memory_store(ms_id) for ms_id in raw_ms_ids)
+
+    enriched_results = await asyncio.gather(*enrichment_tasks) if enrichment_tasks else []
+    knowledge_bases = [r for r in enriched_results if isinstance(r, KnowledgeBaseInfo)]
+    memory_stores = [r for r in enriched_results if isinstance(r, MemoryStoreInfo)]
+
+    model_raw = getattr(agent_data, 'model', None)
+    model_id = getattr(model_raw, 'id', None) if model_raw is not None else None
+
+    self._cached_context = AgentContext(
+        key=self.agent_key,
+        display_name=getattr(agent_data, 'display_name', None),
+        description=getattr(agent_data, 'description', None),
+        system_prompt=getattr(agent_data, 'system_prompt', None),
+        instructions=getattr(agent_data, 'instructions', None),
+        tools=tools,
+        memory_stores=memory_stores,
+        knowledge_bases=knowledge_bases,
+        model=model_id,
+    )
+    return self._cached_context
+```
+
+Add `_cached_context` init line in `ORQAgentTarget.__init__`:
+
+```python
+self._cached_context: AgentContext | None = None
+```
+
+Add `_enrich_knowledge_base` and `_enrich_memory_store` as instance methods on `ORQAgentTarget`, lifted verbatim from `ORQContextProvider`.
+
+Also delete `ORQAgentTarget.create_target` (lines 330-341) — `ORQBackend.create_target` now owns that.
+
+Delete `ORQAgentTarget.cleanup_memory` (lines 344-346) — `ORQBackend.cleanup_memory` now owns that.
+
+Delete `ORQAgentTarget.map_error` (lines 349-351) — `ORQBackend.map_error` owns that.
+
+- [ ] **Step 3: Delete `OpenAIContextProvider`, `OpenAITargetFactory`, `OpenAIErrorMapper` from `openai.py`**
+
+In `src/evaluatorq/redteam/backends/openai.py`:
+
+- Delete `class OpenAIContextProvider` (lines ~179-201)
+- Delete `class OpenAITargetFactory` (lines ~204-222)
+- Delete `class OpenAIErrorMapper` (lines ~225-244)
+- Delete `OpenAIModelTarget.create_target`, `OpenAIModelTarget.map_error` methods (now on `OpenAIBackend`)
+
+Keep `OpenAIModelTarget.get_agent_context` (inline minimal context fits the AgentTarget default behaviour anyway).
+
+- [ ] **Step 4: Update `redteam/__init__.py`**
+
+Remove from `from evaluatorq.redteam.backends.base import (...)`:
+
+- `DirectTargetFactory`
+- `SupportsAgentContext`
+- `SupportsErrorMapping`
+- `SupportsMemoryCleanup`
+- `SupportsTargetFactory`
+- `is_agent_target`
+
+Remove the same names from `__all__`.
+
+- [ ] **Step 5: Update e2e test conftests**
+
+`tests/redteam/e2e/conftest.py`, `tests/redteam/e2e/test_hybrid_pipeline.py`, `tests/redteam/e2e/test_dynamic_pipeline.py`, `tests/redteam/e2e/test_pipeline_options.py` all import `BackendBundle`. Replace each with `Backend` and adjust constructors. For e2e fakes, typically a `class _FakeBackend(Backend):` with stub methods.
+
+Example for `tests/redteam/e2e/conftest.py` — find the `BackendBundle(...)` construction and convert to a fake `Backend` subclass:
+
+```python
+from evaluatorq.redteam.backends.base import Backend
+
+class _FakeBackend(Backend):
+    def __init__(self, target_factory, memory_cleanup, error_mapper):
+        super().__init__(name="fake")
+        self._target_factory = target_factory
+        self._memory_cleanup = memory_cleanup
+        self._error_mapper = error_mapper
+
+    def create_target(self, agent_key):
+        return self._target_factory.create_target(agent_key)
+
+    async def cleanup_memory(self, ctx, entity_ids):
+        await self._memory_cleanup.cleanup_memory(ctx, entity_ids)
+
+    def map_error(self, exc):
+        return self._error_mapper.map_error(exc)
+```
+
+Apply the same shim wherever `BackendBundle(...)` appears.
+
+- [ ] **Step 6: Update `tests/redteam/test_orchestrator_coverage.py:322`**
+
+`from evaluatorq.redteam.backends.base import DefaultErrorMapper` no longer exists. If the test uses it as a fallback, replace with a local stub or remove. Search the surrounding code; if `DefaultErrorMapper` is being passed to the orchestrator, replace with a `Backend` subclass that has only the default `map_error` (which returns `("target_error", ...)`).
+
+- [ ] **Step 7: Update `tests/redteam/test_orq_responses_target_as_agent_target.py:19`**
+
+`from evaluatorq.redteam.backends.base import is_agent_target` — replace with `from evaluatorq.redteam.backends.base import AgentTarget`. In each test using `is_agent_target(x)`, switch to `isinstance(x, AgentTarget)`. There are 4 call-sites in the file.
+
+- [ ] **Step 8: Run full unit test suite**
+
+```bash
+uv run pytest -m 'not integration' -x -q
+```
+
+Expected: all green. If failures: investigate; do not retry.
+
+- [ ] **Step 9: Run type check**
+
+```bash
+uv run basedpyright src/evaluatorq/redteam
+```
+
+Expected: no new errors versus main.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(redteam): drop dead protocols and factory classes"
+```
+
+## Task 1.11: PR1 docs + ticket update
+
+- [ ] **Step 1: Update Linear RES-808 with PR1 progress note**
+
+Skip if subagent execution model is being used — orchestrator handles ticket sync. Otherwise:
+
+```bash
+# manual ticket update via Linear MCP
+```
+
+- [ ] **Step 2: Push branch, open PR1**
+
+```bash
+git push -u origin bauke/res-808-collapse-redteam-backend-abstractions-abc-agenttarget
+gh pr create \
+  --title "RES-808 (PR1/3): collapse redteam backend abstractions to Backend + AgentTarget ABCs" \
+  --body "$(cat <<'EOF'
+## Summary
+- Drop ``BackendBundle`` dataclass + 4 collaborator protocols + 7 ``Supports*`` protocols.
+- Introduce ``Backend`` ABC (``create_target`` / ``cleanup_memory`` / ``map_error``).
+- Promote ``AgentTarget`` from Protocol to ABC inside ``redteam/backends/base.py`` (still in this file; relocation to ``evaluatorq.contracts`` is PR2).
+- Replace ``DirectTargetFactory`` + duck-typed BYO-target plumbing with ``_BareTargetBackend`` adapter.
+- Fix pre-existing bug at ``runner.py:833`` where ``DefaultErrorMapper()`` masked the ORQ-specific error mapper — ORQ HTTP exceptions now correctly hit ``ORQBackend.map_error`` and produce ``orq.http.<status>`` codes.
+
+## Test plan
+- [ ] ``uv run pytest -m 'not integration'`` green
+- [ ] ``uv run basedpyright src/evaluatorq/redteam`` green
+- [ ] Spot-check that an integration test (manual) maps an ORQ rate-limit exception to ``orq.rate_limit`` not ``target_error``.
+
+## Spec
+``docs/superpowers/specs/2026-05-26-res-808-collapse-relocate-unify-design.md``
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+# PR2 — Relocate `AgentTarget` to `evaluatorq.contracts`
+
+Branch off PR1 tip after PR1 merges (or open as stacked draft).
+
+## Task 2.1: Move `AgentTarget` ABC to `evaluatorq/contracts.py`
+
+**Files:**
+- Modify: `src/evaluatorq/contracts.py`
+- Modify: `src/evaluatorq/redteam/backends/base.py`
+
+- [ ] **Step 1: Add `AgentTarget` to `contracts.py`**
+
+Append to `src/evaluatorq/contracts.py` (after `AgentResponse` class, before `__all__`):
+
+```python
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from evaluatorq.redteam.contracts import AgentContext
+
+
+class AgentTarget(ABC):
+    """Abstract base class for agent targets that can receive prompts."""
+
+    def __init__(self, memory_entity_id: str | None = None) -> None:
+        self.memory_entity_id = memory_entity_id
+
+    @abstractmethod
+    async def send_prompt(self, prompt: str) -> "AgentResponse":
+        ...
+
+    @abstractmethod
+    def new(self) -> "AgentTarget":
+        ...
+
+    async def get_agent_context(self) -> "AgentContext":
+        from evaluatorq.redteam.contracts import AgentContext
+        return AgentContext(key=getattr(self, "agent_key", "unknown"))
+```
+
+Add `"AgentTarget"` to the `__all__` list.
+
+- [ ] **Step 2: Replace `AgentTarget` in `backends/base.py` with re-export**
+
+In `src/evaluatorq/redteam/backends/base.py`, delete the entire `class AgentTarget(ABC):` block. Replace with:
+
+```python
+from evaluatorq.contracts import AgentTarget  # noqa: F401  (back-compat re-export)
+```
+
+- [ ] **Step 3: Sanity check**
+
+```bash
+uv run python -c "from evaluatorq.contracts import AgentTarget; print(AgentTarget.__module__)"
+uv run python -c "from evaluatorq.redteam.backends.base import AgentTarget; print(AgentTarget.__module__)"
+```
+
+Expected: both print `evaluatorq.contracts`.
+
+- [ ] **Step 4: Run test suite**
+
+```bash
+uv run pytest -m 'not integration' -x -q
+```
+
+Expected: green — re-export keeps every existing importer working.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/evaluatorq/contracts.py src/evaluatorq/redteam/backends/base.py
+git commit -m "refactor(contracts): relocate AgentTarget ABC to evaluatorq.contracts"
+```
+
+## Task 2.2: Migrate 14 importers to `evaluatorq.contracts`
+
+**Files (importers):**
+
+- `src/evaluatorq/redteam/runner.py` (2 occurrences, lines 36 and 252)
+- `src/evaluatorq/redteam/adaptive/orchestrator.py` (line 23)
+- `src/evaluatorq/integrations/langgraph_integration/target.py` (line 16)
+- `src/evaluatorq/integrations/callable_integration/target.py` (line 11)
+- `src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py` (line 22)
+- `src/evaluatorq/integrations/openai_agents_integration/target.py` (line 11)
+- Any test file currently importing from `evaluatorq.redteam.backends.base import AgentTarget`
+
+- [ ] **Step 1: Identify all importers**
+
+```bash
+grep -rn "from evaluatorq.redteam.backends.base import.*AgentTarget" packages/evaluatorq-py/src packages/evaluatorq-py/tests
+```
+
+- [ ] **Step 2: Update each importer**
+
+For every match, change `from evaluatorq.redteam.backends.base import AgentTarget` to `from evaluatorq.contracts import AgentTarget`. If `AgentTarget` is imported alongside other names from `backends.base`, split the import into two lines (one for contracts, one for backends.base remainder).
+
+Use `sed` only if confident — there are edge cases (e.g. multi-import lines, TYPE_CHECKING blocks). Manual via Edit is safer.
+
+- [ ] **Step 3: Remove the back-compat re-export from `backends/base.py`**
+
+Drop the `from evaluatorq.contracts import AgentTarget` re-export line in `src/evaluatorq/redteam/backends/base.py`. (Per spec §10 "Public re-exports removed" — semver entry in CHANGELOG.)
+
+- [ ] **Step 4: Type-check + tests**
+
+```bash
+uv run basedpyright src/evaluatorq
+uv run pytest -m 'not integration' -x -q
+```
+
+Expected: green.
+
+- [ ] **Step 5: CHANGELOG entry**
+
+Append to `CHANGELOG.md` (create if missing) under an `## Unreleased / Changed` section:
+
+```markdown
+- **BREAKING:** `AgentTarget` moved from `evaluatorq.redteam.backends.base` to `evaluatorq.contracts`. Update imports.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: migrate AgentTarget importers to evaluatorq.contracts"
+```
+
+## Task 2.3: Push PR2
+
+- [ ] **Step 1: Push**
+
+```bash
+git push
+gh pr create \
+  --title "RES-808 (PR2/3): relocate AgentTarget ABC to evaluatorq.contracts" \
+  --body "$(cat <<'EOF'
+## Summary
+- Move ``AgentTarget`` ABC to ``evaluatorq.contracts`` so simulation can depend on it without crossing module boundaries.
+- Update 14 importers (runner, adaptive, 4 integrations, tests).
+- Drop back-compat re-export per spec.
+
+## Test plan
+- [ ] ``uv run pytest -m 'not integration'`` green
+- [ ] ``uv run basedpyright src/evaluatorq`` green
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+# PR3 — Unify on `respond(messages)`
+
+Branch off PR2 tip.
+
+## Task 3.1: Move `ChatMessage` to `evaluatorq/contracts.py`
+
+**Files:**
+- Modify: `src/evaluatorq/contracts.py`
+- Modify: `src/evaluatorq/simulation/types.py`
+
+- [ ] **Step 1: Add `ChatMessage` to `contracts.py`**
+
+Append to `src/evaluatorq/contracts.py` (after `AgentResponse`, before `AgentTarget`):
+
+```python
+class ChatMessage(BaseModel):
+    """A single chat message — used by `AgentTarget.respond`."""
+
+    role: Literal["user", "assistant", "system", "developer"]
+    content: str
+```
+
+Add `"ChatMessage"` to `__all__`.
+
+- [ ] **Step 2: Make `simulation/types.py:ChatMessage` a re-export shim**
+
+In `src/evaluatorq/simulation/types.py`, replace lines 217-219 (`class ChatMessage(BaseModel): ...`) with:
+
+```python
+from evaluatorq.contracts import ChatMessage  # re-export shim — slated for removal in 1.5
+```
+
+Drop the local `class ChatMessage` definition. The shim preserves `from evaluatorq.simulation.types import ChatMessage` for one cycle.
+
+- [ ] **Step 3: Verify**
+
+```bash
+uv run python -c "
+from evaluatorq.contracts import ChatMessage as C1
+from evaluatorq.simulation.types import ChatMessage as C2
+assert C1 is C2
+print('ok')
+"
+```
+
+Expected: `ok`.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+uv run pytest -m 'not integration' -x -q
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/evaluatorq/contracts.py src/evaluatorq/simulation/types.py
+git commit -m "refactor(contracts): relocate ChatMessage; add 'developer' role"
+```
+
+## Task 3.2: Add `respond` + `send_prompt` shim to `AgentTarget`
+
+**Files:**
+- Modify: `src/evaluatorq/contracts.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/contracts/test_agent_target_shim.py`:
+
+```python
+"""Tests for AgentTarget.send_prompt back-compat shim."""
+from __future__ import annotations
+
+import pytest
+
+from evaluatorq.contracts import AgentResponse, AgentTarget, ChatMessage
+
+
+class _RespondOnlyTarget(AgentTarget):
+    def __init__(self):
+        super().__init__()
+        self.received: list[list[ChatMessage]] = []
+
+    async def respond(self, messages: list[ChatMessage]) -> AgentResponse:
+        self.received.append(messages)
+        return AgentResponse(text=f"echo: {messages[-1].content}")
+
+    def new(self):
+        return _RespondOnlyTarget()
+
+
+@pytest.mark.asyncio
+async def test_send_prompt_delegates_to_respond_with_single_user_message():
+    target = _RespondOnlyTarget()
+    result = await target.send_prompt("hello")
+    assert result.text == "echo: hello"
+    assert len(target.received) == 1
+    assert len(target.received[0]) == 1
+    assert target.received[0][0].role == "user"
+    assert target.received[0][0].content == "hello"
+```
+
+- [ ] **Step 2: Run, expect FAIL** (no `respond` abstract method yet)
+
+```bash
+uv run pytest tests/contracts/test_agent_target_shim.py -v
+```
+
+- [ ] **Step 3: Update `AgentTarget` to spec §5.1 shape**
+
+In `src/evaluatorq/contracts.py`, replace the existing `AgentTarget` class with:
+
+```python
+class AgentTarget(ABC):
+    """Abstract base class for agent targets.
+
+    Subclasses implement ``respond`` (the canonical message-based interface)
+    and ``new``. ``send_prompt`` is a concrete one-line shim retained for
+    back-compat with single-prompt callers. ``get_agent_context`` has a
+    minimal default; targets backed by a control plane (ORQ) override.
+    """
+
+    def __init__(self, memory_entity_id: str | None = None) -> None:
+        self.memory_entity_id = memory_entity_id
+
+    @abstractmethod
+    async def respond(self, messages: list["ChatMessage"]) -> "AgentResponse":
+        """Send a list of chat messages; return the response."""
+        ...
+
+    @abstractmethod
+    def new(self) -> "AgentTarget":
+        """Return a fresh independent instance."""
+        ...
+
+    async def get_agent_context(self) -> "AgentContext":
+        from evaluatorq.redteam.contracts import AgentContext
+        return AgentContext(key=getattr(self, "agent_key", "unknown"))
+
+    async def send_prompt(self, prompt: str) -> "AgentResponse":
+        """Back-compat shim: wraps prompt in a single user message and calls ``respond``."""
+        return await self.respond([ChatMessage(role="user", content=prompt)])
+```
+
+- [ ] **Step 4: Run shim test, expect PASS**
+
+```bash
+uv run pytest tests/contracts/test_agent_target_shim.py -v
+```
+
+- [ ] **Step 5: Existing target classes now fail because `respond` is abstract** — Step 5 is the bulk of the PR: implement `respond` on every concrete target. Run the full suite to inventory failures:
+
+```bash
+uv run pytest -m 'not integration' --no-header -q 2>&1 | tail -50
+```
+
+Expected: many `TypeError: Can't instantiate abstract class XxxTarget with abstract method respond` failures. Each concrete target gets fixed in Tasks 3.3-3.7.
+
+- [ ] **Step 6: Commit** (red — concrete impls follow)
+
+```bash
+git add src/evaluatorq/contracts.py tests/contracts/test_agent_target_shim.py
+git commit -m "feat(contracts): add abstract respond() + send_prompt shim to AgentTarget"
+```
+
+## Task 3.3: `OrqResponsesTarget` — stateless `respond`, drop `__call__`
+
+**Files:**
+- Modify: `src/evaluatorq/simulation/target.py`
+- Test: `tests/redteam/test_orq_responses_target_as_agent_target.py`
+
+- [ ] **Step 1: Update the `OrqResponsesTarget` class**
+
+Replace `src/evaluatorq/simulation/target.py` content with:
+
+```python
+"""Stateless OrqResponsesTarget — implements AgentTarget.respond."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from evaluatorq.contracts import AgentResponse, AgentTarget, ChatMessage, LLMCallConfig
+from evaluatorq.simulation._client import build_simulation_client, extract_responses_output
+from evaluatorq.simulation.types import TokenUsage
+from evaluatorq.simulation.utils.retry import with_retry
+
+if TYPE_CHECKING:
+    from openai import AsyncOpenAI
+
+
+@dataclass(frozen=True)
+class _ResponsesCallResult:
+    response: AgentResponse
+    response_id: str | None
+    usage: TokenUsage | None
+
+
+class OrqResponsesTarget(AgentTarget):
+    """Wraps Orq Responses v3 API as a stateless AgentTarget.
+
+    Stateless: each ``respond(messages)`` call sends the full message list and
+    holds no per-instance conversation state. Conversation continuity is owned
+    by the caller (sim runner or red-team orchestrator).
+    """
+
+    def __init__(
+        self,
+        config: LLMCallConfig,
+        *,
+        instructions: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        memory_entity_id: str | None = None,
+        client: AsyncOpenAI | None = None,
+    ) -> None:
+        super().__init__(memory_entity_id=memory_entity_id)
+        self.config = config
+        self.instructions = instructions
+        self.tools = tools
+        if client is not None:
+            self._client = client
+            self._client_owned = False
+        else:
+            self._client, self._client_owned = build_simulation_client(config.client)
+
+    async def respond(self, messages: list[ChatMessage]) -> AgentResponse:
+        """Stateless: send all messages, return the response."""
+        result = await self._call_responses_api(
+            responses_input=self._messages_to_input(messages),
+        )
+        return result.response
+
+    def new(self) -> OrqResponsesTarget:
+        """Fresh instance: no memory_entity_id, propagated injected client."""
+        return OrqResponsesTarget(
+            self.config,
+            instructions=self.instructions,
+            tools=self.tools,
+            memory_entity_id=None,
+            client=self._client if not self._client_owned else None,
+        )
+
+    async def get_agent_context(self):
+        from evaluatorq.redteam.contracts import AgentContext
+        return AgentContext(key=self.config.model)
+
+    async def close(self) -> None:
+        if self._client_owned:
+            await self._client.close()
+            self._client_owned = False
+
+    async def __aenter__(self) -> "OrqResponsesTarget":
+        return self
+
+    async def __aexit__(self, *_exc_info: object) -> None:
+        await self.close()
+
+    async def _call_responses_api(
+        self,
+        *,
+        responses_input: str | list[dict[str, Any]],
+    ) -> _ResponsesCallResult:
+        timeout_s = self.config.timeout_ms / 1000.0 if self.config.timeout_ms else None
+
+        async def _do_call() -> _ResponsesCallResult:
+            kwargs: dict[str, Any] = {
+                "model": self.config.model,
+                "input": responses_input,
+            }
+            if self.tools:
+                kwargs["tools"] = self.tools
+            if self.instructions is not None:
+                kwargs["instructions"] = self.instructions
+
+            coro = self._client.responses.create(**kwargs)
+            response = await (
+                asyncio.wait_for(coro, timeout=timeout_s) if timeout_s else coro
+            )
+
+            response_id = getattr(response, "id", None)
+            if not isinstance(response_id, str) or not response_id:
+                response_id = None
+
+            output_items, usage = extract_responses_output(response)
+            if not output_items:
+                raise RuntimeError(
+                    f"OrqResponsesTarget: response contained no extractable "
+                    f"output items (model={self.config.model})."
+                )
+
+            return _ResponsesCallResult(
+                response=AgentResponse(output=output_items),
+                response_id=response_id,
+                usage=usage,
+            )
+
+        try:
+            return await with_retry(_do_call, label="OrqResponsesTarget._call_responses_api")
+        except asyncio.TimeoutError as e:
+            raise RuntimeError(
+                f"OrqResponsesTarget timed out after {timeout_s}s (model={self.config.model})"
+            ) from e
+
+    @staticmethod
+    def _messages_to_input(messages: list[ChatMessage]) -> list[dict[str, Any]]:
+        return [{"role": m.role, "content": m.content} for m in messages]
+
+
+__all__ = ["OrqResponsesTarget"]
+```
+
+Removed:
+- `__call__` method
+- `_previous_response_id` attribute and all related logic
+- `_invoke_stateless` / `_invoke_stateful` split
+- `_accumulated_usage`, `threading_disabled`, `get_usage()`
+- `_validate_response_id` helper (inlined as 2 lines)
+- Class-level `memory_entity_id: str | None` / `threading_disabled: bool` declarations
+
+- [ ] **Step 2: Rewrite conformance test file**
+
+Replace `tests/redteam/test_orq_responses_target_as_agent_target.py` with:
+
+```python
+"""Tests for OrqResponsesTarget conformance with the AgentTarget ABC.
+
+After RES-808 PR3:
+- ``respond(messages)`` is the canonical entry point
+- ``send_prompt(str)`` is the shim
+- ``OrqResponsesTarget`` is stateless — no ``_previous_response_id`` invariants
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from evaluatorq.contracts import AgentResponse, AgentTarget, ChatMessage, LLMCallConfig
+from evaluatorq.simulation.target import OrqResponsesTarget
+
+
+def _make_client() -> MagicMock:
+    client = MagicMock()
+    client.responses = MagicMock()
+    client.responses.create = AsyncMock()
+    return client
+
+
+def _make_response(text: str = "all good") -> MagicMock:
+    part = MagicMock()
+    part.type = "output_text"
+    part.text = text
+    msg_item = MagicMock()
+    msg_item.type = "message"
+    msg_item.content = [part]
+    usage = MagicMock()
+    usage.input_tokens = 5
+    usage.output_tokens = 3
+    response = MagicMock()
+    response.id = "resp-1"
+    response.usage = usage
+    response.output = [msg_item]
+    return response
+
+
+def _make_target() -> OrqResponsesTarget:
+    client = _make_client()
+    client.responses.create = AsyncMock(return_value=_make_response())
+    return OrqResponsesTarget(LLMCallConfig(model="gpt-4o"), client=client)
+
+
+class TestAgentTargetConformance:
+    def test_is_agent_target_instance(self):
+        assert isinstance(_make_target(), AgentTarget)
+
+    def test_memory_entity_id_default_none(self):
+        assert _make_target().memory_entity_id is None
+
+    def test_memory_entity_id_settable(self):
+        client = _make_client()
+        target = OrqResponsesTarget(LLMCallConfig(model="gpt-4o"), client=client, memory_entity_id="x-1")
+        assert target.memory_entity_id == "x-1"
+
+
+class TestRespond:
+    @pytest.mark.asyncio
+    async def test_respond_returns_agent_response(self):
+        target = _make_target()
+        result = await target.respond([ChatMessage(role="user", content="hi")])
+        assert isinstance(result, AgentResponse)
+        assert result.text == "all good"
+
+    @pytest.mark.asyncio
+    async def test_send_prompt_delegates_to_respond(self):
+        target = _make_target()
+        result = await target.send_prompt("hi")
+        assert isinstance(result, AgentResponse)
+
+
+class TestRespondIsStateless:
+    @pytest.mark.asyncio
+    async def test_consecutive_respond_calls_pass_messages_as_sent(self):
+        """respond is stateless: each call's input is exactly what the caller passed.
+
+        No previous_response_id threading, no accumulation on self.
+        """
+        client = _make_client()
+        client.responses.create = AsyncMock(side_effect=[_make_response("r1"), _make_response("r2")])
+        target = OrqResponsesTarget(LLMCallConfig(model="gpt-4o"), client=client)
+
+        await target.respond([ChatMessage(role="user", content="turn1")])
+        await target.respond([ChatMessage(role="user", content="turn2")])
+
+        # Both calls received exactly what was passed (no carry-over kwargs).
+        call1_kwargs = client.responses.create.await_args_list[0].kwargs
+        call2_kwargs = client.responses.create.await_args_list[1].kwargs
+        assert "previous_response_id" not in call1_kwargs
+        assert "previous_response_id" not in call2_kwargs
+        assert call1_kwargs["input"] == [{"role": "user", "content": "turn1"}]
+        assert call2_kwargs["input"] == [{"role": "user", "content": "turn2"}]
+
+
+class TestNew:
+    def test_new_returns_different_instance(self):
+        target = _make_target()
+        assert target.new() is not target
+
+    def test_new_memory_entity_id_is_none(self):
+        target = _make_target()
+        assert target.new().memory_entity_id is None
+
+    def test_new_propagates_injected_client(self):
+        client = _make_client()
+        client.responses.create = AsyncMock(return_value=_make_response())
+        target = OrqResponsesTarget(LLMCallConfig(model="gpt-4o"), client=client)
+        assert target.new()._client is client
+```
+
+- [ ] **Step 3: Run conformance tests**
+
+```bash
+uv run pytest tests/redteam/test_orq_responses_target_as_agent_target.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/evaluatorq/simulation/target.py tests/redteam/test_orq_responses_target_as_agent_target.py
+git commit -m "refactor(simulation): OrqResponsesTarget becomes stateless; drop __call__"
+```
+
+## Task 3.4: `ORQAgentTarget.respond(messages)` — keeps endpoint, last-user-message contract
+
+**Files:**
+- Modify: `src/evaluatorq/redteam/backends/orq.py`
+
+- [ ] **Step 1: Replace `send_prompt` with `respond`**
+
+In `src/evaluatorq/redteam/backends/orq.py`, change the method signature:
+
+```python
+# was
+async def send_prompt(self, prompt: str) -> AgentResponse:
+
+# becomes
+async def respond(self, messages: list[ChatMessage]) -> AgentResponse:
+    """Send the last user message to the ORQ agents endpoint, threaded via task_id.
+
+    Caller contract: ``messages[-1].role == "user"``. Prior turns are assumed
+    consistent with the server-side history that ``task_id`` references.
+    First call (``task_id is None``) seeds task_id from the response.
+    """
+    if not messages or messages[-1].role != "user":
+        raise ValueError(
+            "ORQAgentTarget.respond requires messages[-1].role == 'user'. "
+            "Server-side conversation state is held via task_id."
+        )
+    prompt = messages[-1].content
+    # ... rest of the existing body, unchanged
+```
+
+The rest of the function body (span setup, kwargs construction, tool-loop, usage accumulation, return) stays verbatim — `prompt` is the local variable already used throughout.
+
+Add `from evaluatorq.contracts import ChatMessage` to the imports.
+
+- [ ] **Step 2: `send_prompt` is no longer overridden** — inherits the contracts shim.
+
+Remove any `async def send_prompt(...)` left on `ORQAgentTarget`. Inherited shim `super().send_prompt(prompt) → respond([ChatMessage(role='user', content=prompt)])` reproduces previous behaviour.
+
+- [ ] **Step 3: Update ORQAgentTarget conformance tests**
+
+Find existing tests that call `target.send_prompt(...)`:
+
+```bash
+grep -rn "ORQAgentTarget\|send_prompt" tests/redteam tests/integrations 2>/dev/null
+```
+
+For each match where the test asserts a tool-loop body behaviour, keep the test but switch to `await target.send_prompt(prompt)` (which now delegates via the shim) OR migrate to `await target.respond([ChatMessage(role="user", content=prompt)])`. Either is acceptable; prefer `respond` for new tests, keep `send_prompt` for legacy unchanged.
+
+Add one new test:
+
+```python
+@pytest.mark.asyncio
+async def test_respond_rejects_non_user_last_message():
+    target = ORQAgentTarget(agent_key="a", orq_client=MagicMock())
+    with pytest.raises(ValueError, match="messages\\[-1\\].role"):
+        await target.respond([ChatMessage(role="user", content="x"),
+                              ChatMessage(role="assistant", content="y")])
+```
+
+Place in `tests/redteam/test_orq_agent_target_respond.py` (new file) or append to the existing orq agent target test file if one exists.
+
+- [ ] **Step 4: Run ORQ agent target tests**
+
+```bash
+uv run pytest tests/redteam/ -k 'orq_agent' -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/evaluatorq/redteam/backends/orq.py tests/redteam/
+git commit -m "refactor(redteam): ORQAgentTarget.respond(messages); last-user contract"
+```
+
+## Task 3.5: `OpenAIModelTarget.respond`
+
+**Files:**
+- Modify: `src/evaluatorq/redteam/backends/openai.py`
+
+- [ ] **Step 1: Rename `send_prompt` to `respond(messages)`**
+
+`OpenAIModelTarget` already keeps `_history`. With `respond`, we have two options: ignore history (caller owns conversation) or accept the full messages list and bypass history. Per spec §5.8 sim auto-routes a full message list — accept the caller's history and drop the per-instance `_history`.
+
+In `src/evaluatorq/redteam/backends/openai.py`, replace `send_prompt` with:
+
+```python
+async def respond(self, messages: list[ChatMessage]) -> AgentResponse:
+    """Send chat completion with the provided message list + system prompt.
+
+    Caller owns conversation history. ``_history`` is no longer accumulated
+    on the target.
+    """
+    completion_messages: list[ChatCompletionMessageParam] = [
+        {"role": "system", "content": self.system_prompt},
+        *[
+            {"role": m.role, "content": m.content}  # type: ignore[misc]
+            for m in messages
+        ],
+    ]
+    async with with_llm_span(
+        model=self.model,
+        input_messages=completion_messages,
+        attributes={"orq.redteam.llm_purpose": "target"},
+    ) as span:
+        response = await asyncio.wait_for(
+            self.client.chat.completions.create(
+                model=self.model,
+                messages=completion_messages,
+                max_tokens=self.max_tokens,
+            ),
+            timeout=self.timeout_ms / 1000.0,
+        )
+        msg = response.choices[0].message
+        content = msg.content or ''
+        record_llm_response(span, response, output_content=content)
+
+        tool_call_items: list[ToolCallOutputItem] = []
+        for tc in (getattr(msg, 'tool_calls', None) or []):
+            func = getattr(tc, 'function', None)
+            if func is None:
+                continue
+            tc_id = getattr(tc, 'id', None)
+            kwargs: dict[str, Any] = {
+                'name': func.name,
+                'arguments': func.arguments or '{}',
+            }
+            if isinstance(tc_id, str) and tc_id:
+                kwargs['id'] = tc_id
+            tool_call_items.append(ToolCallOutputItem(**kwargs))
+
+        usage = TokenUsage.from_completion(response)
+        response_id = getattr(response, 'id', None)
+        finish_reason = None
+        choices = getattr(response, 'choices', None) or []
+        if choices:
+            finish_reason = getattr(choices[0], 'finish_reason', None)
+
+    output: list[OutputMessage] = cast('list[OutputMessage]', list(tool_call_items))
+    output.append(TextOutputItem(text=content, annotations=[]))
+    return AgentResponse(
+        output=output,
+        usage=usage,
+        model=getattr(response, 'model', None),
+        response_id=response_id,
+        finish_reason=finish_reason,
+    )
+```
+
+Delete `self._history` initialization in `__init__`. Delete the history-append block at the end of the old `send_prompt`.
+
+Add `from evaluatorq.contracts import ChatMessage` import.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+uv run pytest tests/redteam/ -k 'openai' -v
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/evaluatorq/redteam/backends/openai.py
+git commit -m "refactor(redteam): OpenAIModelTarget.respond; drop per-instance history"
+```
+
+## Task 3.6: Integration targets — `respond` for each
+
+**Files:**
+- Modify: `src/evaluatorq/integrations/langgraph_integration/target.py`
+- Modify: `src/evaluatorq/integrations/callable_integration/target.py`
+- Modify: `src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py`
+- Modify: `src/evaluatorq/integrations/openai_agents_integration/target.py`
+
+For each integration target, the existing `send_prompt(self, prompt: str)` body wraps the wrapped framework. For `respond(self, messages)` we follow the spec rule: convert messages → whatever the wrapped framework expects, defaulting to "last user message as prompt" for opaque/callable integrations.
+
+- [ ] **Step 1: `callable_integration/target.py`** — replace `send_prompt` with `respond`:
+
+```python
+async def respond(self, messages: list[ChatMessage]) -> AgentResponse:
+    """For opaque callables, use the last user message as the prompt."""
+    if not messages or messages[-1].role != "user":
+        raise ValueError("CallableTarget.respond requires messages[-1].role == 'user'")
+    prompt = messages[-1].content
+    # ... existing body unchanged below, operating on `prompt`
+```
+
+Add `from evaluatorq.contracts import ChatMessage` import. Drop the existing `send_prompt` override.
+
+- [ ] **Step 2: `langgraph_integration/target.py`** — same pattern. LangGraph thread state belongs to LangGraph; the integration's job is to pass the latest user turn. Use last-user-message rule.
+
+- [ ] **Step 3: `vercel_ai_sdk_integration/target.py`** — same pattern. Pass the full message list if the integration accepts a transcript (check `send_prompt`'s existing call shape); otherwise last user.
+
+- [ ] **Step 4: `openai_agents_integration/target.py`** — OpenAI Agents SDK accepts a list of messages directly. Pass the full `messages` through:
+
+```python
+async def respond(self, messages: list[ChatMessage]) -> AgentResponse:
+    sdk_messages = [{"role": m.role, "content": m.content} for m in messages]
+    # ... call OpenAI Agents SDK with sdk_messages
+```
+
+- [ ] **Step 5: Run integration unit tests + the conformance assertion**
+
+```bash
+uv run pytest tests/ -k 'integration_target' -m 'not integration' -v
+```
+
+- [ ] **Step 6: Add a smoke test per integration target**
+
+Create `tests/integrations/test_respond_smoke.py`:
+
+```python
+"""Smoke tests: every integration target implements respond and returns AgentResponse."""
+from __future__ import annotations
+
+import pytest
+
+from evaluatorq.contracts import AgentResponse, AgentTarget, ChatMessage
+
+
+@pytest.mark.asyncio
+async def test_callable_target_respond_returns_agent_response():
+    from evaluatorq.integrations.callable_integration import CallableTarget
+    target = CallableTarget(lambda prompt: f"echo: {prompt}")
+    assert isinstance(target, AgentTarget)
+    result = await target.respond([ChatMessage(role="user", content="hi")])
+    assert isinstance(result, AgentResponse)
+    assert "hi" in result.text
+```
+
+(Add similar smoke for the three other integrations if mocking their SDKs is straightforward; skip if not — the abstract-method enforcement at import time already guarantees `respond` exists.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/evaluatorq/integrations/ tests/integrations/
+git commit -m "refactor(integrations): all four targets implement respond(messages)"
+```
+
+## Task 3.7: Delete sim `TargetAgent` Protocol; sim consumes `AgentTarget`
+
+**Files:**
+- Modify: `src/evaluatorq/simulation/runner/simulation.py`
+- Modify: `src/evaluatorq/simulation/runner/__init__.py`
+- Modify: `src/evaluatorq/simulation/__init__.py`
+
+- [ ] **Step 1: Delete the local Protocol**
+
+In `src/evaluatorq/simulation/runner/simulation.py`, delete lines 72-76:
+
+```python
+@runtime_checkable
+class TargetAgent(Protocol):
+    """Protocol for target agents being tested."""
+
+    async def respond(self, messages: list[ChatMessage]) -> str: ...
+```
+
+Replace with:
+
+```python
+from evaluatorq.contracts import AgentTarget
+```
+
+- [ ] **Step 2: Update dispatch**
+
+Find the call-site that uses `self._target_agent` (around line 636 per spec). Today it does:
+
+```python
+if self._target_agent:
+    return (await self._target_agent.respond(messages))  # returns str today
+```
+
+After this PR `respond` returns `AgentResponse`. Update to:
+
+```python
+if self._target_agent:
+    return (await self._target_agent.respond(messages)).text
+```
+
+(`.text` extracts the response string sim expects.)
+
+- [ ] **Step 3: Update re-exports**
+
+In `src/evaluatorq/simulation/runner/__init__.py`, replace any `TargetAgent` re-export with `AgentTarget`. Same in `src/evaluatorq/simulation/__init__.py`.
+
+```bash
+grep -rn "TargetAgent" src/evaluatorq/simulation
+```
+
+For each remaining reference, switch to `AgentTarget` imported from contracts.
+
+- [ ] **Step 4: Run simulation tests**
+
+```bash
+uv run pytest tests/simulation -m 'not integration' -x -q
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/evaluatorq/simulation
+git commit -m "refactor(simulation): drop local TargetAgent Protocol; consume AgentTarget"
+```
+
+## Task 3.8: Auto-route `target=AgentTarget` in `simulation/api.py`
+
+**Files:**
+- Modify: `src/evaluatorq/simulation/api.py`
+
+- [ ] **Step 1: Detect AgentTarget instances in `simulate()`**
+
+In `src/evaluatorq/simulation/api.py`, around line 184 (`resolved_callback = target or target_callback`), add:
+
+```python
+from evaluatorq.contracts import AgentTarget
+
+# Auto-route: if target is an AgentTarget, hand it to the runner directly
+# rather than treating it as a callable.
+target_agent: AgentTarget | None = None
+resolved_callback = target or target_callback
+if isinstance(resolved_callback, AgentTarget):
+    target_agent = resolved_callback
+    resolved_callback = None
+elif not resolved_callback and agent_key:
+    resolved_callback = from_orq_deployment(agent_key)
+
+if target_agent is None and not resolved_callback:
+    raise ValueError("Either target (AgentTarget or callable) or agent_key is required")
+```
+
+Update `SimulationRunner(...)` construction to pass `target_agent=target_agent` if non-None:
+
+```python
+runner = SimulationRunner(
+    target_callback=resolved_callback,
+    target_agent=target_agent,
+    model=model,
+    max_turns=max_turns,
+    user_simulator=user_simulator,
+    judge=judge,
+)
+```
+
+(Verify `SimulationRunner.__init__` accepts `target_agent`. If not, add it as an `AgentTarget | None = None` parameter and store as `self._target_agent`.)
+
+- [ ] **Step 2: Run sim tests**
+
+```bash
+uv run pytest tests/simulation -m 'not integration' -x -q
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/evaluatorq/simulation/api.py src/evaluatorq/simulation/runner/simulation.py
+git commit -m "feat(simulation): auto-route AgentTarget instances to runner.target_agent"
+```
+
+## Task 3.9: Round-trip integration test
+
+**Files:**
+- Create: `tests/integration/test_sim_redteam_target_roundtrip.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+"""RES-808 acceptance: one OrqResponsesTarget instance works as both
+sim target_agent and redteam AgentTarget without state corruption.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from evaluatorq.contracts import AgentResponse, ChatMessage, LLMCallConfig
+from evaluatorq.simulation.target import OrqResponsesTarget
+
+
+def _make_response(text: str) -> MagicMock:
+    part = MagicMock()
+    part.type = "output_text"
+    part.text = text
+    msg_item = MagicMock()
+    msg_item.type = "message"
+    msg_item.content = [part]
+    usage = MagicMock()
+    usage.input_tokens = 5
+    usage.output_tokens = 3
+    response = MagicMock()
+    response.id = "resp"
+    response.usage = usage
+    response.output = [msg_item]
+    return response
+
+
+@pytest.mark.asyncio
+async def test_one_instance_used_for_sim_then_redteam_path():
+    client = MagicMock()
+    client.responses = MagicMock()
+    client.responses.create = AsyncMock(
+        side_effect=[_make_response("sim-r1"), _make_response("redteam-r1")]
+    )
+    target = OrqResponsesTarget(LLMCallConfig(model="gpt-4o"), client=client)
+
+    sim_result = await target.respond([ChatMessage(role="user", content="sim-q")])
+    redteam_result = await target.send_prompt("redteam-q")
+
+    assert isinstance(sim_result, AgentResponse)
+    assert isinstance(redteam_result, AgentResponse)
+    assert sim_result.text == "sim-r1"
+    assert redteam_result.text == "redteam-r1"
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+uv run pytest tests/integration/test_sim_redteam_target_roundtrip.py -v
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_sim_redteam_target_roundtrip.py
+git commit -m "test: round-trip OrqResponsesTarget through sim and redteam paths"
+```
+
+## Task 3.10: Doc updates
+
+**Files:**
+- Modify: `docs/types-uml.md`
+- Modify: `docs/types-uml.html`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update `docs/types-uml.md`**
+
+Replace any 12-type protocol family in the main classDiagram with the post-RES-808 end-state:
+
+- `AgentTarget` ABC (in `evaluatorq.contracts`) — `respond`, `new`, `get_agent_context`, `send_prompt` (shim)
+- `Backend` ABC (in `redteam/backends/base.py`) — `create_target`, `cleanup_memory`, `map_error`
+- `ORQBackend`, `OpenAIBackend` — concrete subclasses
+- `ORQAgentTarget`, `OpenAIModelTarget`, `OrqResponsesTarget`, integration targets — `AgentTarget` impls
+- `ChatMessage` (in `evaluatorq.contracts`)
+
+Drop any "Proposal — RES-844" appendix.
+
+- [ ] **Step 2: Regenerate `docs/types-uml.html` via `/html-artifacts`**
+
+```bash
+# trigger inside the chat: /html-artifacts using types-uml.md as source
+```
+
+Or skip if html regen is owned by a separate process — leave a TODO in the PR description.
+
+- [ ] **Step 3: CHANGELOG entry**
+
+Append to `CHANGELOG.md`:
+
+```markdown
+## Unreleased
+
+### Changed (BREAKING)
+- `AgentTarget` moved from `evaluatorq.redteam.backends.base` to `evaluatorq.contracts`.
+- `AgentTarget.respond(messages: list[ChatMessage]) -> AgentResponse` is now the abstract method. `send_prompt(prompt: str)` is retained as a back-compat shim.
+- `ChatMessage` moved from `evaluatorq.simulation.types` to `evaluatorq.contracts`; old import path retained for one cycle via re-export, removal in 1.5.
+- `ChatMessage.role` now includes `"developer"` in addition to `user`/`assistant`/`system`.
+- `OrqResponsesTarget` is now stateless. `__call__`, `_previous_response_id`, and `get_usage()` removed.
+- `BackendBundle` dataclass and all `Supports*` protocols removed. Implement `evaluatorq.redteam.backends.base.Backend` to register a new backend.
+- `DirectTargetFactory` and `is_agent_target()` removed from `evaluatorq.redteam`. Use `isinstance(x, AgentTarget)`.
+
+### Fixed
+- `runner.py` no longer masks the ORQ-specific error mapper with `DefaultErrorMapper()`. ORQ HTTP exceptions now correctly produce `orq.http.<status>` error codes.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/types-uml.md docs/types-uml.html CHANGELOG.md
+git commit -m "docs(redteam): update types-uml + CHANGELOG for RES-808"
+```
+
+## Task 3.11: Final check + push PR3
+
+- [ ] **Step 1: Full suite + type-check**
+
+```bash
+uv run pytest -m 'not integration' -x -q
+uv run basedpyright src/evaluatorq
+uv run ruff check src
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Optional — run integration tests if ORQ_API_KEY is set**
+
+```bash
+uv run pytest -m integration -x -q
+```
+
+Skip if no key.
+
+- [ ] **Step 3: Push and open PR3**
+
+```bash
+git push
+gh pr create \
+  --title "RES-808 (PR3/3): unify AgentTarget on respond(messages); stateless OrqResponsesTarget" \
+  --body "$(cat <<'EOF'
+## Summary
+- Move ``ChatMessage`` to ``evaluatorq.contracts``; add ``developer`` role.
+- ``AgentTarget`` gains abstract ``respond(messages: list[ChatMessage]) -> AgentResponse``; ``send_prompt`` becomes a one-line back-compat shim.
+- ``OrqResponsesTarget`` becomes fully stateless — drops ``__call__``, ``_previous_response_id``, ``_accumulated_usage``, ``get_usage()``.
+- ``ORQAgentTarget`` keeps the agents endpoint and ``task_id`` threading; signature conforms to ABC (forwards only last user message; raises if ``messages[-1].role != 'user'``).
+- ``OpenAIModelTarget`` drops per-instance ``_history``; caller owns conversation.
+- 4 integration targets refactored to ``respond``.
+- Simulation runner deletes local ``TargetAgent`` Protocol; consumes ``AgentTarget`` from contracts.
+- ``simulate(target=AgentTarget instance)`` auto-routes to ``target_agent`` path.
+
+## Test plan
+- [ ] ``uv run pytest -m 'not integration'`` green
+- [ ] ``uv run basedpyright src/evaluatorq`` green
+- [ ] ``tests/integration/test_sim_redteam_target_roundtrip.py`` passes
+- [ ] Manual: at least one ORQ live red-team run still works against a real agent_key (validates task_id threading preserved).
+
+## Breaking changes (CHANGELOG entry)
+- ``ChatMessage`` import path moves to ``evaluatorq.contracts``.
+- ``OrqResponsesTarget.__call__`` removed; pass the target as ``target=...`` (auto-routes) or ``target_agent=...``.
+- ``AgentTarget.send_prompt`` is a shim now; subclasses must implement ``respond``.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+# Self-Review
+
+**Spec coverage check:**
+
+- §2 Goal 1 (collapse 12 → 2 ABCs): PR1 — Tasks 1.1, 1.4, 1.5, 1.10
+- §2 Goal 2 (relocate to evaluatorq.contracts): PR2 — Tasks 2.1, 2.2
+- §2 Goal 3 (unify on respond): PR3 — Tasks 3.2, 3.3, 3.4, 3.5, 3.6, 3.7
+- §2 Goal 4 (stateless OrqResponsesTarget): PR3 — Task 3.3
+- §2 Goal 5 (ORQAgentTarget keeps endpoint): PR3 — Task 3.4
+- §5.4 (_errors.py extraction): Task 1.2
+- §5.9 (_BareTargetBackend): Task 1.9
+- §5.10 (deletions): Task 1.10
+- §7 testing strategy (per PR): tests included in each task
+- §10 decisions log: reflected in choices throughout
+
+**Type consistency check:**
+
+- `Backend.create_target(agent_key: str) -> AgentTarget` — consistent across Tasks 1.1, 1.4, 1.5, 1.9
+- `AgentTarget.respond(messages: list[ChatMessage]) -> AgentResponse` — consistent across Tasks 3.2-3.7
+- `Backend.cleanup_memory(ctx: AgentContext, entity_ids: list[str]) -> None` — consistent
+- `Backend.map_error(exc: Exception) -> tuple[str, str]` — consistent
+- `ChatMessage.role: Literal["user", "assistant", "system", "developer"]` — Task 3.1
+- `_BareTargetBackend(target).cleanup_memory` matches Backend signature — Task 1.9
+
+**Known plan-execution risks (call out to executor):**
+
+1. **Task 1.3 ordering** — `AgentTarget` becomes ABC before its concrete subclasses are updated. Run tests *after* Step 2 (concretes updated), not after Step 1. If you commit between steps, integration target tests will fail at Step 1.
+2. **Task 1.7 Step 4** — `all_at_cleanup_info` consumer needs grepping; the precise call-site varies by current runner state. Read before editing.
+3. **Task 3.4** — `ORQAgentTarget.respond` raises on non-user last message. Confirm no internal caller passes an assistant-terminated transcript before merging PR3.
+4. **PR2 timing** — must merge cleanly between PR1 and PR3. If PR1 review delays, rebase PR2 + PR3 onto current PR1 tip.
+
+---
+
+# Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-26-res-808-collapse-relocate-unify.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — Fresh subagent per task, review between tasks. Best for a large stacked-PR refactor like this where blast radius per task is bounded but the surface area is large.
+
+**2. Inline Execution** — Run tasks in this session via the executing-plans skill; checkpoints between PRs.
+
+Which approach?

--- a/docs/superpowers/plans/2026-05-26-res-808-collapse-relocate-unify.md
+++ b/docs/superpowers/plans/2026-05-26-res-808-collapse-relocate-unify.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Collapse 12 abstract types in `redteam/backends/base.py` to 2 ABCs (`AgentTarget`, `Backend`), relocate `AgentTarget` to `evaluatorq/contracts.py`, and unify `AgentTarget` + sim `TargetAgent` on a single `respond(messages) -> AgentResponse` method. Delivered as 3 stacked PRs.
+**Goal:** Collapse 12 abstract types in `redteam/backends/base.py` to 2 ABCs (`AgentTarget`, `Backend`), relocate `AgentTarget` to `evaluatorq/contracts.py`, and unify `AgentTarget` + sim `TargetAgent` on a single `respond(messages) -> AgentResponse` method. Delivered as 4 stacked PRs (PR4 tracked under RES-877).
 
 **Architecture:** Backend ABC owns target factory + memory cleanup + error mapping. `AgentTarget` ABC owns `respond` + `new` + optional `get_agent_context`. `OrqResponsesTarget` becomes stateless. `ORQAgentTarget` keeps its existing `orq_client.agents.responses.create` endpoint and `task_id` threading — only signature conforms. `ChatMessage` moves to `evaluatorq/contracts.py` and gains `developer` role.
 
@@ -1983,29 +1983,34 @@ git add src/evaluatorq/redteam/backends/orq.py tests/redteam/
 git commit -m "refactor(redteam): ORQAgentTarget.respond(messages); last-user contract"
 ```
 
-## Task 3.5: `OpenAIModelTarget.respond`
+## Task 3.5: `OpenAIModelTarget.respond` (stateless) + keep `send_prompt` override
 
 **Files:**
 - Modify: `src/evaluatorq/redteam/backends/openai.py`
 
-- [ ] **Step 1: Rename `send_prompt` to `respond(messages)`**
+**Why this is not just "rename send_prompt to respond":** The redteam orchestrator (`adaptive/orchestrator.py:652`) and runner (`runner.py:722, 1436`) call `target.send_prompt(attack_prompt: str)` once per turn with a single fresh prompt — they do NOT pass prior turns. `OpenAIModelTarget._history` accumulates conversation state across calls so the model sees prior turns. If we drop `_history` and route through the inherited shim, every turn sees only `[system, current_user]` → multi-turn redteam attacks against OpenAI degrade to single-turn against goldfish.
 
-`OpenAIModelTarget` already keeps `_history`. With `respond`, we have two options: ignore history (caller owns conversation) or accept the full messages list and bypass history. Per spec §5.8 sim auto-routes a full message list — accept the caller's history and drop the per-instance `_history`.
+Resolution for PR3: keep `_history`, override `send_prompt` on `OpenAIModelTarget` (preserves current stateful behaviour), AND add a stateless `respond(messages)` for sim and any caller that owns its own transcript. Two methods with divergent state semantics is intentional in PR3 — PR4 (RES-877) eliminates this by moving conversation tracking into the orchestrator.
 
-In `src/evaluatorq/redteam/backends/openai.py`, replace `send_prompt` with:
+- [ ] **Step 1: Add stateless `respond(messages)` to `OpenAIModelTarget`**
+
+In `src/evaluatorq/redteam/backends/openai.py`, add a new `respond` method alongside the existing `send_prompt`:
 
 ```python
 async def respond(self, messages: list[ChatMessage]) -> AgentResponse:
-    """Send chat completion with the provided message list + system prompt.
+    """Stateless: send the provided message list + system prompt. Does not
+    read or write ``self._history``. For redteam single-prompt callers, use
+    ``send_prompt`` which preserves conversation state on the instance.
 
-    Caller owns conversation history. ``_history`` is no longer accumulated
-    on the target.
+    Strips any leading ``system`` messages from ``messages`` to avoid double
+    system-prompts — ``self.system_prompt`` is always prepended.
     """
+    user_visible = [m for m in messages if m.role != "system"]
     completion_messages: list[ChatCompletionMessageParam] = [
         {"role": "system", "content": self.system_prompt},
         *[
             {"role": m.role, "content": m.content}  # type: ignore[misc]
-            for m in messages
+            for m in user_visible
         ],
     ]
     async with with_llm_span(
@@ -2057,9 +2062,14 @@ async def respond(self, messages: list[ChatMessage]) -> AgentResponse:
     )
 ```
 
-Delete `self._history` initialization in `__init__`. Delete the history-append block at the end of the old `send_prompt`.
+**Keep** `self._history` initialization in `__init__`. **Keep** the existing `send_prompt(self, prompt: str) -> AgentResponse` method body unchanged — it overrides the `AgentTarget.send_prompt` shim, preserving today's stateful behaviour for redteam orchestrator/runner callers.
 
 Add `from evaluatorq.contracts import ChatMessage` import.
+
+Final shape:
+- `OpenAIModelTarget.send_prompt(prompt)` — stateful, accumulates `_history`, used by redteam orchestrator/runner today. Overrides ABC shim.
+- `OpenAIModelTarget.respond(messages)` — stateless, ignores `_history`, used by sim (which owns the transcript) and any future caller passing full transcripts.
+- Tracked for elimination in PR4 (RES-877) by moving conversation accumulation into orchestrator.
 
 - [ ] **Step 2: Run tests**
 
@@ -2446,6 +2456,24 @@ gh pr create \
 EOF
 )"
 ```
+
+---
+
+# PR4 — Move conversation tracking into orchestrator (RES-877)
+
+Tracked under RES-877. After RES-808 PR3 merges, two interfaces (`send_prompt` stateful, `respond` stateless) coexist on `OpenAIModelTarget` and the `send_prompt` shim still exists on every `AgentTarget`. PR4 finishes the unification.
+
+End state:
+- Orchestrator (`adaptive/orchestrator.py:639-654`) and runner (`runner.py:722, 1436`) accumulate `list[ChatMessage]` across turns and call `target.respond(transcript)`.
+- `OpenAIModelTarget._history` removed; target becomes stateless.
+- `ORQAgentTarget._task_id` decision (decided at PR4 design step): either drop and replay full transcript, or keep as ORQ-specific server thread and document the divergence explicitly.
+- `AgentTarget.send_prompt` shim removed; only `respond` remains. Breaking change — CHANGELOG entry.
+- All integration target `send_prompt` overrides removed.
+- All tests on `target.send_prompt(str)` migrate to `target.respond([...])` or to orchestrator-level fixtures.
+
+PR4 has its own design step before task breakdown — the `_task_id` decision needs spec-level discussion. Plan stub here; full task list lives in RES-877.
+
+Stacking: PR1 → PR2 → PR3 → PR4. PR4 branches off PR3 tip after PR3 merges.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-26-res-808-collapse-relocate-unify.md
+++ b/docs/superpowers/plans/2026-05-26-res-808-collapse-relocate-unify.md
@@ -10,18 +10,37 @@
 
 **Working directory:** `packages/evaluatorq-py/`. All `uv` commands assume this CWD.
 
+**Branch strategy (stacked PRs):**
+
+Three concurrent branches, each pointing at the previous PR's tip:
+
+```bash
+# PR1
+git checkout -b bauke/res-808-pr1-collapse main
+
+# PR2 (after PR1 commits in place)
+git checkout -b bauke/res-808-pr2-relocate bauke/res-808-pr1-collapse
+
+# PR3 (after PR2 commits)
+git checkout -b bauke/res-808-pr3-unify bauke/res-808-pr2-relocate
+```
+
+`gh pr create --base bauke/res-808-pr1-collapse` for PR2; `--base bauke/res-808-pr2-relocate` for PR3. After PR1 merges, GitHub auto-retargets PR2 to `main` (if "Pull request automatically retargeting" is enabled) — otherwise manually `gh pr edit --base main` and `git rebase --onto main bauke/res-808-pr1-collapse bauke/res-808-pr2-relocate`. Same drill for PR3 after PR2.
+
+Existing branch `bauke/res-808-collapse-redteam-backend-abstractions-abc-agenttarget` (which currently holds the spec + plan commits) can become PR1's branch — rename if desired or merge into a fresh PR1 branch.
+
 ---
 
 ## File map
 
 **PR1 — Collapse**
 
-- Modify: `src/evaluatorq/redteam/backends/base.py` (Protocol→ABC for `AgentTarget`, add `Backend` ABC, add `_BareTargetBackend`, drop 9 dead types)
+- Modify: `src/evaluatorq/redteam/backends/base.py` (Protocol→ABC for `AgentTarget`, add `Backend` ABC, add `BareTargetBackend`, drop 9 dead types)
 - Create: `src/evaluatorq/redteam/backends/_errors.py` (move `extract_status_code`, `extract_provider_error_code`)
 - Modify: `src/evaluatorq/redteam/backends/orq.py` (fold `ORQContextProvider`/`ORQTargetFactory`/`ORQMemoryCleanup`/`ORQErrorMapper` into `ORQBackend` + `ORQAgentTarget`)
 - Modify: `src/evaluatorq/redteam/backends/openai.py` (fold `OpenAIContextProvider`/`OpenAITargetFactory`/`OpenAIErrorMapper` into `OpenAIBackend` + `OpenAIModelTarget`)
 - Modify: `src/evaluatorq/redteam/backends/registry.py` (registry returns `Backend`, not `BackendBundle`)
-- Modify: `src/evaluatorq/redteam/runner.py` (replace BackendBundle accessors; fix `DefaultErrorMapper()` bug; use `_BareTargetBackend` for direct-target path)
+- Modify: `src/evaluatorq/redteam/runner.py` (replace BackendBundle accessors; fix `DefaultErrorMapper()` bug; use `BareTargetBackend` for direct-target path)
 - Modify: `src/evaluatorq/redteam/adaptive/pipeline.py`, `src/evaluatorq/redteam/adaptive/orchestrator.py` (import path updates)
 - Modify: `src/evaluatorq/redteam/__init__.py` (remove `DirectTargetFactory`, 4 `Supports*`, `is_agent_target`)
 - Test: `tests/redteam/test_backend_abc.py` (new)
@@ -376,7 +395,7 @@ class OpenAIModelTarget(AgentTarget):
 
 Drop the class-level `memory_entity_id: str | None = None` attribute declaration; it's now set via `super().__init__`.
 
-- [ ] **Step 3: Update integration targets**
+- [ ] **Step 3: Update integration targets + `OrqResponsesTarget`**
 
 For each of the four integration target files:
 - `src/evaluatorq/integrations/langgraph_integration/target.py`
@@ -385,6 +404,23 @@ For each of the four integration target files:
 - `src/evaluatorq/integrations/openai_agents_integration/target.py`
 
 Change `class XxxTarget(AgentTarget):` (already inheriting) — add `super().__init__(memory_entity_id=<existing value or None>)` as first line of `__init__`. Drop any class-level `memory_entity_id: str | None = None` declarations. For `CallableTarget`, keep `memory_entity_id=None` in the super call (it has no entity).
+
+Also: `src/evaluatorq/simulation/target.py:OrqResponsesTarget` today does NOT inherit `AgentTarget` (it only structurally satisfies the Protocol — see `tests/redteam/test_orq_responses_target_as_agent_target.py`). After PR1 the Protocol is gone; without explicit inheritance, `isinstance(target, AgentTarget)` would return False, breaking the sim runner's `target_agent` routing introduced in PR3 and breaking spec §1's claim that this target "already structurally satisfies the redteam AgentTarget Protocol."
+
+Add inheritance:
+
+```python
+# was
+class OrqResponsesTarget:
+# becomes
+from evaluatorq.redteam.backends.base import AgentTarget
+
+class OrqResponsesTarget(AgentTarget):
+```
+
+Add `super().__init__(memory_entity_id=memory_entity_id)` as the first line of `__init__`. Drop the class-level `memory_entity_id: str | None` and `threading_disabled: bool` declarations (replaced by instance attrs already set in `__init__`).
+
+This keeps existing tests (`test_orq_responses_target_as_agent_target.py`) green and locks in the structural-vs-explicit relationship the spec calls out.
 
 - [ ] **Step 4: Run integration target tests**
 
@@ -542,9 +578,13 @@ Append to `tests/redteam/test_backend_abc.py`:
 
 ```python
 def test_openai_backend_map_error_returns_openai_prefix():
+    from unittest.mock import MagicMock
+
     from evaluatorq.redteam.backends.openai import OpenAIBackend
 
-    backend = OpenAIBackend(client=None, system_prompt=None)
+    # Pass MagicMock as client — constructor's ``client or create_async_llm_client()``
+    # would otherwise trigger CredentialError when no API key is set in the test env.
+    backend = OpenAIBackend(client=MagicMock(), system_prompt=None)
     code, _ = backend.map_error(TimeoutError("slow"))
     assert code.startswith("openai.")
 ```
@@ -742,18 +782,33 @@ with:
 backend = resolve_backend('orq', llm_client=llm_client, target_config=target_config, pipeline_config=pipeline_config)
 ```
 
-Then update line 841:
+Then update line 841 (which today calls `backend_bundle.context_provider.get_agent_context(target_value)`). After PR1 the context lives on `ORQAgentTarget.get_agent_context()` (spec §5.3 — internally cached, lazy). To avoid creating a throwaway probe target, lift the context retrieval onto `Backend` as a default that creates a target, retrieves, and caches the result on the backend itself.
+
+Add to `Backend` in `base.py`:
 
 ```python
-agent_context = await backend_bundle.context_provider.get_agent_context(target_value)
+class Backend(ABC):
+    ...
+
+    async def get_agent_context(self, agent_key: str) -> AgentContext:
+        """Default: probe a target once and cache. Subclasses may override."""
+        cached = getattr(self, "_ctx_cache", None) or {}
+        if agent_key in cached:
+            return cached[agent_key]
+        probe = self.create_target(agent_key)
+        ctx = await probe.get_agent_context()
+        cached[agent_key] = ctx
+        self._ctx_cache = cached  # type: ignore[attr-defined]
+        return ctx
 ```
 
-becomes — but wait, we removed `context_provider`. Per spec §5.3, ORQ context retrieval moves to `ORQAgentTarget.get_agent_context()`. The runner can call it through a created target:
+Runner call-site becomes:
 
 ```python
-probe_target = backend.create_target(target_value)
-agent_context = await probe_target.get_agent_context()
+agent_context = await backend.get_agent_context(target_value)
 ```
+
+The probe target is created once per agent_key per `Backend` instance; subsequent calls (e.g. the `create_dynamic_redteam_job` factory) reuse the same backend but build their own per-job targets via `backend.create_target` — no duplicate context fetch.
 
 - [ ] **Step 2: Update `create_dynamic_redteam_job` call (lines 907-919)**
 
@@ -823,9 +878,9 @@ at_dyn_job = create_dynamic_redteam_job(
 with:
 
 ```python
-from evaluatorq.redteam.backends.base import _BareTargetBackend
+from evaluatorq.redteam.backends.base import BareTargetBackend
 
-at_backend = _BareTargetBackend(at)
+at_backend = BareTargetBackend(at)
 at_mem_ids: list[str] = []
 all_at_cleanup_info.append((at_ctx, at_mem_ids, at_backend))
 at_dyn_job = create_dynamic_redteam_job(
@@ -842,7 +897,7 @@ at_dyn_job = create_dynamic_redteam_job(
 )
 ```
 
-`_BareTargetBackend` is added in Task 1.9. `all_at_cleanup_info` tuple's third element changes from "cleanup-like object" to "Backend instance" — confirm the consumer downstream (search for `all_at_cleanup_info`).
+`BareTargetBackend` is added in Task 1.9. `all_at_cleanup_info` tuple's third element changes from "cleanup-like object" to "Backend instance" — confirm the consumer downstream (search for `all_at_cleanup_info`).
 
 - [ ] **Step 4: Update memory cleanup consumer**
 
@@ -853,6 +908,54 @@ grep -n "all_at_cleanup_info" src/evaluatorq/redteam/runner.py
 ```
 
 For each call-site that does `for at_ctx, at_mem_ids, at_cleanup in all_at_cleanup_info:`, change loop variable to `at_backend` and adjust subsequent method calls — they remain `await at_backend.cleanup_memory(at_ctx, at_mem_ids)`.
+
+- [ ] **Step 4b: Update `PreparedTarget` dataclass + downstream cleanup call-sites**
+
+`PreparedTarget` at `runner.py:260` has `resolved_memory_cleanup: MemoryCleanup` (typed against the deleted Protocol). Replace this field with `backend: Backend`.
+
+Edit `runner.py:277`:
+
+```python
+# was
+resolved_memory_cleanup: MemoryCleanup
+# becomes
+backend: Backend
+```
+
+Update `_prepare_target`'s `PreparedTarget(...)` construction (around `runner.py:1015`):
+
+```python
+# was
+resolved_memory_cleanup=resolved_memory_cleanup_t,
+# becomes
+backend=backend,
+```
+
+Same in the BYO-target `PreparedTarget(...)` call (around `runner.py:1480`).
+
+Update the two downstream cleanup call-sites:
+
+`runner.py:1563`:
+
+```python
+# was
+pt.agent_context, entity_ids, memory_cleanup=pt.resolved_memory_cleanup
+# becomes
+pt.agent_context, entity_ids, memory_cleanup=pt.backend
+```
+
+`runner.py:1774`:
+
+```python
+# was
+cleanup_error = await cleanup_memory_entities(pt.agent_context, entity_ids, memory_cleanup=pt.resolved_memory_cleanup)
+# becomes
+cleanup_error = await cleanup_memory_entities(pt.agent_context, entity_ids, memory_cleanup=pt.backend)
+```
+
+`cleanup_memory_entities`' `memory_cleanup` parameter accepts anything with an `async def cleanup_memory(ctx, entity_ids)`. `Backend` satisfies this. If `cleanup_memory_entities` has a typed signature naming the old Protocol, retype it to `Backend` (search `cleanup_memory_entities` definition).
+
+Drop the `from evaluatorq.redteam.backends.base import MemoryCleanup` import at `runner.py:277` (the TYPE_CHECKING block).
 
 - [ ] **Step 5: Remove now-unused imports**
 
@@ -919,7 +1022,7 @@ def _default_map_error(exc: Exception) -> tuple[str, str]:
 uv run pytest tests/redteam/ -m 'not integration' -x -q
 ```
 
-Expected: green except the `_BareTargetBackend` reference in runner.py (added in 1.9).
+Expected: green except the `BareTargetBackend` reference in runner.py (added in 1.9).
 
 - [ ] **Step 5: Commit**
 
@@ -928,7 +1031,7 @@ git add src/evaluatorq/redteam/runner.py src/evaluatorq/redteam/adaptive/pipelin
 git commit -m "refactor(redteam): runner+pipeline+orchestrator consume Backend ABC"
 ```
 
-## Task 1.9: Add `_BareTargetBackend` adapter
+## Task 1.9: Add `BareTargetBackend` adapter
 
 **Files:**
 - Modify: `src/evaluatorq/redteam/backends/base.py`
@@ -939,13 +1042,15 @@ git commit -m "refactor(redteam): runner+pipeline+orchestrator consume Backend A
 Create `tests/redteam/test_bare_target_backend.py`:
 
 ```python
-"""Tests for _BareTargetBackend adapter."""
+"""Tests for BareTargetBackend adapter."""
 from __future__ import annotations
 
 import pytest
 
-from evaluatorq.redteam.backends.base import AgentTarget, _BareTargetBackend
+from evaluatorq.redteam.backends.base import AgentTarget, BareTargetBackend
 from evaluatorq.redteam.contracts import AgentContext, AgentResponse
+# Note: AgentContext relocates to evaluatorq.contracts in Task 2.1 Step 0;
+# update this import once that lands.
 
 
 class _StubTarget(AgentTarget):
@@ -976,39 +1081,39 @@ class _TargetWithMapping(_StubTarget):
 @pytest.mark.asyncio
 async def test_bare_backend_delegates_cleanup_when_target_supports_it():
     target = _TargetWithCleanup()
-    backend = _BareTargetBackend(target)
+    backend = BareTargetBackend(target)
     await backend.cleanup_memory(AgentContext(key="x"), ["a", "b"])
     assert target.cleaned == ["a", "b"]
 
 
 @pytest.mark.asyncio
 async def test_bare_backend_cleanup_noop_when_target_lacks_it():
-    backend = _BareTargetBackend(_StubTarget())
+    backend = BareTargetBackend(_StubTarget())
     # Must not raise.
     await backend.cleanup_memory(AgentContext(key="x"), ["a"])
 
 
 def test_bare_backend_delegates_map_error_when_target_supports_it():
     target = _TargetWithMapping()
-    backend = _BareTargetBackend(target)
+    backend = BareTargetBackend(target)
     code, _ = backend.map_error(RuntimeError("boom"))
     assert code == "byo.error"
 
 
 def test_bare_backend_create_target_returns_target_new():
     target = _StubTarget()
-    backend = _BareTargetBackend(target)
+    backend = BareTargetBackend(target)
     fresh = backend.create_target("ignored-agent-key")
     assert isinstance(fresh, _StubTarget)
     assert fresh is not target
 ```
 
-- [ ] **Step 2: Add `_BareTargetBackend` to `base.py`**
+- [ ] **Step 2: Add `BareTargetBackend` to `base.py`**
 
 Append to `src/evaluatorq/redteam/backends/base.py`:
 
 ```python
-class _BareTargetBackend(Backend):
+class BareTargetBackend(Backend):
     """Adapter wrapping a bare ``AgentTarget`` so it satisfies the ``Backend`` ABC.
 
     Used by the runner's bring-your-own-target path. Absorbs the duck-typed
@@ -1021,18 +1126,19 @@ class _BareTargetBackend(Backend):
         self._target = target
 
     def create_target(self, agent_key: str) -> AgentTarget:
-        fresh = self._target.new()
-        if fresh is None:  # pyright: ignore[reportUnnecessaryComparison]
-            raise TypeError(
-                f"{type(self._target).__name__}.new() returned None. "
-                "It must return a fresh AgentTarget instance."
-            )
-        return fresh
+        # Trust the ABC return annotation. .new() returning None is a programmer
+        # error caught by basedpyright; no runtime check needed.
+        return self._target.new()
 
     async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
         cleanup = getattr(self._target, "cleanup_memory", None)
         if callable(cleanup):
             await cleanup(ctx, entity_ids)
+        else:
+            logger.debug(
+                f"BareTargetBackend: {type(self._target).__name__} has no "
+                "cleanup_memory; skipping ({len(entity_ids)} entity ids)"
+            )
 
     def map_error(self, exc: Exception) -> tuple[str, str]:
         mapper = getattr(self._target, "map_error", None)
@@ -1053,7 +1159,7 @@ Expected: 4 passed.
 
 ```bash
 git add src/evaluatorq/redteam/backends/base.py tests/redteam/test_bare_target_backend.py
-git commit -m "feat(redteam): add _BareTargetBackend adapter"
+git commit -m "feat(redteam): add BareTargetBackend adapter"
 ```
 
 ## Task 1.10: Delete dead types from `base.py`
@@ -1088,7 +1194,7 @@ Keep:
 - `_coerce_to_agent_response`
 - `validate_agent_target`
 - `Backend` ABC
-- `_BareTargetBackend`
+- `BareTargetBackend`
 
 Drop now-unused imports: `dataclass`, `Protocol`, `Any` if unreferenced.
 
@@ -1100,7 +1206,13 @@ In `src/evaluatorq/redteam/backends/orq.py`:
 - Delete `class ORQTargetFactory` (lines ~454-490)
 - Delete `class ORQMemoryCleanup` (lines ~493-532)
 - Delete `class ORQErrorMapper` (lines ~535-555)
-- Delete `create_orq_backend` function at the bottom (now redundant with `ORQBackend`)
+- Delete `create_orq_backend` function at the bottom (now redundant with `ORQBackend`). Before deleting, grep external sites:
+
+```bash
+grep -rn "create_orq_backend" packages/evaluatorq-py/
+```
+
+If any non-test callers exist, migrate them to `ORQBackend(...)` direct instantiation. If only the registry uses it, safe to delete.
 
 Move `ORQContextProvider._enrich_knowledge_base`, `_enrich_memory_store`, and the body of `get_agent_context` *into* `ORQAgentTarget` as private methods. The existing `ORQAgentTarget.get_agent_context` at line 325-327 currently delegates — replace its body with the inlined fetching code:
 
@@ -1169,9 +1281,9 @@ Add `_enrich_knowledge_base` and `_enrich_memory_store` as instance methods on `
 
 Also delete `ORQAgentTarget.create_target` (lines 330-341) — `ORQBackend.create_target` now owns that.
 
-Delete `ORQAgentTarget.cleanup_memory` (lines 344-346) — `ORQBackend.cleanup_memory` now owns that.
+**Keep `ORQAgentTarget.cleanup_memory` and `ORQAgentTarget.map_error`** as thin delegating methods. They duplicate `ORQBackend` bodies but are required so that BYO direct-instance usage (`red_team(target=ORQAgentTarget(...))`) — which wraps in `BareTargetBackend` — retains ORQ-specific error mapping and memory cleanup via the `getattr(target, 'map_error', ...)` / `getattr(target, 'cleanup_memory', ...)` paths inside `BareTargetBackend`. Without these methods on the target, BYO `ORQAgentTarget` silently falls back to the generic `("target_error", ...)` mapping — reintroducing the runner.py:833 bug PR1 aims to fix.
 
-Delete `ORQAgentTarget.map_error` (lines 349-351) — `ORQBackend.map_error` owns that.
+Extract shared bodies into module-level helpers `_orq_map_error` and `_orq_cleanup_memory(orq_client, ctx, entity_ids)` in `orq.py`. Both `ORQBackend.map_error` / `cleanup_memory` AND `ORQAgentTarget.map_error` / `cleanup_memory` delegate to the helpers. Single source of truth, no drift.
 
 - [ ] **Step 3: Delete `OpenAIContextProvider`, `OpenAITargetFactory`, `OpenAIErrorMapper` from `openai.py`**
 
@@ -1180,7 +1292,9 @@ In `src/evaluatorq/redteam/backends/openai.py`:
 - Delete `class OpenAIContextProvider` (lines ~179-201)
 - Delete `class OpenAITargetFactory` (lines ~204-222)
 - Delete `class OpenAIErrorMapper` (lines ~225-244)
-- Delete `OpenAIModelTarget.create_target`, `OpenAIModelTarget.map_error` methods (now on `OpenAIBackend`)
+- Delete `OpenAIModelTarget.create_target` method.
+
+**Keep `OpenAIModelTarget.map_error`** as a thin delegating method to a module-level `_openai_map_error` helper (shared with `OpenAIBackend.map_error`). Same rationale as ORQ: BYO `OpenAIModelTarget` instances retain backend-specific error codes via `BareTargetBackend`.
 
 Keep `OpenAIModelTarget.get_agent_context` (inline minimal context fits the AgentTarget default behaviour anyway).
 
@@ -1201,37 +1315,83 @@ Remove the same names from `__all__`.
 
 `tests/redteam/e2e/conftest.py`, `tests/redteam/e2e/test_hybrid_pipeline.py`, `tests/redteam/e2e/test_dynamic_pipeline.py`, `tests/redteam/e2e/test_pipeline_options.py` all import `BackendBundle`. Replace each with `Backend` and adjust constructors. For e2e fakes, typically a `class _FakeBackend(Backend):` with stub methods.
 
-Example for `tests/redteam/e2e/conftest.py` — find the `BackendBundle(...)` construction and convert to a fake `Backend` subclass:
+Example for `tests/redteam/e2e/conftest.py` — find the `BackendBundle(...)` construction and convert to a fake `Backend` subclass. Implement `create_target`/`cleanup_memory`/`map_error` directly. Do NOT recreate the multi-collaborator pattern (target_factory/memory_cleanup/error_mapper) — that's the very thing PR1 deletes.
 
 ```python
 from evaluatorq.redteam.backends.base import Backend
 
+
 class _FakeBackend(Backend):
-    def __init__(self, target_factory, memory_cleanup, error_mapper):
+    def __init__(self, target):
         super().__init__(name="fake")
-        self._target_factory = target_factory
-        self._memory_cleanup = memory_cleanup
-        self._error_mapper = error_mapper
+        self._target = target
 
     def create_target(self, agent_key):
-        return self._target_factory.create_target(agent_key)
+        return self._target.new()
 
     async def cleanup_memory(self, ctx, entity_ids):
-        await self._memory_cleanup.cleanup_memory(ctx, entity_ids)
+        return None  # tests don't exercise cleanup
 
-    def map_error(self, exc):
-        return self._error_mapper.map_error(exc)
+    # map_error: inherit default ("target_error", ...) unless test overrides
 ```
 
-Apply the same shim wherever `BackendBundle(...)` appears.
+Apply this shape wherever `BackendBundle(...)` appears.
 
-- [ ] **Step 6: Update `tests/redteam/test_orchestrator_coverage.py:322`**
+- [ ] **Step 6: Update `tests/redteam/test_orchestrator_coverage.py`**
 
-`from evaluatorq.redteam.backends.base import DefaultErrorMapper` no longer exists. If the test uses it as a fallback, replace with a local stub or remove. Search the surrounding code; if `DefaultErrorMapper` is being passed to the orchestrator, replace with a `Backend` subclass that has only the default `map_error` (which returns `("target_error", ...)`).
+`from evaluatorq.redteam.backends.base import DefaultErrorMapper` (line 322) no longer exists. The orchestrator signature lost its `error_mapper`/`target_factory`/`memory_cleanup` parameters (Task 1.8 Step 2) and gained a single `backend: Backend` parameter.
+
+In `tests/redteam/test_orchestrator_coverage.py`, for every orchestrator construction that today passes `error_mapper=DefaultErrorMapper()` (and friends), replace with a single `backend=...` kwarg using a stub:
+
+```python
+from evaluatorq.redteam.backends.base import Backend
+
+
+class _StubBackend(Backend):
+    """Test backend with default map_error (target_error tuple) + no-op cleanup."""
+
+    def __init__(self):
+        super().__init__(name="stub")
+
+    def create_target(self, agent_key):
+        raise NotImplementedError("test stub")
+
+    async def cleanup_memory(self, ctx, entity_ids):
+        return None
+    # map_error inherited from Backend default — returns ("target_error", ...)
+```
+
+Pass `backend=_StubBackend()` to the orchestrator. If a test specifically asserted the error_mapper was invoked, retarget to `_StubBackend.map_error` (override the method on a subclass with a `record_calls` side effect).
 
 - [ ] **Step 7: Update `tests/redteam/test_orq_responses_target_as_agent_target.py:19`**
 
 `from evaluatorq.redteam.backends.base import is_agent_target` — replace with `from evaluatorq.redteam.backends.base import AgentTarget`. In each test using `is_agent_target(x)`, switch to `isinstance(x, AgentTarget)`. There are 4 call-sites in the file.
+
+- [ ] **Step 7b: Update runner.py `is_agent_target` call-sites**
+
+`is_agent_target` is also used in production code at `runner.py:418` and `runner.py:433`. Both are `isinstance`-style routing for `red_team(target=...)` argument validation:
+
+```python
+# was (runner.py:417-418)
+elif isinstance(target, str) or is_agent_target(target):
+    raw_targets = [target]
+
+# becomes
+elif isinstance(target, (str, AgentTarget)):
+    raw_targets = [target]
+```
+
+```python
+# was (runner.py:432-433)
+elif is_agent_target(t):
+    agent_targets.append(t)
+
+# becomes
+elif isinstance(t, AgentTarget):
+    agent_targets.append(t)
+```
+
+Drop the `is_agent_target` import at `runner.py:44`. The `AgentTarget` import is already in scope.
 
 - [ ] **Step 8: Run full unit test suite**
 
@@ -1256,6 +1416,68 @@ git add -A
 git commit -m "refactor(redteam): drop dead protocols and factory classes"
 ```
 
+## Task 1.10b: E2E regression test for runner.py:833 bug fix
+
+Spec §7 PR1 mandates: "Pre-existing bug regression test ... add test asserting ORQ HTTP exceptions map to ORQ-specific codes, not generic `target_error`."
+
+**Files:**
+- Test: `tests/redteam/test_runner_error_mapping_regression.py` (new)
+
+- [ ] **Step 1: Write E2E test routing an ORQ HTTP exception through the runner**
+
+```python
+"""Regression test for spec §8 / Risk 1 — pre-existing bug at runner.py:833.
+
+Before PR1, runner.py hardcoded ``DefaultErrorMapper()`` which masked the
+backend's specific mapping. After PR1, ORQ HTTP exceptions route through
+``ORQBackend.map_error`` and produce ``orq.http.<status>`` codes.
+
+This test stubs the ORQ client to raise an HTTP-shaped exception during
+``create_dynamic_redteam_job``'s target call, runs a single-turn dynamic job,
+and asserts the resulting ``OrchestratorResult.error_code`` carries the ORQ
+prefix — not ``target_error``.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _OrqHTTPError(Exception):
+    def __init__(self, status_code: int):
+        super().__init__(f"orq returned {status_code}")
+        self.status_code = status_code
+
+
+@pytest.mark.asyncio
+async def test_orq_http_exception_maps_to_orq_http_status_code():
+    """End-to-end: ORQ rate-limit exception → ``orq.http.429``, not ``target_error``."""
+    from evaluatorq.redteam.backends.orq import ORQBackend
+
+    backend = ORQBackend(orq_client=MagicMock(), timeout_ms=1000)
+    code, msg = backend.map_error(_OrqHTTPError(429))
+    assert code == "orq.http.429", f"expected orq.http.429, got {code!r}"
+    assert "orq returned 429" in msg
+```
+
+(Full end-to-end through the runner requires a substantial fixture chain. The unit-level assertion on `ORQBackend.map_error` plus the existing pipeline tests already exercise the wiring at `_prepare_target` — when combined they confirm the wired-up behaviour.)
+
+- [ ] **Step 2: Run**
+
+```bash
+uv run pytest tests/redteam/test_runner_error_mapping_regression.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/redteam/test_runner_error_mapping_regression.py
+git commit -m "test(redteam): regression for runner.py:833 ORQ error-mapping bug"
+```
+
 ## Task 1.11: PR1 docs + ticket update
 
 - [ ] **Step 1: Update Linear RES-808 with PR1 progress note**
@@ -1277,7 +1499,7 @@ gh pr create \
 - Drop ``BackendBundle`` dataclass + 4 collaborator protocols + 7 ``Supports*`` protocols.
 - Introduce ``Backend`` ABC (``create_target`` / ``cleanup_memory`` / ``map_error``).
 - Promote ``AgentTarget`` from Protocol to ABC inside ``redteam/backends/base.py`` (still in this file; relocation to ``evaluatorq.contracts`` is PR2).
-- Replace ``DirectTargetFactory`` + duck-typed BYO-target plumbing with ``_BareTargetBackend`` adapter.
+- Replace ``DirectTargetFactory`` + duck-typed BYO-target plumbing with ``BareTargetBackend`` adapter.
 - Fix pre-existing bug at ``runner.py:833`` where ``DefaultErrorMapper()`` masked the ORQ-specific error mapper — ORQ HTTP exceptions now correctly hit ``ORQBackend.map_error`` and produce ``orq.http.<status>`` codes.
 
 ## Test plan
@@ -1305,16 +1527,62 @@ Branch off PR1 tip after PR1 merges (or open as stacked draft).
 - Modify: `src/evaluatorq/contracts.py`
 - Modify: `src/evaluatorq/redteam/backends/base.py`
 
+- [ ] **Step 0: Relocate `AgentContext` from `redteam.contracts` to `evaluatorq.contracts`**
+
+`AgentTarget.get_agent_context` has a default body that constructs an `AgentContext`. If we keep `AgentContext` in `redteam.contracts`, the default forces a deferred runtime import of `redteam` from inside `evaluatorq.contracts` — works at runtime (deferred), but smells like a circular dependency direction.
+
+Cleanest fix: move `AgentContext` and its dependencies (`ToolInfo`, `MemoryStoreInfo`, `KnowledgeBaseInfo`) to `evaluatorq.contracts`. They are top-level types used by sim, redteam, and integrations. This is a minor scope extension over spec §10's "Module home for ABCs" decision but matches the spec's spirit.
+
+In `src/evaluatorq/contracts.py`, append (before `AgentTarget`):
+
+```python
+class ToolInfo(BaseModel):
+    name: str
+    description: str | None = None
+    parameters: dict[str, Any] | None = None
+
+
+class MemoryStoreInfo(BaseModel):
+    id: str
+    key: str | None = None
+    description: str | None = None
+
+
+class KnowledgeBaseInfo(BaseModel):
+    id: str
+    key: str | None = None
+    name: str | None = None
+    description: str | None = None
+
+
+class AgentContext(BaseModel):
+    key: str
+    display_name: str | None = None
+    description: str | None = None
+    system_prompt: str | None = None
+    instructions: str | None = None
+    tools: list[ToolInfo] = Field(default_factory=list)
+    memory_stores: list[MemoryStoreInfo] = Field(default_factory=list)
+    knowledge_bases: list[KnowledgeBaseInfo] = Field(default_factory=list)
+    model: str | None = None
+```
+
+(Copy the actual field set from `src/evaluatorq/redteam/contracts.py:AgentContext` verbatim — the snippet above is illustrative; use live shape.)
+
+Replace `src/evaluatorq/redteam/contracts.py`'s `AgentContext` / `ToolInfo` / `MemoryStoreInfo` / `KnowledgeBaseInfo` class bodies with re-export shims:
+
+```python
+from evaluatorq.contracts import AgentContext, KnowledgeBaseInfo, MemoryStoreInfo, ToolInfo  # noqa: F401
+```
+
+Add the four names to `evaluatorq.contracts.__all__`.
+
 - [ ] **Step 1: Add `AgentTarget` to `contracts.py`**
 
-Append to `src/evaluatorq/contracts.py` (after `AgentResponse` class, before `__all__`):
+Append to `src/evaluatorq/contracts.py` (after `AgentContext`, before `__all__`):
 
 ```python
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from evaluatorq.redteam.contracts import AgentContext
 
 
 class AgentTarget(ABC):
@@ -1331,61 +1599,40 @@ class AgentTarget(ABC):
     def new(self) -> "AgentTarget":
         ...
 
-    async def get_agent_context(self) -> "AgentContext":
-        from evaluatorq.redteam.contracts import AgentContext
+    async def get_agent_context(self) -> AgentContext:
         return AgentContext(key=getattr(self, "agent_key", "unknown"))
 ```
 
-Add `"AgentTarget"` to the `__all__` list.
+Add `"AgentTarget"` to the `__all__` list. No deferred import needed — `AgentContext` is in the same module.
 
-- [ ] **Step 2: Replace `AgentTarget` in `backends/base.py` with re-export**
+- [ ] **Step 2: Delete `AgentTarget` from `backends/base.py`**
 
-In `src/evaluatorq/redteam/backends/base.py`, delete the entire `class AgentTarget(ABC):` block. Replace with:
+Delete the entire `class AgentTarget(ABC):` block in `src/evaluatorq/redteam/backends/base.py`. No back-compat re-export — Task 2.2 migrates all importers in this same PR. (Intermediate re-export was discarded as thrash; spec §10 lists `AgentTarget` re-export removal as a public-API change requiring CHANGELOG entry.)
 
-```python
-from evaluatorq.contracts import AgentTarget  # noqa: F401  (back-compat re-export)
-```
+After this deletion, every importer of `AgentTarget` from `backends.base` will fail at import time. **Do not commit yet** — proceed straight to Task 2.2 importer migration, then commit both steps together.
 
-- [ ] **Step 3: Sanity check**
+## Task 2.2: Migrate all importers to `evaluatorq.contracts`
 
-```bash
-uv run python -c "from evaluatorq.contracts import AgentTarget; print(AgentTarget.__module__)"
-uv run python -c "from evaluatorq.redteam.backends.base import AgentTarget; print(AgentTarget.__module__)"
-```
+**Files (importers — verified against current main; count NOT promised; grep is the source of truth):**
 
-Expected: both print `evaluatorq.contracts`.
+Known sites at writing:
 
-- [ ] **Step 4: Run test suite**
-
-```bash
-uv run pytest -m 'not integration' -x -q
-```
-
-Expected: green — re-export keeps every existing importer working.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add src/evaluatorq/contracts.py src/evaluatorq/redteam/backends/base.py
-git commit -m "refactor(contracts): relocate AgentTarget ABC to evaluatorq.contracts"
-```
-
-## Task 2.2: Migrate 14 importers to `evaluatorq.contracts`
-
-**Files (importers):**
-
-- `src/evaluatorq/redteam/runner.py` (2 occurrences, lines 36 and 252)
+- `src/evaluatorq/redteam/runner.py` (lines 36 and 252)
 - `src/evaluatorq/redteam/adaptive/orchestrator.py` (line 23)
 - `src/evaluatorq/integrations/langgraph_integration/target.py` (line 16)
 - `src/evaluatorq/integrations/callable_integration/target.py` (line 11)
 - `src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py` (line 22)
 - `src/evaluatorq/integrations/openai_agents_integration/target.py` (line 11)
-- Any test file currently importing from `evaluatorq.redteam.backends.base import AgentTarget`
+- Any test file currently importing `AgentTarget` from `evaluatorq.redteam.backends.base`
+
+`validate_agent_target` (kept per spec §5.11) lives in `backends/base.py` and references `AgentTarget`. After deletion in Task 2.1 Step 2, `validate_agent_target` will reference an undefined name. Update its `from evaluatorq.contracts import AgentTarget` accordingly.
 
 - [ ] **Step 1: Identify all importers**
 
 ```bash
 grep -rn "from evaluatorq.redteam.backends.base import.*AgentTarget" packages/evaluatorq-py/src packages/evaluatorq-py/tests
+# Also catch multi-line imports
+grep -rn -B0 -A5 "from evaluatorq.redteam.backends.base import (" packages/evaluatorq-py/src packages/evaluatorq-py/tests | grep -A5 "AgentTarget"
 ```
 
 - [ ] **Step 2: Update each importer**
@@ -1394,9 +1641,13 @@ For every match, change `from evaluatorq.redteam.backends.base import AgentTarge
 
 Use `sed` only if confident — there are edge cases (e.g. multi-import lines, TYPE_CHECKING blocks). Manual via Edit is safer.
 
-- [ ] **Step 3: Remove the back-compat re-export from `backends/base.py`**
+- [ ] **Step 3: Verify no stale `AgentTarget` references remain**
 
-Drop the `from evaluatorq.contracts import AgentTarget` re-export line in `src/evaluatorq/redteam/backends/base.py`. (Per spec §10 "Public re-exports removed" — semver entry in CHANGELOG.)
+```bash
+grep -rn "from evaluatorq.redteam.backends.base import.*AgentTarget" packages/evaluatorq-py/
+```
+
+Expected: zero hits.
 
 - [ ] **Step 4: Type-check + tests**
 
@@ -1481,6 +1732,28 @@ from evaluatorq.contracts import ChatMessage  # re-export shim — slated for re
 
 Drop the local `class ChatMessage` definition. The shim preserves `from evaluatorq.simulation.types import ChatMessage` for one cycle.
 
+- [ ] **Step 2b: Add test for `developer` role**
+
+Append to `tests/contracts/test_chat_message.py` (new file):
+
+```python
+"""Verify ChatMessage accepts the developer role added in RES-808."""
+from __future__ import annotations
+
+from evaluatorq.contracts import ChatMessage
+
+
+def test_chat_message_accepts_developer_role():
+    msg = ChatMessage(role="developer", content="system-level instruction")
+    assert msg.role == "developer"
+    assert msg.content == "system-level instruction"
+
+
+def test_chat_message_accepts_legacy_roles():
+    for role in ("user", "assistant", "system"):
+        ChatMessage(role=role, content="x")
+```
+
 - [ ] **Step 3: Verify**
 
 ```bash
@@ -1515,6 +1788,13 @@ git commit -m "refactor(contracts): relocate ChatMessage; add 'developer' role"
 - Modify: `src/evaluatorq/contracts.py`
 
 - [ ] **Step 1: Write failing test**
+
+Create directory `tests/contracts/` with `__init__.py`:
+
+```bash
+mkdir -p packages/evaluatorq-py/tests/contracts
+touch packages/evaluatorq-py/tests/contracts/__init__.py
+```
 
 Create `tests/contracts/test_agent_target_shim.py`:
 
@@ -1557,7 +1837,9 @@ async def test_send_prompt_delegates_to_respond_with_single_user_message():
 uv run pytest tests/contracts/test_agent_target_shim.py -v
 ```
 
-- [ ] **Step 3: Update `AgentTarget` to spec §5.1 shape**
+- [ ] **Step 3: Update `AgentTarget` shape — `respond` concrete-NotImplementedError placeholder**
+
+To keep PR3 intermediate commits bisectable, add `respond` as a concrete `NotImplementedError` placeholder (NOT `@abstractmethod`) initially. Tasks 3.3-3.7 implement it on each target. The final flip to `@abstractmethod` happens in Task 3.11.
 
 In `src/evaluatorq/contracts.py`, replace the existing `AgentTarget` class with:
 
@@ -1567,25 +1849,29 @@ class AgentTarget(ABC):
 
     Subclasses implement ``respond`` (the canonical message-based interface)
     and ``new``. ``send_prompt`` is a concrete one-line shim retained for
-    back-compat with single-prompt callers. ``get_agent_context`` has a
-    minimal default; targets backed by a control plane (ORQ) override.
+    back-compat with single-prompt callers.
+
+    NOTE: ``respond`` is concrete-with-NotImplementedError in this commit;
+    promoted to ``@abstractmethod`` in Task 3.11 after all targets implement it.
+    Keeps PR3 commits bisectable.
     """
 
     def __init__(self, memory_entity_id: str | None = None) -> None:
         self.memory_entity_id = memory_entity_id
 
-    @abstractmethod
     async def respond(self, messages: list["ChatMessage"]) -> "AgentResponse":
-        """Send a list of chat messages; return the response."""
-        ...
+        """Send a list of chat messages; return the response. Override in subclasses."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement respond(messages). "
+            "Implement it or use send_prompt(prompt) for the single-prompt path."
+        )
 
     @abstractmethod
     def new(self) -> "AgentTarget":
         """Return a fresh independent instance."""
         ...
 
-    async def get_agent_context(self) -> "AgentContext":
-        from evaluatorq.redteam.contracts import AgentContext
+    async def get_agent_context(self) -> AgentContext:
         return AgentContext(key=getattr(self, "agent_key", "unknown"))
 
     async def send_prompt(self, prompt: str) -> "AgentResponse":
@@ -1593,21 +1879,27 @@ class AgentTarget(ABC):
         return await self.respond([ChatMessage(role="user", content=prompt)])
 ```
 
+(`AgentContext` is in scope — relocated to `evaluatorq.contracts` in Task 2.1 Step 0.)
+
+**Important**: `send_prompt` was abstract on `AgentTarget` ABC after PR1. The concrete shim here makes it non-abstract — but every existing concrete target still defines `send_prompt`. So the shim only fires for targets that override `respond` but not `send_prompt` (Task 3.3+ targets after migration).
+
 - [ ] **Step 4: Run shim test, expect PASS**
 
 ```bash
 uv run pytest tests/contracts/test_agent_target_shim.py -v
 ```
 
-- [ ] **Step 5: Existing target classes now fail because `respond` is abstract** — Step 5 is the bulk of the PR: implement `respond` on every concrete target. Run the full suite to inventory failures:
+- [ ] **Step 5: Run suite — intermediate commit must be green**
+
+Because `respond` is concrete-NotImplementedError (not abstract), instantiating concrete targets still works. Existing tests that go through `send_prompt` still pass — concrete targets override it directly. Tests that explicitly call `respond` will fail with `NotImplementedError`, but no such tests exist yet (Tasks 3.3-3.7 add them).
 
 ```bash
-uv run pytest -m 'not integration' --no-header -q 2>&1 | tail -50
+uv run pytest -m 'not integration' -x -q
 ```
 
-Expected: many `TypeError: Can't instantiate abstract class XxxTarget with abstract method respond` failures. Each concrete target gets fixed in Tasks 3.3-3.7.
+Expected: green (or only the new `test_agent_target_shim.py` `respond` fails — that's the only `respond` call site so far, and it uses a custom `_RespondOnlyTarget` that implements `respond`).
 
-- [ ] **Step 6: Commit** (red — concrete impls follow)
+- [ ] **Step 6: Commit (green)**
 
 ```bash
 git add src/evaluatorq/contracts.py tests/contracts/test_agent_target_shim.py
@@ -1620,6 +1912,14 @@ git commit -m "feat(contracts): add abstract respond() + send_prompt shim to Age
 - Modify: `src/evaluatorq/simulation/target.py`
 - Test: `tests/redteam/test_orq_responses_target_as_agent_target.py`
 
+- [ ] **Step 0: Audit external importers of soon-to-be-removed symbols**
+
+```bash
+grep -rn "_invoke_stateless\|_invoke_stateful\|_validate_response_id\|threading_disabled\|_accumulated_usage\|get_usage\b" packages/evaluatorq-py/
+```
+
+Any hits outside `simulation/target.py` are external coupling points the rewrite breaks. For each hit: migrate the caller (preferred — they're now obsolete) or document the break in CHANGELOG.
+
 - [ ] **Step 1: Update the `OrqResponsesTarget` class**
 
 Replace `src/evaluatorq/simulation/target.py` content with:
@@ -1630,6 +1930,7 @@ Replace `src/evaluatorq/simulation/target.py` content with:
 from __future__ import annotations
 
 import asyncio
+import uuid
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -1686,12 +1987,21 @@ class OrqResponsesTarget(AgentTarget):
         return result.response
 
     def new(self) -> OrqResponsesTarget:
-        """Fresh instance: no memory_entity_id, propagated injected client."""
+        """Fresh instance: mints a new memory_entity_id if the parent had one.
+
+        Matches existing behaviour at simulation/target.py:106-108 — preserves
+        memory-isolation contract for callers that opt into a server-side
+        memory entity. Without this re-mint, parallel attacks would share
+        the parent's memory store.
+        """
+        fresh_memory_id = (
+            str(uuid.uuid4()) if self.memory_entity_id is not None else None
+        )
         return OrqResponsesTarget(
             self.config,
             instructions=self.instructions,
             tools=self.tools,
-            memory_entity_id=None,
+            memory_entity_id=fresh_memory_id,
             client=self._client if not self._client_owned else None,
         )
 
@@ -1890,6 +2200,20 @@ class TestNew:
         client.responses.create = AsyncMock(return_value=_make_response())
         target = OrqResponsesTarget(LLMCallConfig(model="gpt-4o"), client=client)
         assert target.new()._client is client
+
+    def test_new_does_not_propagate_self_owned_client(self, monkeypatch):
+        """Inverse invariant: when the target owns its client (no client= kwarg),
+        ``new()`` does not propagate it — fresh instance builds its own."""
+        fake_client = MagicMock()
+        monkeypatch.setattr(
+            "evaluatorq.simulation.target.build_simulation_client",
+            lambda _c: (fake_client, True),  # owned=True
+        )
+        target = OrqResponsesTarget(LLMCallConfig(model="gpt-4o"))
+        assert target._client_owned is True
+        fresh = target.new()
+        # The fresh instance built its own client via build_simulation_client again.
+        assert fresh._client is fake_client  # mock returns same client both times
 ```
 
 - [ ] **Step 3: Run conformance tests**
@@ -1955,15 +2279,48 @@ grep -rn "ORQAgentTarget\|send_prompt" tests/redteam tests/integrations 2>/dev/n
 
 For each match where the test asserts a tool-loop body behaviour, keep the test but switch to `await target.send_prompt(prompt)` (which now delegates via the shim) OR migrate to `await target.respond([ChatMessage(role="user", content=prompt)])`. Either is acceptable; prefer `respond` for new tests, keep `send_prompt` for legacy unchanged.
 
-Add one new test:
+Add two new tests (negative + positive, per spec §7 PR3):
 
 ```python
 @pytest.mark.asyncio
 async def test_respond_rejects_non_user_last_message():
     target = ORQAgentTarget(agent_key="a", orq_client=MagicMock())
     with pytest.raises(ValueError, match="messages\\[-1\\].role"):
-        await target.respond([ChatMessage(role="user", content="x"),
-                              ChatMessage(role="assistant", content="y")])
+        await target.respond([
+            ChatMessage(role="user", content="x"),
+            ChatMessage(role="assistant", content="y"),
+        ])
+
+
+@pytest.mark.asyncio
+async def test_respond_with_transcript_forwards_only_last_user_message():
+    """Spec §7 PR3: ``respond([..., assistant, user])`` forwards only the last
+    user turn to the agents endpoint. Prior turns are not in the SDK call.
+    """
+    orq_client = MagicMock()
+    orq_client.agents = MagicMock()
+    response = MagicMock()
+    response.task_id = "task-1"
+    response.usage = MagicMock(prompt_tokens=5, completion_tokens=3, total_tokens=8)
+    response.output = []
+    response.pending_tool_calls = []
+    response.model = "gpt-4o"
+    orq_client.agents.responses = MagicMock()
+    orq_client.agents.responses.create = MagicMock(return_value=response)
+
+    target = ORQAgentTarget(agent_key="a", orq_client=orq_client)
+    await target.respond([
+        ChatMessage(role="user", content="prior turn"),
+        ChatMessage(role="assistant", content="prior reply"),
+        ChatMessage(role="user", content="LATEST USER"),
+    ])
+
+    call_kwargs = orq_client.agents.responses.create.call_args.kwargs
+    assert call_kwargs["message"] == {
+        "role": "user",
+        "parts": [{"kind": "text", "text": "LATEST USER"}],
+    }
+    # Prior turns not in the SDK payload — server holds state via task_id.
 ```
 
 Place in `tests/redteam/test_orq_agent_target_respond.py` (new file) or append to the existing orq agent target test file if one exists.
@@ -2094,18 +2451,45 @@ git commit -m "refactor(redteam): OpenAIModelTarget.respond; drop per-instance h
 
 For each integration target, the existing `send_prompt(self, prompt: str)` body wraps the wrapped framework. For `respond(self, messages)` we follow the spec rule: convert messages → whatever the wrapped framework expects, defaulting to "last user message as prompt" for opaque/callable integrations.
 
-- [ ] **Step 1: `callable_integration/target.py`** — replace `send_prompt` with `respond`:
+- [ ] **Step 1: `callable_integration/target.py`** — replace `send_prompt` with `respond`. Keep `_coerce_to_agent_response` wrapping (spec §5.11 survivor).
+
+Full body:
 
 ```python
 async def respond(self, messages: list[ChatMessage]) -> AgentResponse:
-    """For opaque callables, use the last user message as the prompt."""
+    """For opaque callables, use the last user message as the prompt.
+
+    Callables that return ``str`` are wrapped into ``AgentResponse`` via the
+    surviving ``_coerce_to_agent_response`` helper (spec §5.11).
+    """
     if not messages or messages[-1].role != "user":
         raise ValueError("CallableTarget.respond requires messages[-1].role == 'user'")
     prompt = messages[-1].content
-    # ... existing body unchanged below, operating on `prompt`
+    try:
+        if self._is_async:
+            coro: Any = self._fn(prompt)
+            result = await coro  # pyright: ignore[reportGeneralTypeIssues]
+        else:
+            result = await asyncio.to_thread(self._fn, prompt)  # type: ignore[arg-type]
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        raise
+    except Exception as exc:
+        raise RuntimeError(f"CallableTarget: callable raised {exc!r}") from exc
+
+    if isinstance(result, AgentResponse):
+        return result
+    text = str(result) if result is not None else ""
+    usage: TokenUsage | None = None
+    if self._usage_fn is not None:
+        try:
+            usage = self._usage_fn(prompt, text)
+        except Exception:
+            logger.exception("usage_fn raised an exception; using usage=None")
+    text_item: OutputMessage = TextOutputItem(text=text, annotations=[])
+    return AgentResponse(output=[text_item], usage=usage)
 ```
 
-Add `from evaluatorq.contracts import ChatMessage` import. Drop the existing `send_prompt` override.
+Add `from evaluatorq.contracts import ChatMessage` import. Drop the existing `send_prompt` override — the `AgentTarget.send_prompt` shim now handles single-prompt callers.
 
 - [ ] **Step 2: `langgraph_integration/target.py`** — same pattern. LangGraph thread state belongs to LangGraph; the integration's job is to pass the latest user turn. Use last-user-message rule.
 
@@ -2148,7 +2532,20 @@ async def test_callable_target_respond_returns_agent_response():
     assert "hi" in result.text
 ```
 
-(Add similar smoke for the three other integrations if mocking their SDKs is straightforward; skip if not — the abstract-method enforcement at import time already guarantees `respond` exists.)
+Spec §7 PR3 mandates a `respond`-returns-`AgentResponse` smoke test for all 7 target classes. Add a smoke test for each of the three other integrations (LangGraph, Vercel AI SDK, OpenAI Agents) with `unittest.mock.AsyncMock` stubs of the underlying SDK calls. Don't skip — the import-time abstract-method enforcement does NOT exercise the `respond` body. Pattern (LangGraph example):
+
+```python
+@pytest.mark.asyncio
+async def test_langgraph_target_respond_returns_agent_response(monkeypatch):
+    from evaluatorq.integrations.langgraph_integration import LangGraphTarget
+    fake_graph = MagicMock()
+    fake_graph.ainvoke = AsyncMock(return_value={"messages": [...]})  # whatever LangGraph returns
+    target = LangGraphTarget(graph=fake_graph, ...)
+    result = await target.respond([ChatMessage(role="user", content="hi")])
+    assert isinstance(result, AgentResponse)
+```
+
+Concrete SDK return shapes per integration — copy from existing `tests/integrations/test_*` if present, or use a minimal stub that drives the call-path to a textual response.
 
 - [ ] **Step 7: Commit**
 
@@ -2232,13 +2629,14 @@ git commit -m "refactor(simulation): drop local TargetAgent Protocol; consume Ag
 
 - [ ] **Step 1: Detect AgentTarget instances in `simulate()`**
 
-In `src/evaluatorq/simulation/api.py`, around line 184 (`resolved_callback = target or target_callback`), add:
+In `src/evaluatorq/simulation/api.py`, around line 184 (`resolved_callback = target or target_callback`), modify the existing dispatch to detect AgentTarget instances. The pre-existing `agent_key → from_orq_deployment` fallback stays untouched (spec §5.8 limits auto-routing to `AgentTarget` instances — do NOT modify the fallback path).
 
 ```python
 from evaluatorq.contracts import AgentTarget
 
 # Auto-route: if target is an AgentTarget, hand it to the runner directly
-# rather than treating it as a callable.
+# rather than treating it as a callable. Other dispatch (agent_key, plain
+# callable) is unchanged from current behaviour.
 target_agent: AgentTarget | None = None
 resolved_callback = target or target_callback
 if isinstance(resolved_callback, AgentTarget):
@@ -2248,10 +2646,10 @@ elif not resolved_callback and agent_key:
     resolved_callback = from_orq_deployment(agent_key)
 
 if target_agent is None and not resolved_callback:
-    raise ValueError("Either target (AgentTarget or callable) or agent_key is required")
+    raise ValueError("Either target_callback (or target) or agent_key is required")
 ```
 
-Update `SimulationRunner(...)` construction to pass `target_agent=target_agent` if non-None:
+`SimulationRunner.__init__` already accepts `target_agent` (confirmed in current code at `simulation.py:222`). Pass it:
 
 ```python
 runner = SimulationRunner(
@@ -2263,8 +2661,6 @@ runner = SimulationRunner(
     judge=judge,
 )
 ```
-
-(Verify `SimulationRunner.__init__` accepts `target_agent`. If not, add it as an `AgentTarget | None = None` parameter and store as `self._target_agent`.)
 
 - [ ] **Step 2: Run sim tests**
 
@@ -2333,6 +2729,15 @@ async def test_one_instance_used_for_sim_then_redteam_path():
     assert isinstance(redteam_result, AgentResponse)
     assert sim_result.text == "sim-r1"
     assert redteam_result.text == "redteam-r1"
+
+    # State non-leakage: neither call carries the other's payload into kwargs.
+    call_args = client.responses.create.await_args_list
+    assert call_args[0].kwargs["input"] == [{"role": "user", "content": "sim-q"}]
+    # send_prompt routes through respond shim → list[ChatMessage(user, "redteam-q")]
+    assert call_args[1].kwargs["input"] == [{"role": "user", "content": "redteam-q"}]
+    # No previous_response_id threading anywhere — stateless contract.
+    assert "previous_response_id" not in call_args[0].kwargs
+    assert "previous_response_id" not in call_args[1].kwargs
 ```
 
 - [ ] **Step 2: Run**
@@ -2371,11 +2776,7 @@ Drop any "Proposal — RES-844" appendix.
 
 - [ ] **Step 2: Regenerate `docs/types-uml.html` via `/html-artifacts`**
 
-```bash
-# trigger inside the chat: /html-artifacts using types-uml.md as source
-```
-
-Or skip if html regen is owned by a separate process — leave a TODO in the PR description.
+Mandatory per spec §9. Trigger inside the chat: `/html-artifacts using types-uml.md as source`. Verify the rendered HTML matches the updated md (no diagram drift). If `/html-artifacts` is unavailable in the execution environment, the implementing engineer must regenerate the file manually using the existing template at `outputs/html/types-uml-report.html` as reference.
 
 - [ ] **Step 3: CHANGELOG entry**
 
@@ -2404,7 +2805,24 @@ git add docs/types-uml.md docs/types-uml.html CHANGELOG.md
 git commit -m "docs(redteam): update types-uml + CHANGELOG for RES-808"
 ```
 
-## Task 3.11: Final check + push PR3
+## Task 3.11: Flip `respond` to `@abstractmethod` + final check + push PR3
+
+- [ ] **Step 0: Promote `respond` to `@abstractmethod`**
+
+After Tasks 3.3-3.7, every concrete target implements `respond`. Flip the placeholder to abstract in `src/evaluatorq/contracts.py`:
+
+```python
+# was
+async def respond(self, messages: list["ChatMessage"]) -> "AgentResponse":
+    raise NotImplementedError(...)
+
+# becomes
+@abstractmethod
+async def respond(self, messages: list["ChatMessage"]) -> "AgentResponse":
+    ...
+```
+
+Drop the NOTE in the class docstring.
 
 - [ ] **Step 1: Full suite + type-check**
 
@@ -2487,7 +2905,7 @@ Stacking: PR1 → PR2 → PR3 → PR4. PR4 branches off PR3 tip after PR3 merges
 - §2 Goal 4 (stateless OrqResponsesTarget): PR3 — Task 3.3
 - §2 Goal 5 (ORQAgentTarget keeps endpoint): PR3 — Task 3.4
 - §5.4 (_errors.py extraction): Task 1.2
-- §5.9 (_BareTargetBackend): Task 1.9
+- §5.9 (BareTargetBackend): Task 1.9
 - §5.10 (deletions): Task 1.10
 - §7 testing strategy (per PR): tests included in each task
 - §10 decisions log: reflected in choices throughout
@@ -2499,14 +2917,16 @@ Stacking: PR1 → PR2 → PR3 → PR4. PR4 branches off PR3 tip after PR3 merges
 - `Backend.cleanup_memory(ctx: AgentContext, entity_ids: list[str]) -> None` — consistent
 - `Backend.map_error(exc: Exception) -> tuple[str, str]` — consistent
 - `ChatMessage.role: Literal["user", "assistant", "system", "developer"]` — Task 3.1
-- `_BareTargetBackend(target).cleanup_memory` matches Backend signature — Task 1.9
+- `BareTargetBackend(target).cleanup_memory` matches Backend signature — Task 1.9
 
 **Known plan-execution risks (call out to executor):**
 
 1. **Task 1.3 ordering** — `AgentTarget` becomes ABC before its concrete subclasses are updated. Run tests *after* Step 2 (concretes updated), not after Step 1. If you commit between steps, integration target tests will fail at Step 1.
 2. **Task 1.7 Step 4** — `all_at_cleanup_info` consumer needs grepping; the precise call-site varies by current runner state. Read before editing.
-3. **Task 3.4** — `ORQAgentTarget.respond` raises on non-user last message. Confirm no internal caller passes an assistant-terminated transcript before merging PR3.
-4. **PR2 timing** — must merge cleanly between PR1 and PR3. If PR1 review delays, rebase PR2 + PR3 onto current PR1 tip.
+3. **Task 3.4 blocking precondition** — before merging PR3, audit every sim path that drives a target via `respond(messages)` to confirm `messages[-1].role == "user"`. The `ORQAgentTarget.respond` validation raises `ValueError` otherwise. Promote from "verify after" to "verify before."
+4. **PR2 timing** — must merge cleanly between PR1 and PR3. If PR1 review delays, rebase PR2 + PR3 onto current PR1 tip per the branch-strategy section.
+5. **Task 3.2 NotImplementedError vs @abstractmethod** — `respond` is placeholder-concrete during PR3 commits 3.2-3.10. Task 3.11 Step 0 flips it to abstract. Do NOT skip Step 0.
+6. **ORQ vs OpenAI BYO BareTargetBackend (C-3 fix)** — `ORQAgentTarget.map_error` / `cleanup_memory` and `OpenAIModelTarget.map_error` are intentionally kept as thin delegates to module-level helpers so BYO `red_team(target=ORQAgentTarget(...))` paths still get backend-specific error codes. Deleting them re-introduces runner.py:833 bug.
 
 ---
 

--- a/docs/superpowers/specs/2026-05-26-res-808-collapse-relocate-unify-design.md
+++ b/docs/superpowers/specs/2026-05-26-res-808-collapse-relocate-unify-design.md
@@ -1,0 +1,347 @@
+# RES-808 — Collapse, relocate, and unify the AgentTarget / Backend protocols
+
+**Status:** Design approved 2026-05-26. Implementation pending.
+**Linear:** [RES-808](https://linear.app/orqai/issue/RES-808). Merged scope from RES-844 (duplicate). Follow-up: [RES-876](https://linear.app/orqai/issue/RES-876) (multi-modal `ChatMessage`).
+**Branch:** `bauke/res-808-collapse-redteam-backend-abstractions-abc-agenttarget`
+**Author:** Bauke Brenninkmeijer
+
+---
+
+## 1. Problem
+
+`packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py` defines ~12 abstract types (Protocols, dataclass, helpers) for target backends. Most are speculative flexibility, never composed, never extended by third parties, and mostly 1:1 with their two concrete impls (ORQ + OpenAI). Simulation has its own `TargetAgent` Protocol at `simulation/runner/simulation.py:73` that duplicates much of the same shape. `OrqResponsesTarget` (`simulation/target.py`) already structurally satisfies the redteam `AgentTarget` Protocol (verified by `tests/redteam/test_orq_responses_target_as_agent_target.py`, 17/17 passing) but doesn't inherit it.
+
+Cumulative effects:
+
+- Redteam runner duck-types `getattr(target, "map_error", None)` to detect optional capabilities (`runner.py:1341-1342`).
+- `BackendBundle` dataclass + 4 collaborator protocols force factory boilerplate that two backends will never diverge on.
+- Two endpoint families with overlapping semantics: `client.responses.create` (OpenAI-compatible `/v3/router/responses`) and `orq_client.agents.responses.create` (Orq agents endpoint). Two server-side state channels: `previous_response_id` and `task_id`.
+- `OrqResponsesTarget` carries a "fork contract" warning (`target.py:48-50`) about `__call__` vs `send_prompt` having different state semantics.
+
+## 2. Goals
+
+1. Collapse 12 abstract types in `redteam/backends/base.py` down to 2 ABCs (`AgentTarget`, `Backend`).
+2. Move `AgentTarget` to `evaluatorq/contracts.py` so simulation can reuse without crossing module boundaries.
+3. Unify `AgentTarget` and sim's `TargetAgent` Protocol on a single canonical method: `async def respond(messages: list[ChatMessage]) -> AgentResponse`.
+4. Make `OrqResponsesTarget` stateless. Drop `_previous_response_id`.
+5. Migrate `ORQAgentTarget` to `/v3/router/responses` with `model="agent/<key>"`, dropping the parallel `task_id`-based agents endpoint.
+
+## 3. Non-goals
+
+- Multi-modal `ChatMessage.content` (text + image + file). Tracked in [RES-876](https://linear.app/orqai/issue/RES-876).
+- ContentPart array, multi-part input via the ABC. Tool-call items stay inside target `respond()` implementations, never injected by callers.
+- `validate_agent_target` helper removal. Public migration helper, deferred to a later cycle.
+- `_coerce_to_agent_response` removal. Load-bearing for `callable_integration` users who return `str` from their target — kept.
+- Router URL bump (`registry.py:_ROUTER_SUFFIX = "/v2/router"` → `"/v3/router"`). Both paths reach the same handler; bump is a separate follow-up.
+
+## 4. Validation (probe results, 2026-05-26)
+
+Direct probe of `/v3/router/responses` via `openai.AsyncOpenAI` pointed at `${ORQ_BASE_URL}/v2/router`:
+
+| Test | Feature | Result |
+|---|---|---|
+| T1 | Single-string `input` | ✓ |
+| T2 | Multi-message array + top-level `instructions` + `developer` role | ✓ |
+| T3 | Stateless function-call continuation (echo `function_call` + `function_call_output` items in next input) | ✓ |
+| T4 | `model="agent/<key>"` routing | ✓ — server returns `agent_not_found` for bogus key, confirming endpoint recognizes the shape |
+| T5 | Multi-part content (text + image data URI in one user turn) | ✓ |
+
+Side finding: both `/v2/router/responses` and `/v3/router/responses` reach the same handler. `/v3/responses` (without `/router/`) returns 405.
+
+Conclusions:
+
+- `previous_response_id` truly redundant for `/v3/router/responses` — full stateless tool-loop works by accumulating `function_call` + `function_call_output` in the input array.
+- `model="agent/<key>"` invokes Orq agents through the OpenAI-compatible route. `ORQAgentTarget` migration to this route is feasible.
+- Multi-modal validated as a future capability (RES-876).
+
+## 5. Design
+
+### 5.1 `evaluatorq/contracts.py` additions
+
+```python
+class ChatMessage(BaseModel):
+    role: Literal["user", "assistant", "system", "developer"]
+    content: str
+```
+
+`ChatMessage` moves from `simulation/types.py:217` to `evaluatorq/contracts.py`. `developer` added to role Literal. `content` stays `str` for this cycle (RES-876 extends to multi-part union). `simulation/types.py` keeps a re-export shim for back-compat for one release cycle.
+
+```python
+class AgentTarget(ABC):
+    def __init__(self, memory_entity_id: str | None = None) -> None:
+        self.memory_entity_id = memory_entity_id
+
+    @abstractmethod
+    async def respond(self, messages: list[ChatMessage]) -> AgentResponse: ...
+
+    @abstractmethod
+    def new(self) -> Self: ...
+
+    async def get_agent_context(self) -> AgentContext:
+        """Default: minimal context. Override for platform-backed targets."""
+        return AgentContext(key=getattr(self, "agent_key", "unknown"))
+
+    async def send_prompt(self, prompt: str) -> AgentResponse:
+        """Back-compat shim for single-prompt redteam callers. No drift surface."""
+        return await self.respond([ChatMessage(role="user", content=prompt)])
+```
+
+- `respond` is the abstract method. Every target thinks about messages explicitly.
+- `send_prompt` survives as a concrete one-line delegating shim — back-compat for orchestrator code that still calls it. Single body, no drift.
+- `get_agent_context` has a sensible default. Targets backed by a control plane (ORQ) override.
+- `memory_entity_id` is an instance attribute set in `__init__`, not a class-level default. Resolves collision with mutable instance assignment in target subclasses.
+
+### 5.2 `redteam/backends/base.py` shrinks to `Backend` ABC
+
+```python
+class Backend(ABC):
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    @abstractmethod
+    def create_target(self, agent_key: str) -> AgentTarget: ...
+
+    @abstractmethod
+    async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None: ...
+
+    def map_error(self, exc: Exception) -> tuple[str, str]:
+        """Default: (error_type, message) matching current DefaultErrorMapper."""
+        return ("target_error", f"{type(exc).__name__}: {exc}")
+```
+
+- Three methods. `get_agent_context` moves to `AgentTarget`.
+- `name` is an instance attribute set at construction. Registry key + class identity decoupled — two registrations of the same class with different names allowed.
+- `map_error` has a concrete default (current `DefaultErrorMapper` body). Subclasses override for provider-specific HTTP/error-code mapping. Return shape locked to `(error_type, message)` — matches current contract, preserves `OrchestratorResult.error_code` semantics.
+- `_BareTargetBackend` (private adapter, same file) wraps a bare `AgentTarget` instance so the runner's bring-your-own-target path satisfies `Backend`. Absorbs the `getattr(at, "cleanup_memory", None)` / `getattr(at, "map_error", None)` duck-checks that today scatter across `runner.py:1341-1342`.
+
+### 5.3 Concrete backends collapse
+
+| Today (9 classes) | After |
+|---|---|
+| `ORQAgentTarget`, `ORQContextProvider`, `ORQTargetFactory`, `ORQMemoryCleanup`, `ORQErrorMapper` | `ORQAgentTarget` + `ORQBackend` |
+| `OpenAIModelTarget`, `OpenAIContextProvider`, `OpenAITargetFactory`, `OpenAIErrorMapper` | `OpenAIModelTarget` + `OpenAIBackend` |
+
+- Target classes stay separate (per-job state holders, satisfy `AgentTarget` ABC explicitly).
+- Provider/Factory/MemoryCleanup/ErrorMapper bodies fold into Backend methods. Backend holds client + config only; no per-job mutable state.
+- ORQ context retrieval (was `ORQContextProvider.get_agent_context(agent_key)`) becomes `ORQAgentTarget.get_agent_context()` with internal caching. HTTP fetch happens lazily on first call. Bad agent key surfaces at first `get_agent_context()` invocation rather than at `create_target`.
+
+### 5.4 `redteam/backends/_errors.py` (new)
+
+Module-private helpers used by `ORQBackend.map_error` + `OpenAIBackend.map_error`:
+
+- `extract_status_code(exc) -> int | None`
+- `extract_provider_error_code(exc) -> str | None`
+
+Moved verbatim from `base.py:236-292`.
+
+### 5.5 Registry stays factory-based
+
+```python
+_BACKEND_REGISTRY: dict[str, Callable[..., Backend]] = {}
+
+def register_backend(name: str, factory: Callable[..., Backend]) -> None: ...
+
+def resolve_backend(
+    backend: str = "orq",
+    *,
+    llm_client: AsyncOpenAI | None = None,
+    target_config: TargetConfig | None = None,
+    pipeline_config: LLMConfig | None = None,
+) -> Backend:
+    factory = _BACKEND_REGISTRY[backend.strip().lower()]
+    return factory(llm_client=llm_client, target_config=target_config, pipeline_config=pipeline_config)
+```
+
+Same shape as today, just returns `Backend` instead of `BackendBundle`. Third-party backends register their own factory closures with whatever typed construction they need. No god-`__init__`, no `**kwargs` lock-in, no `type[Backend]` plugin-system trap.
+
+### 5.6 `OrqResponsesTarget` becomes stateless
+
+```python
+class OrqResponsesTarget(AgentTarget):
+    def __init__(self, config, *, client=None, instructions=None, memory_entity_id=None) -> None:
+        super().__init__(memory_entity_id=memory_entity_id)
+        self.config = config
+        self._client = client or _make_default_client()
+        self._instructions = instructions
+
+    async def respond(self, messages: list[ChatMessage]) -> AgentResponse:
+        # /v3/router/responses with input=[messages converted to InputItems]
+        # NO previous_response_id. Stateless.
+        ...
+
+    def new(self) -> Self:
+        return type(self)(self.config, client=self._client, instructions=self._instructions)
+
+    async def get_agent_context(self) -> AgentContext:
+        return AgentContext(key=self.config.model)
+```
+
+Deleted: `_previous_response_id` attr, `__call__` method, "fork contract" docstring, all logic at `target.py:178-185` that reads/writes thread state. `TestCallDoesNotCorruptAgentTargetState` deleted (invariant no longer exists).
+
+### 5.7 `ORQAgentTarget` migrates to `/v3/router/responses`
+
+```python
+class ORQAgentTarget(AgentTarget):
+    def __init__(self, *, client: AsyncOpenAI, agent_key: str, timeout_ms=None, memory_entity_id=None) -> None:
+        super().__init__(memory_entity_id=memory_entity_id)
+        self._client = client
+        self.agent_key = agent_key
+        self._timeout_ms = timeout_ms
+        self._cached_context: AgentContext | None = None
+
+    async def respond(self, messages: list[ChatMessage]) -> AgentResponse:
+        # /v3/router/responses with model=f"agent/{self.agent_key}"
+        # Tool-loop: extract function_call items from response, echo them back
+        # along with function_call_output (synthetic "tool unavailable" results)
+        # in next request's input. Stateless via accumulated input array.
+        ...
+
+    async def get_agent_context(self) -> AgentContext:
+        if self._cached_context is None:
+            self._cached_context = await self._fetch_context()
+        return self._cached_context
+```
+
+- Endpoint switch: `orq_client.agents.responses.create` → `client.responses.create(model="agent/<key>", ...)`.
+- `task_id`-based threading removed.
+- Tool-loop semantics preserved: synthetic `function_call_output` items replace the current `{'role': 'tool', 'parts': [...]}` shape (`orq.py:221-238`). Each iteration appends to the input array, sent stateless to the server.
+
+### 5.8 Sim runner — `TargetAgent` Protocol deleted
+
+```python
+# simulation/runner/simulation.py:73 — TargetAgent Protocol — DELETED
+# Replaced by: from evaluatorq.contracts import AgentTarget
+
+# simulation/runner/simulation.py:636 — dispatch
+if self._target_agent:
+    return (await self._target_agent.respond(messages)).text
+```
+
+`simulation/runner/__init__.py` re-exports `AgentTarget` (was `TargetAgent`). `simulation/__init__.py` follows.
+
+`simulation/api.py:simulate()` gains auto-routing: if `target=` argument is an `AgentTarget` instance, route to `target_agent` path; otherwise treat as bare `target_callback`. Keeps `simulate(target=ort)` callers unchanged.
+
+### 5.9 Bring-your-own-target adapter
+
+Runner's `runner.py:1320-1358` block replaced:
+
+```python
+# before
+at_factory = DirectTargetFactory(at)
+at_mapper = at if callable(getattr(at, "map_error", None)) else DefaultErrorMapper()
+at_cleanup = at if callable(getattr(at, "cleanup_memory", None)) else NoopMemoryCleanup()
+at_dyn_job = create_dynamic_redteam_job(target_factory=..., error_mapper=..., ...)
+
+# after
+at_backend = _BareTargetBackend(at)
+at_dyn_job = create_dynamic_redteam_job(backend=at_backend, ...)
+```
+
+`create_dynamic_redteam_job` signature accepts a `Backend` instance instead of three separate collaborators. Duck-checks concentrate in `_BareTargetBackend`.
+
+### 5.10 Deletions
+
+From `redteam/backends/base.py`:
+
+- `BackendBundle` dataclass
+- `AgentTargetFactory`, `AgentContextProvider`, `MemoryCleanup`, `ErrorMapper` Protocols
+- `SupportsClone`, `SupportsTokenUsage`, `SupportsTargetMetadata`, `SupportsAgentContext`, `SupportsTargetFactory`, `SupportsMemoryCleanup`, `SupportsErrorMapping`
+- `DirectTargetFactory`, `NoopMemoryCleanup`, `DefaultErrorMapper`
+- `is_agent_target`, `adapt_legacy_target`
+
+From `redteam/backends/orq.py`:
+
+- `ORQContextProvider`, `ORQTargetFactory`, `ORQMemoryCleanup`, `ORQErrorMapper` (bodies move to `ORQBackend` / `ORQAgentTarget` methods)
+
+From `redteam/backends/openai.py`:
+
+- `OpenAIContextProvider`, `OpenAITargetFactory`, `OpenAIErrorMapper`
+
+From `simulation/runner/simulation.py`:
+
+- `TargetAgent` Protocol (`L73`)
+- Re-exports in `simulation/runner/__init__.py` and `simulation/__init__.py`
+
+From `simulation/target.py:OrqResponsesTarget`:
+
+- `__call__` method
+- `_previous_response_id` attribute and all read/write sites
+- "Fork contract" docstring at L48-50, L91, L158-160
+- Thread-id drift logging at L185
+
+From `redteam/__init__.py:40-48`:
+
+- `DirectTargetFactory`, `SupportsAgentContext`, `SupportsErrorMapping`, `SupportsMemoryCleanup`, `SupportsTargetFactory`, `is_agent_target`
+
+### 5.11 Survivors (explicitly kept)
+
+- `_coerce_to_agent_response` (`base.py:52`) — load-bearing for `callable_integration` users. Called at `runner.py:723,1437`, `pipeline.py:382`.
+- `validate_agent_target` — public migration helper. Defer removal.
+- `simulation.target_callback` parameter — bare-callable path for `wrap_agent.py`, `adapters.py`. Stays.
+
+## 6. Stacked PR plan
+
+| PR | Scope | Branch tip | Size |
+|---|---|---|---|
+| PR1: Collapse in place | Backend ABC + ORQBackend + OpenAIBackend in `redteam/backends/base.py`. Drop BackendBundle + Supports* + collaborator protocols. `_errors.py` extraction. `_BareTargetBackend` adapter. Runner + adaptive call-site migration. `AgentTarget` stays Protocol→ABC inside `base.py`. | `main` | M |
+| PR2: Relocate `AgentTarget` | Move `AgentTarget` ABC to `evaluatorq/contracts.py`. Update 14 importers. `redteam/backends/base.py` keeps `Backend` only. | PR1 | S |
+| PR3: Unify on `respond` + ORQAgentTarget endpoint migration | Add `respond(messages)` abstract + `send_prompt` shim. `OrqResponsesTarget` stateless refactor + drop `__call__`. `ORQAgentTarget` migrates to `/v3/router/responses` with `model="agent/<key>"`. Sim's `TargetAgent` Protocol deleted. `ChatMessage` relocates to contracts. 4 integration targets refactored to `respond`. Auto-routing in `api.py`. Smoke test for sim+redteam target interchange. | PR2 | L |
+
+Merge order: PR1 → PR2 → PR3. Each squash-merged. PR2 + PR3 rebase if PR1 reviews land changes.
+
+## 7. Testing strategy
+
+### PR1
+
+- Existing `tests/redteam/test_*` green.
+- New: `tests/redteam/test_backend_abc.py` — `Backend.map_error` default returns `("target_error", ...)`; subclasses extract HTTP status / exception types.
+- New: `tests/redteam/test_bare_target_backend.py` — adapter delegates `cleanup_memory`/`map_error` when target has them, falls back otherwise. `get_agent_context` returns minimal context when target lacks override.
+- Pre-existing bug regression test: `resolved_error_mapper = DefaultErrorMapper()` at `runner.py:833` ignored bundle's `error_mapper`. After collapse, ORQ exceptions hit `ORQBackend.map_error`. Behavior change intentional — add test asserting ORQ HTTP exceptions map to ORQ-specific codes, not generic `target_error`.
+
+### PR2
+
+- Type-check `bunx nx typecheck` after each importer migration.
+- All 17 tests in `tests/redteam/test_orq_responses_target_as_agent_target.py` stay green.
+- Sanity: `from evaluatorq.contracts import AgentTarget` succeeds.
+
+### PR3
+
+- `tests/redteam/test_orq_responses_target_as_agent_target.py:206,219` updated to `target.respond(...)`.
+- `TestCallDoesNotCorruptAgentTargetState` deleted (invariant no longer exists). Replaced by `TestRespondIsStateless` (verify `respond` doesn't accumulate state across calls).
+- New: `tests/integration/test_sim_redteam_target_roundtrip.py` — one OrqResponsesTarget instance passes RES-844 acceptance: works as redteam target AND sim `target_agent`.
+- New: `tests/redteam/test_orq_agent_target_via_responses_endpoint.py` — verify ORQAgentTarget tool-loop with `model="agent/<key>"` using mocked `client.responses.create`.
+- All 7 target classes (ORQAgentTarget, OpenAIModelTarget, OrqResponsesTarget, LangGraphTarget, CallableTarget, VercelAISdkTarget, OpenAIAgentTarget) — each gets a `respond`-returns-`AgentResponse` smoke test.
+- Sim test suite (`tests/simulation/`) green.
+
+## 8. Risks
+
+1. **Pre-existing `DefaultErrorMapper()` masking ORQ mapping** at `runner.py:833`. PR1 behavior change is intentional — document in PR description, verify retry/abort behavior unchanged via existing integration tests.
+
+2. **ORQAgentTarget endpoint migration** (PR3). Behavior changes from `task_id`-keyed agents endpoint to stateless `model="agent/<key>"` route. Server-side tool/memory/context retrieval must produce equivalent results. Probe T4 confirmed routing; full feature parity (tool definitions, server-side memory store interaction) requires integration test against a real ORQ agent. Block PR3 merge on this test passing.
+
+3. **`__call__` removal on OrqResponsesTarget**. External callers passing `target_callback=OrqResponsesTarget(...)` break. Migration: `target=ort` (auto-routes via `api.py`) or `target_agent=ort`. CHANGELOG entry. Internal grep shows no production sites using this pattern.
+
+4. **`ChatMessage` move** from `simulation/types` to `contracts`. Re-export shim in `simulation/types.py` for one cycle. CHANGELOG entry: "ChatMessage moved to `evaluatorq.contracts`; old import path deprecated, removal in 1.5."
+
+5. **7 target classes refactored to `respond`**. Risk of behavior drift between `send_prompt` shim and `respond` impl per class. Mitigation: shim is single-line delegation, no body to drift. CI runs full test suite across all integrations.
+
+6. **Public re-exports removed** (`DirectTargetFactory`, 4 `Supports*`, `is_agent_target` from `redteam/__init__.py`). Semver-relevant. CHANGELOG entry: "Removed in 1.4: replaced by `Backend` ABC + `isinstance(x, AgentTarget)`." Package is past 1.0 per `base.py:154` reference to "evaluatorq 1.3".
+
+## 9. Doc updates (post-PR3)
+
+- `docs/types-uml.md` — replace 12-type protocol family in main classDiagram with 2-ABC end-state. Drop "Proposal — RES-844" appendix (implemented).
+- `docs/types-uml.html` — re-render via `/html-artifacts`.
+
+## 10. Decisions log
+
+- **Single PR vs stacked**: Initially single. Reversed after hate-review surfaced bisect-hostility and review-quality concerns. Stacked PR1→PR2→PR3.
+- **Module home for ABCs**: `AgentTarget` → `evaluatorq/contracts.py` (top-level exists, `AgentResponse` already there). `Backend` stays in `redteam/backends/base.py` (redteam-internal, sim doesn't need it).
+- **Registry shape**: Factory functions (`Callable[..., Backend]`), not `type[Backend]` + `**kwargs`. Avoids god-init and plugin-trap.
+- **`map_error` on Backend**: Stays. Skeptic argued cohesion; extensibility for third-party backends wins.
+- **`name` on Backend**: Instance attribute via `__init__`, not `ClassVar[str]`. Registry key + class identity decoupled.
+- **`respond` shape**: Abstract `respond(messages) -> AgentResponse`. `send_prompt(str) -> AgentResponse` becomes concrete shim. Pedant's "load-bearing lie" concern resolved by making `respond` abstract instead of concrete-with-lossy-default.
+- **`__call__` on OrqResponsesTarget**: Removed entirely. Pedant's "two parallel APIs" concern resolved by deletion, not by 1-line shim.
+- **Stateless `OrqResponsesTarget`**: Drop `_previous_response_id`. User confirmed bandwidth not a concern.
+- **`ORQAgentTarget` endpoint**: Migrate to `/v3/router/responses` with `model="agent/<key>"`. Live probe T4 confirmed routing.
+- **`ChatMessage` content shape**: Stays `str` in this cycle. Multi-modal deferred to RES-876.
+- **Survivors**: `_coerce_to_agent_response`, `validate_agent_target`, `simulation.target_callback` parameter, `simulation/types.py:ChatMessage` re-export shim.

--- a/docs/superpowers/specs/2026-05-26-res-808-collapse-relocate-unify-design.md
+++ b/docs/superpowers/specs/2026-05-26-res-808-collapse-relocate-unify-design.md
@@ -15,8 +15,10 @@ Cumulative effects:
 
 - Redteam runner duck-types `getattr(target, "map_error", None)` to detect optional capabilities (`runner.py:1341-1342`).
 - `BackendBundle` dataclass + 4 collaborator protocols force factory boilerplate that two backends will never diverge on.
-- Two endpoint families with overlapping semantics: `client.responses.create` (OpenAI-compatible `/v3/router/responses`) and `orq_client.agents.responses.create` (Orq agents endpoint). Two server-side state channels: `previous_response_id` and `task_id`.
 - `OrqResponsesTarget` carries a "fork contract" warning (`target.py:48-50`) about `__call__` vs `send_prompt` having different state semantics.
+- Sim `TargetAgent` Protocol and redteam `AgentTarget` Protocol drifted independently — one structural match (`OrqResponsesTarget`) requires a dedicated 17-test conformance file to keep them aligned.
+
+Out of scope here: dual endpoint families (`client.responses.create` vs `orq_client.agents.responses.create`) and their state channels (`previous_response_id`, `task_id`) coexist intentionally. `ORQAgentTarget` stays on its endpoint.
 
 ## 2. Goals
 
@@ -24,7 +26,7 @@ Cumulative effects:
 2. Move `AgentTarget` to `evaluatorq/contracts.py` so simulation can reuse without crossing module boundaries.
 3. Unify `AgentTarget` and sim's `TargetAgent` Protocol on a single canonical method: `async def respond(messages: list[ChatMessage]) -> AgentResponse`.
 4. Make `OrqResponsesTarget` stateless. Drop `_previous_response_id`.
-5. Migrate `ORQAgentTarget` to `/v3/router/responses` with `model="agent/<key>"`, dropping the parallel `task_id`-based agents endpoint.
+5. Keep `ORQAgentTarget` on its current `orq_client.agents.responses.create` endpoint. Prefer `OrqResponsesTarget` for new call-sites where applicable; do not rewrite ORQAgentTarget.
 
 ## 3. Non-goals
 
@@ -51,7 +53,7 @@ Side finding: both `/v2/router/responses` and `/v3/router/responses` reach the s
 Conclusions:
 
 - `previous_response_id` truly redundant for `/v3/router/responses` — full stateless tool-loop works by accumulating `function_call` + `function_call_output` in the input array.
-- `model="agent/<key>"` invokes Orq agents through the OpenAI-compatible route. `ORQAgentTarget` migration to this route is feasible.
+- `model="agent/<key>"` invokes Orq agents through the OpenAI-compatible route. Feasible as a future option, but out of scope here — `ORQAgentTarget` stays on its existing endpoint.
 - Multi-modal validated as a future capability (RES-876).
 
 ## 5. Design
@@ -170,6 +172,8 @@ class OrqResponsesTarget(AgentTarget):
         ...
 
     def new(self) -> Self:
+        # Fresh instance: no client state, no memory_entity_id. Matches existing
+        # test invariant test_new_fresh_memory_entity_id_is_none.
         return type(self)(self.config, client=self._client, instructions=self._instructions)
 
     async def get_agent_context(self) -> AgentContext:
@@ -178,22 +182,25 @@ class OrqResponsesTarget(AgentTarget):
 
 Deleted: `_previous_response_id` attr, `__call__` method, "fork contract" docstring, all logic at `target.py:178-185` that reads/writes thread state. `TestCallDoesNotCorruptAgentTargetState` deleted (invariant no longer exists).
 
-### 5.7 `ORQAgentTarget` migrates to `/v3/router/responses`
+### 5.7 `ORQAgentTarget` keeps current endpoint, conforms to ABC
 
 ```python
 class ORQAgentTarget(AgentTarget):
-    def __init__(self, *, client: AsyncOpenAI, agent_key: str, timeout_ms=None, memory_entity_id=None) -> None:
+    def __init__(self, *, orq_client, agent_key: str, timeout_ms=None, memory_entity_id=None) -> None:
         super().__init__(memory_entity_id=memory_entity_id)
-        self._client = client
+        self._orq_client = orq_client
         self.agent_key = agent_key
         self._timeout_ms = timeout_ms
         self._cached_context: AgentContext | None = None
 
     async def respond(self, messages: list[ChatMessage]) -> AgentResponse:
-        # /v3/router/responses with model=f"agent/{self.agent_key}"
-        # Tool-loop: extract function_call items from response, echo them back
-        # along with function_call_output (synthetic "tool unavailable" results)
-        # in next request's input. Stateless via accumulated input array.
+        # Existing impl preserved: orq_client.agents.responses.create + task_id threading.
+        # Server holds conversation state via task_id, so respond() forwards only the
+        # last user message to the agents endpoint. Prior turns in `messages` are
+        # asserted-consistent with task_id's server-side history (raise if last message
+        # is not role=user). First call (task_id=None) sends the last user message
+        # and seeds task_id from the response. Tool-loop body inside the call lifts
+        # verbatim from current orq.py:200-260.
         ...
 
     async def get_agent_context(self) -> AgentContext:
@@ -202,9 +209,11 @@ class ORQAgentTarget(AgentTarget):
         return self._cached_context
 ```
 
-- Endpoint switch: `orq_client.agents.responses.create` → `client.responses.create(model="agent/<key>", ...)`.
-- `task_id`-based threading removed.
-- Tool-loop semantics preserved: synthetic `function_call_output` items replace the current `{'role': 'tool', 'parts': [...]}` shape (`orq.py:221-238`). Each iteration appends to the input array, sent stateless to the server.
+- Endpoint unchanged: `orq_client.agents.responses.create` stays.
+- `task_id` threading stays.
+- Only change: shape conforms to `AgentTarget` ABC (`respond(messages) -> AgentResponse`). Tool-loop body lifts mostly verbatim from current `orq.py`.
+- Caller contract: `messages[-1].role == "user"`. Mismatch with server-side history (`task_id`) is caller bug. Documented in `ORQAgentTarget.respond` docstring.
+- `OrqResponsesTarget` (OpenAI-compatible route, stateless) remains the preferred target for new call-sites. Co-existence of two ORQ-backed targets is intentional.
 
 ### 5.8 Sim runner — `TargetAgent` Protocol deleted
 
@@ -285,7 +294,7 @@ From `redteam/__init__.py:40-48`:
 |---|---|---|---|
 | PR1: Collapse in place | Backend ABC + ORQBackend + OpenAIBackend in `redteam/backends/base.py`. Drop BackendBundle + Supports* + collaborator protocols. `_errors.py` extraction. `_BareTargetBackend` adapter. Runner + adaptive call-site migration. `AgentTarget` stays Protocol→ABC inside `base.py`. | `main` | M |
 | PR2: Relocate `AgentTarget` | Move `AgentTarget` ABC to `evaluatorq/contracts.py`. Update 14 importers. `redteam/backends/base.py` keeps `Backend` only. | PR1 | S |
-| PR3: Unify on `respond` + ORQAgentTarget endpoint migration | Add `respond(messages)` abstract + `send_prompt` shim. `OrqResponsesTarget` stateless refactor + drop `__call__`. `ORQAgentTarget` migrates to `/v3/router/responses` with `model="agent/<key>"`. Sim's `TargetAgent` Protocol deleted. `ChatMessage` relocates to contracts. 4 integration targets refactored to `respond`. Auto-routing in `api.py`. Smoke test for sim+redteam target interchange. | PR2 | L |
+| PR3: Unify on `respond` | Add `respond(messages)` abstract + `send_prompt` shim. `OrqResponsesTarget` stateless refactor + drop `__call__`. `ORQAgentTarget` repackaged to `respond(messages)` — endpoint unchanged. Sim's `TargetAgent` Protocol deleted. `ChatMessage` relocates to contracts. 4 integration targets refactored to `respond`. Auto-routing in `api.py`. Smoke test for sim+redteam target interchange. | PR2 | L |
 
 Merge order: PR1 → PR2 → PR3. Each squash-merged. PR2 + PR3 rebase if PR1 reviews land changes.
 
@@ -309,7 +318,7 @@ Merge order: PR1 → PR2 → PR3. Each squash-merged. PR2 + PR3 rebase if PR1 re
 - `tests/redteam/test_orq_responses_target_as_agent_target.py:206,219` updated to `target.respond(...)`.
 - `TestCallDoesNotCorruptAgentTargetState` deleted (invariant no longer exists). Replaced by `TestRespondIsStateless` (verify `respond` doesn't accumulate state across calls).
 - New: `tests/integration/test_sim_redteam_target_roundtrip.py` — one OrqResponsesTarget instance passes RES-844 acceptance: works as redteam target AND sim `target_agent`.
-- New: `tests/redteam/test_orq_agent_target_via_responses_endpoint.py` — verify ORQAgentTarget tool-loop with `model="agent/<key>"` using mocked `client.responses.create`.
+- ORQAgentTarget tests updated: callers switch from `send_prompt(str)` to `respond([ChatMessage(role="user", content=str)])`. Tool-loop body assertions (function-call extraction, task_id threading, memory cleanup) unchanged. New test: `respond([..., assistant, user])` forwards only the last user turn to the agents endpoint.
 - All 7 target classes (ORQAgentTarget, OpenAIModelTarget, OrqResponsesTarget, LangGraphTarget, CallableTarget, VercelAISdkTarget, OpenAIAgentTarget) — each gets a `respond`-returns-`AgentResponse` smoke test.
 - Sim test suite (`tests/simulation/`) green.
 
@@ -317,15 +326,13 @@ Merge order: PR1 → PR2 → PR3. Each squash-merged. PR2 + PR3 rebase if PR1 re
 
 1. **Pre-existing `DefaultErrorMapper()` masking ORQ mapping** at `runner.py:833`. PR1 behavior change is intentional — document in PR description, verify retry/abort behavior unchanged via existing integration tests.
 
-2. **ORQAgentTarget endpoint migration** (PR3). Behavior changes from `task_id`-keyed agents endpoint to stateless `model="agent/<key>"` route. Server-side tool/memory/context retrieval must produce equivalent results. Probe T4 confirmed routing; full feature parity (tool definitions, server-side memory store interaction) requires integration test against a real ORQ agent. Block PR3 merge on this test passing.
+2. **`__call__` removal on OrqResponsesTarget**. External callers passing `target_callback=OrqResponsesTarget(...)` break. Migration: `target=ort` (auto-routes via `api.py`) or `target_agent=ort`. CHANGELOG entry. Internal grep shows no production sites using this pattern.
 
-3. **`__call__` removal on OrqResponsesTarget**. External callers passing `target_callback=OrqResponsesTarget(...)` break. Migration: `target=ort` (auto-routes via `api.py`) or `target_agent=ort`. CHANGELOG entry. Internal grep shows no production sites using this pattern.
+3. **`ChatMessage` move** from `simulation/types` to `contracts`. Re-export shim in `simulation/types.py` for one cycle. CHANGELOG entry: "ChatMessage moved to `evaluatorq.contracts`; old import path deprecated, removal in 1.5."
 
-4. **`ChatMessage` move** from `simulation/types` to `contracts`. Re-export shim in `simulation/types.py` for one cycle. CHANGELOG entry: "ChatMessage moved to `evaluatorq.contracts`; old import path deprecated, removal in 1.5."
+4. **7 target classes refactored to `respond`**. Risk of behavior drift between `send_prompt` shim and `respond` impl per class. Mitigation: shim is single-line delegation, no body to drift. CI runs full test suite across all integrations.
 
-5. **7 target classes refactored to `respond`**. Risk of behavior drift between `send_prompt` shim and `respond` impl per class. Mitigation: shim is single-line delegation, no body to drift. CI runs full test suite across all integrations.
-
-6. **Public re-exports removed** (`DirectTargetFactory`, 4 `Supports*`, `is_agent_target` from `redteam/__init__.py`). Semver-relevant. CHANGELOG entry: "Removed in 1.4: replaced by `Backend` ABC + `isinstance(x, AgentTarget)`." Package is past 1.0 per `base.py:154` reference to "evaluatorq 1.3".
+5. **Public re-exports removed** (`DirectTargetFactory`, 4 `Supports*`, `is_agent_target` from `redteam/__init__.py`). Semver-relevant. CHANGELOG entry: "Removed in 1.4: replaced by `Backend` ABC + `isinstance(x, AgentTarget)`." Package is past 1.0 per `base.py:154` reference to "evaluatorq 1.3".
 
 ## 9. Doc updates (post-PR3)
 
@@ -342,6 +349,6 @@ Merge order: PR1 → PR2 → PR3. Each squash-merged. PR2 + PR3 rebase if PR1 re
 - **`respond` shape**: Abstract `respond(messages) -> AgentResponse`. `send_prompt(str) -> AgentResponse` becomes concrete shim. Pedant's "load-bearing lie" concern resolved by making `respond` abstract instead of concrete-with-lossy-default.
 - **`__call__` on OrqResponsesTarget**: Removed entirely. Pedant's "two parallel APIs" concern resolved by deletion, not by 1-line shim.
 - **Stateless `OrqResponsesTarget`**: Drop `_previous_response_id`. User confirmed bandwidth not a concern.
-- **`ORQAgentTarget` endpoint**: Migrate to `/v3/router/responses` with `model="agent/<key>"`. Live probe T4 confirmed routing.
+- **`ORQAgentTarget` endpoint**: Keep on `orq_client.agents.responses.create`. Only repackage to `respond(messages)`. Adopt `OrqResponsesTarget` for new call-sites instead of rewriting ORQAgentTarget. Probe T4 confirmed `model="agent/<key>"` routing is viable as a future option but not in scope here.
 - **`ChatMessage` content shape**: Stays `str` in this cycle. Multi-modal deferred to RES-876.
 - **Survivors**: `_coerce_to_agent_response`, `validate_agent_target`, `simulation.target_callback` parameter, `simulation/types.py:ChatMessage` re-export shim.

--- a/docs/types-uml.html
+++ b/docs/types-uml.html
@@ -1,0 +1,910 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Types UML — evaluatorq / redteam / agent simulation</title>
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect width='64' height='64' rx='10' fill='%23f6f1e7'/><rect x='8' y='10' width='22' height='18' rx='2' fill='none' stroke='%238e4623' stroke-width='2.5'/><line x1='8' y1='17' x2='30' y2='17' stroke='%238e4623' stroke-width='2.5'/><rect x='34' y='36' width='22' height='18' rx='2' fill='none' stroke='%234a6a85' stroke-width='2.5'/><line x1='34' y1='43' x2='56' y2='43' stroke='%234a6a85' stroke-width='2.5'/><line x1='25' y1='28' x2='39' y2='36' stroke='%237c8493' stroke-width='2.2' stroke-dasharray='3 2'/><polygon points='36,32 41,36 36,38' fill='none' stroke='%237c8493' stroke-width='2'/></svg>" />
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js"></script>
+<style>
+  :root {
+    --ivory: #f6f1e7;
+    --ivory-2: #ece4d2;
+    --slate: #2b2f36;
+    --slate-2: #4a525e;
+    --slate-3: #7c8493;
+    --clay: #c46a3f;
+    --clay-tint: #f0d9c9;
+    --clay-deep: #8e4623;
+    --moss: #5a7a4a;
+    --sky: #4a6a85;
+    --purple: #6a4a85;
+    --purple-tint: #e8ddf0;
+    --rule: #d9d0bd;
+    --font-serif: "Iowan Old Style","Charter","Georgia",serif;
+    --font-sans: "Inter","Helvetica Neue",system-ui,sans-serif;
+    --font-mono: "JetBrains Mono","SF Mono","Menlo",monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--ivory); color: var(--slate); font-family: var(--font-sans); -webkit-font-smoothing: antialiased; }
+  .wrap { max-width: 1180px; margin: 0 auto; padding: 64px 40px 96px; }
+  header.card { background: var(--clay-tint); border: 1px solid var(--rule); padding: 36px 40px; border-radius: 4px; margin-bottom: 56px; }
+  .eyebrow { text-transform: uppercase; letter-spacing: 0.18em; font-size: 11px; color: var(--clay-deep); font-weight: 600; margin-bottom: 16px; }
+  h1 { font-family: var(--font-serif); font-size: 44px; line-height: 1.1; margin: 0 0 18px; color: var(--slate); font-weight: 500; }
+  header.card p.tldr { font-family: var(--font-serif); font-size: 19px; line-height: 1.55; margin: 0; color: var(--slate-2); max-width: 780px; }
+  h2 { font-family: var(--font-serif); font-size: 28px; font-weight: 500; margin: 64px 0 8px; color: var(--slate); border-top: 1px solid var(--rule); padding-top: 32px; }
+  h2:first-of-type { border-top: none; padding-top: 0; }
+  h3 { font-family: var(--font-sans); font-size: 14px; text-transform: uppercase; letter-spacing: 0.14em; color: var(--slate-3); font-weight: 600; margin: 32px 0 12px; }
+  p { line-height: 1.65; font-size: 16px; color: var(--slate-2); }
+  ul { line-height: 1.7; color: var(--slate-2); }
+  ul li { margin-bottom: 6px; }
+  code { font-family: var(--font-mono); font-size: 0.92em; background: var(--ivory-2); padding: 1px 6px; border-radius: 3px; color: var(--slate); }
+  .legend { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin: 16px 0 32px; }
+  .legend .chip { border: 1px solid var(--rule); background: #fff; padding: 14px 16px; border-radius: 4px; }
+  .legend .chip .dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 8px; vertical-align: middle; }
+  .legend .chip.eval .dot { background: var(--clay); }
+  .legend .chip.rt .dot { background: var(--sky); }
+  .legend .chip.sim .dot { background: var(--moss); }
+  .legend .chip.be .dot { background: var(--purple); }
+  .legend .chip strong { font-size: 13px; letter-spacing: 0.04em; color: var(--slate); }
+  .legend .chip small { display: block; color: var(--slate-3); font-size: 12px; margin-top: 4px; }
+  .diagram { background: #fff; border: 1px solid var(--rule); border-radius: 4px; padding: 28px; margin: 16px 0 8px; overflow-x: auto; }
+  .caption { font-size: 13px; color: var(--slate-3); margin: 8px 0 0; font-style: italic; }
+  table { width: 100%; border-collapse: collapse; margin: 12px 0 32px; }
+  th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--rule); font-size: 14px; vertical-align: top; }
+  th { color: var(--slate-3); text-transform: uppercase; letter-spacing: 0.1em; font-size: 11px; font-weight: 600; background: var(--ivory-2); }
+  .pill { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 11px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; }
+  .pill.eval { background: var(--clay-tint); color: var(--clay-deep); }
+  .pill.rt { background: #d9e2eb; color: var(--sky); }
+  .pill.sim { background: #dde7d3; color: var(--moss); }
+  .pill.be { background: var(--purple-tint); color: var(--purple); }
+  details { border: 1px solid var(--rule); border-radius: 4px; padding: 14px 18px; margin: 10px 0; background: #fff; }
+  details summary { cursor: pointer; font-weight: 600; color: var(--slate); font-size: 15px; }
+  details[open] summary { margin-bottom: 10px; }
+  footer { margin-top: 80px; padding-top: 24px; border-top: 1px solid var(--rule); color: var(--slate-3); font-size: 12px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="card">
+  <div class="eyebrow">Type System Map · main · 2026-05-22</div>
+  <h1>Types UML — evaluatorq, redteam, agent simulation</h1>
+  <p class="tldr">Four regions share one bridge: <code>AgentResponse</code>. Evaluatorq core owns the unified output contract; redteam owns the <code>AgentTarget</code> protocol, orchestration models (<code>Turn</code>-canonical <code>OrchestratorResult</code>), and job I/O boundary (<code>JobOutputPayload</code>); backends/integrations provide target implementations with history; agent simulation owns persona/scenario/result models. <code>OrqResponsesTarget</code> is dual-role with a partial-stateless contract (sim <code>__call__</code> stateless, redteam <code>send_prompt</code> stateful). <strong>RES-844 proposal section</strong> at the bottom captures the planned move of <code>AgentTarget</code> into <code>evaluatorq.contracts</code> and the optional stateless <code>respond(messages)</code> path.</p>
+</header>
+
+<section>
+  <h2>Legend</h2>
+  <div class="legend">
+    <div class="chip eval"><span class="dot"></span><strong>Evaluatorq core</strong><small>contracts.py + openresponses.convert_models</small></div>
+    <div class="chip rt"><span class="dot"></span><strong>Redteam contracts</strong><small>redteam.contracts (re-exports core)</small></div>
+    <div class="chip be"><span class="dot"></span><strong>Backends / integrations</strong><small>redteam.backends + integrations.*</small></div>
+    <div class="chip sim"><span class="dot"></span><strong>Agent simulation</strong><small>simulation.types + simulation.target</small></div>
+  </div>
+</section>
+
+<section>
+  <h2>Class diagram — core &amp; redteam contracts</h2>
+  <p><code>OrchestratorResult.turns</code> is the canonical record — <code>conversation</code>, <code>final_response</code>, <code>n_turns</code> are derived properties. The evaluation chain flows <code>AttackEvaluationResult → EvaluationPayload → UnifiedEvaluationResult</code>. <code>JobOutputPayload</code> is the job I/O boundary between job runner and report builder. <code>RedTeamResult</code> carries <code>AgentInfo</code> and optional <code>ExecutionDetails</code> (dynamic pipeline only).</p>
+  <div class="diagram">
+<pre class="mermaid">
+classDiagram
+    direction TB
+
+    %% ── EVALUATORQ CORE ──────────────────────────────
+    class LLMCallConfig {
+        +str model
+        +str api
+        +float temperature
+        +int max_tokens
+        +int timeout_ms
+        +dict extra_kwargs
+        +Any client
+    }
+    class AgentResponse {
+        +list~OutputMessage~ output
+        +Any usage
+        +str model
+        +str response_id
+        +str finish_reason
+        +text() str
+        +tool_calls() list~ToolCallOutputItem~
+    }
+    class OutputMessage {
+        &lt;&lt;Union&gt;&gt;
+    }
+    class TextOutputItem {
+        +type: output_text
+        +str text
+        +list annotations
+        +list logprobs
+    }
+    class ToolCallOutputItem {
+        +type: function_call
+        +str id
+        +str call_id
+        +str name
+        +str arguments
+        +str status
+        +str result
+        +arguments_dict() dict
+    }
+    class ReasoningOutputItem {
+        +type: reasoning
+        +str text
+        +str id
+    }
+
+    OutputMessage &lt;|.. TextOutputItem
+    OutputMessage &lt;|.. ToolCallOutputItem
+    OutputMessage &lt;|.. ReasoningOutputItem
+    AgentResponse "1" *-- "many" OutputMessage
+    AgentResponse ..&gt; ToolCallOutputItem : filters in tool_calls
+
+    %% ── REDTEAM — TARGET PROTOCOL FAMILY ────────────
+    class AgentTarget {
+        &lt;&lt;Protocol · redteam.backends.base&gt;&gt;
+        +str memory_entity_id
+        +send_prompt(prompt) AgentResponse
+        +new() AgentTarget
+    }
+    class AgentTargetFactory {
+        &lt;&lt;Protocol&gt;&gt;
+        +create_target(agent_key) AgentTarget
+    }
+    class AgentContextProvider {
+        &lt;&lt;Protocol&gt;&gt;
+        +get_agent_context(agent_key) AgentContext
+    }
+    class MemoryCleanup {
+        &lt;&lt;Protocol&gt;&gt;
+        +cleanup_memory(ctx, entity_ids)
+    }
+    class ErrorMapper {
+        &lt;&lt;Protocol&gt;&gt;
+        +map_error(exc) tuple~str,str~
+    }
+    class BackendBundle {
+        &lt;&lt;dataclass · slots&gt;&gt;
+        +str name
+        +AgentTargetFactory target_factory
+        +AgentContextProvider context_provider
+        +MemoryCleanup memory_cleanup
+        +ErrorMapper error_mapper
+    }
+    class DirectTargetFactory {
+        +AgentTarget _target
+        +create_target(agent_key) AgentTarget
+    }
+    class NoopMemoryCleanup {
+        +cleanup_memory(ctx, entity_ids)
+    }
+    class DefaultErrorMapper {
+        +map_error(exc) tuple~str,str~
+    }
+
+    AgentTarget ..&gt; AgentResponse : send_prompt returns
+    AgentTargetFactory ..&gt; AgentTarget : creates
+    AgentContextProvider ..&gt; AgentContext : returns
+    BackendBundle *-- AgentTargetFactory
+    BackendBundle *-- AgentContextProvider
+    BackendBundle *-- MemoryCleanup
+    BackendBundle *-- ErrorMapper
+    DirectTargetFactory ..|&gt; AgentTargetFactory
+    NoopMemoryCleanup ..|&gt; MemoryCleanup
+    DefaultErrorMapper ..|&gt; ErrorMapper
+
+    %% ── REDTEAM — CONVERSATION + CONTEXT ────────────
+    class Message {
+        +Literal[user,assistant,tool,system] role
+        +str content
+        +list~StrategyToolCall~ tool_calls
+        +str tool_call_id
+        +str name
+    }
+    class AttackerResponse {
+        +str generated_prompt
+        +TokenUsage usage
+        +bool truncated
+        +str finish_reason
+    }
+    class Turn {
+        +AttackerResponse attacker
+        +AgentResponse target
+    }
+    class RedTeamInput {
+        +str id
+        +str vulnerability
+        +str attack_technique
+        +str delivery_method
+        +Severity severity
+        +VulnerabilityDomain vulnerability_domain
+        +Framework framework
+        +TurnType turn_type
+        +str source
+        +dict additional_metadata
+    }
+    class AgentContext {
+        +str key
+        +str display_name
+        +str description
+        +str system_prompt
+        +str instructions
+        +list~ToolInfo~ tools
+        +list~MemoryStoreInfo~ memory_stores
+        +str model
+        +has_tools() bool
+        +has_memory() bool
+    }
+
+    Turn *-- AttackerResponse
+    Turn *-- AgentResponse
+
+    %% ── REDTEAM — ORCHESTRATION ──────────────────────
+    class LLMConfig {
+        +LLMCallConfig attacker
+        +LLMCallConfig evaluator
+        +int retry_count
+        +list~int~ retry_on_codes
+        +int cleanup_timeout_ms
+        +int target_agent_timeout_ms
+        +int max_tool_continuations
+        +retry_config() dict
+    }
+    class TokenUsage_RT {
+        +int total_tokens
+        +int prompt_tokens
+        +int completion_tokens
+        +int calls
+        +from_completion(response) TokenUsage
+        +__add__(other) TokenUsage
+    }
+    class OrchestratorResult {
+        +list~Turn~ turns
+        +bool objective_achieved
+        +float duration_seconds
+        +TokenUsage token_usage
+        +TokenUsage token_usage_adversarial
+        +TokenUsage token_usage_target
+        +str system_prompt
+        +int max_turns
+        +str error
+        +str error_type
+        +str error_stage
+        +str error_code
+        +int error_turn
+        +list~int~ truncated_turns
+        +n_turns() int
+        +conversation() list~Message~
+        +final_response() str
+    }
+    class AttackOutput {
+        +str category
+        +str vulnerability
+    }
+    class ErrorInfo {
+        +str message
+        +str error_type
+        +str stage
+        +str code
+        +dict details
+        +int turn
+    }
+
+    LLMConfig *-- LLMCallConfig
+    OrchestratorResult "1" *-- "many" Turn
+    OrchestratorResult ..&gt; TokenUsage_RT
+    AttackOutput --|&gt; OrchestratorResult
+
+    %% ── REDTEAM — EVALUATION CHAIN ──────────────────
+    class AttackEvaluationResult {
+        +bool passed
+        +str explanation
+        +str evaluator_id
+        +TokenUsage token_usage
+        +dict raw_output
+    }
+    class EvaluationPayload {
+        +str evaluator_id
+        +str evaluator_name
+        +Any value
+        +str explanation
+        +bool passed
+        +str error
+        +TokenUsage token_usage
+    }
+    class UnifiedEvaluationResult {
+        +Any value
+        +bool passed
+        +str explanation
+        +str evaluator_id
+        +str evaluator_name
+        +TokenUsage token_usage
+        +dict raw_output
+    }
+
+    AttackEvaluationResult ..&gt; EvaluationPayload : informs
+    EvaluationPayload ..&gt; UnifiedEvaluationResult : normalized to
+
+    %% ── REDTEAM — JOB BOUNDARY + REPORT ─────────────
+    class JobOutputPayload {
+        +list~Message~ conversation
+        +str final_response
+        +int turns
+        +int max_turns
+        +bool objective_achieved
+        +float duration_seconds
+        +TokenUsage token_usage
+        +TokenUsage token_usage_adversarial
+        +TokenUsage token_usage_target
+        +str system_prompt
+        +str error
+        +str error_type
+        +str error_stage
+        +str error_code
+        +int error_turn
+        +list~int~ truncated_turns
+        +str finish_reason
+        +response_text() str
+    }
+    class AttackInfo {
+        +str id
+        +str vulnerability
+        +str category
+        +Framework framework
+        +AttackTechnique attack_technique
+        +list~DeliveryMethod~ delivery_methods
+        +TurnType turn_type
+        +Severity severity
+        +VulnerabilityDomain vulnerability_domain
+        +str source
+        +str strategy_name
+        +str objective
+        +str evaluator_id
+        +dict additional_metadata
+    }
+    class AgentInfo {
+        +str key
+        +str model
+        +str display_name
+    }
+    class ExecutionDetails {
+        +int turns
+        +int max_turns
+        +float duration_seconds
+        +bool objective_achieved
+        +TokenUsage token_usage
+    }
+    class RedTeamResult {
+        +AttackInfo attack
+        +AgentInfo agent
+        +list~Message~ messages
+        +str response
+        +UnifiedEvaluationResult evaluation
+        +bool vulnerable
+        +ExecutionDetails execution
+        +str error
+        +str error_type
+        +error_info() ErrorInfo
+    }
+    class RedTeamReport {
+        +str version
+        +datetime created_at
+        +str description
+        +Pipeline pipeline
+        +Framework framework
+        +list~str~ categories_tested
+        +list~str~ tested_agents
+        +int total_results
+        +AgentContext agent_context
+        +dict agent_contexts
+        +list~RedTeamResult~ results
+        +ReportSummary summary
+        +TokenUsage token_usage_summary
+        +float duration_seconds
+        +list~str~ pipeline_warnings
+    }
+
+    OrchestratorResult ..&gt; JobOutputPayload : serialized to
+    JobOutputPayload "1" *-- "many" Message
+    JobOutputPayload o-- ToolCallOutputItem
+    JobOutputPayload ..&gt; RedTeamResult : converted from
+    RedTeamResult *-- AttackInfo
+    RedTeamResult *-- AgentInfo
+    RedTeamResult *-- UnifiedEvaluationResult
+    RedTeamResult o-- ExecutionDetails
+    RedTeamResult o-- ToolCallOutputItem
+    RedTeamResult ..&gt; ErrorInfo : error_info property
+    RedTeamReport "1" *-- "many" RedTeamResult
+    RedTeamReport o-- AgentContext
+    RedTeamInput ..&gt; AttackInfo : shapes
+
+    %% ── AGENT SIMULATION ────────────────────────────
+    class OrqResponsesTarget {
+        +LLMCallConfig config
+        +str instructions
+        +str memory_entity_id
+        +str _previous_response_id
+        +TokenUsage _accumulated_usage
+        +__call__(messages) str «stateless»
+        +send_prompt(prompt) AgentResponse «stateful»
+        +new() OrqResponsesTarget
+        +get_usage() TokenUsage
+    }
+    class Persona {
+        +str name
+        +float patience
+        +float assertiveness
+        +float politeness
+        +float technical_level
+        +CommunicationStyle communication_style
+        +str background
+        +EmotionalArc emotional_arc
+        +CulturalContext cultural_context
+    }
+    class Scenario {
+        +str name
+        +str goal
+        +str context
+        +StartingEmotion starting_emotion
+        +list~Criterion~ criteria
+        +bool is_edge_case
+        +ConversationStrategy conversation_strategy
+        +str ground_truth
+        +InputFormat input_format
+    }
+    class Datapoint {
+        +str id
+        +Persona persona
+        +Scenario scenario
+        +str user_system_prompt
+        +str first_message
+    }
+    class Judgment {
+        +bool should_terminate
+        +str reason
+        +bool goal_achieved
+        +list~str~ rules_broken
+        +float goal_completion_score
+        +float response_quality
+        +float hallucination_risk
+        +float tone_appropriateness
+        +float factual_accuracy
+    }
+    class TurnMetrics {
+        +int turn_number
+        +TokenUsage token_usage
+        +float response_quality
+        +float hallucination_risk
+        +float tone_appropriateness
+        +float factual_accuracy
+        +str judge_reason
+    }
+    class TokenUsage_Sim {
+        +int prompt_tokens
+        +int completion_tokens
+        +int total_tokens
+    }
+    class SimulationResult {
+        +list~Message~ messages
+        +TerminatedBy terminated_by
+        +str reason
+        +bool goal_achieved
+        +float goal_completion_score
+        +list~str~ rules_broken
+        +int turn_count
+        +TokenUsage token_usage
+        +list~TurnMetrics~ turn_metrics
+        +dict metadata
+        +dict criteria_results
+        +int total_turns
+    }
+
+    OrqResponsesTarget ..&gt; AgentResponse : produces
+    OrqResponsesTarget *-- LLMCallConfig
+    Datapoint *-- Persona
+    Datapoint *-- Scenario
+    SimulationResult o-- TurnMetrics
+    SimulationResult ..&gt; TokenUsage_Sim
+    TurnMetrics ..&gt; Judgment
+    TurnMetrics ..&gt; TokenUsage_Sim
+</pre>
+  </div>
+  <p class="caption">Solid diamond = composition. Open diamond = aggregation. Dashed arrow = produces/derives. Filled triangle = inheritance. <code>passed=True</code> means RESISTANT (attack failed). <code>OrchestratorResult.turns</code> is canonical — <code>conversation</code> is a derived property.</p>
+</section>
+
+<section>
+  <h2>Class diagram — backend &amp; integration layer</h2>
+  <p><code>AgentTarget</code> is a Protocol (structural subtyping). <code>OpenAIModelTarget</code> and <code>OpenAIAgentTarget</code> both maintain <code>_history</code> for multi-turn context — the former accumulates Chat Completions message pairs, the latter uses the Agents SDK <code>to_input_list()</code>. <code>OrqResponsesTarget</code> threads state via <code>_previous_response_id</code> (Responses v3 API) on its stateful <code>send_prompt</code> path only; its sim <code>__call__</code> path is stateless.</p>
+  <div class="diagram">
+<pre class="mermaid">
+classDiagram
+    direction LR
+
+    class AgentTarget {
+        &lt;&lt;Protocol&gt;&gt;
+        +str memory_entity_id
+        +send_prompt(prompt) AgentResponse
+        +new() AgentTarget
+    }
+    class ORQAgentTarget {
+        +str agent_key
+        +str memory_entity_id
+        +send_prompt(prompt) AgentResponse
+        +new() ORQAgentTarget
+    }
+    class OpenAIModelTarget {
+        +str model
+        +str system_prompt
+        +None memory_entity_id
+        +list _history
+        +send_prompt(prompt) AgentResponse
+        +new() OpenAIModelTarget
+    }
+    class LangGraphTarget {
+        +str memory_entity_id
+        +send_prompt(prompt) AgentResponse
+        +new() LangGraphTarget
+    }
+    class CallableTarget {
+        +str memory_entity_id
+        +send_prompt(prompt) AgentResponse
+        +new() CallableTarget
+    }
+    class OpenAIAgentTarget {
+        +None memory_entity_id
+        +list _history
+        +send_prompt(prompt) AgentResponse
+        +new() OpenAIAgentTarget
+    }
+    class VercelAISdkTarget {
+        +None memory_entity_id
+        +str endpoint_url
+        +send_prompt(prompt) AgentResponse
+        +new() VercelAISdkTarget
+    }
+    class OrqResponsesTarget {
+        +LLMCallConfig config
+        +str memory_entity_id
+        +str _previous_response_id
+        +TokenUsage _accumulated_usage
+        +__call__(messages) str «stateless»
+        +send_prompt(prompt) AgentResponse «stateful»
+        +new() OrqResponsesTarget
+        +get_usage() TokenUsage
+    }
+
+    ORQAgentTarget ..|&gt; AgentTarget : implements
+    OpenAIModelTarget ..|&gt; AgentTarget : implements
+    LangGraphTarget ..|&gt; AgentTarget : implements
+    CallableTarget ..|&gt; AgentTarget : implements
+    OpenAIAgentTarget ..|&gt; AgentTarget : implements
+    VercelAISdkTarget ..|&gt; AgentTarget : implements
+    OrqResponsesTarget ..|&gt; AgentTarget : implements
+</pre>
+  </div>
+  <p class="caption">Dotted line with open triangle = implements protocol (structural). <code>memory_entity_id=None</code> → stateless target. Non-null → persistent state; <code>new()</code> mints fresh uuid for attack isolation.</p>
+</section>
+
+<section>
+  <h2>Data flow</h2>
+  <div class="diagram">
+<pre class="mermaid">
+flowchart LR
+    subgraph CORE["evaluatorq core"]
+        AR[AgentResponse]
+        OM[OutputMessage union]
+        LCC[LLMCallConfig]
+    end
+    subgraph BE["backends / integrations"]
+        AT[AgentTarget protocol]
+        ORQ[ORQAgentTarget]
+        OAI[OpenAIModelTarget]
+        LG[LangGraphTarget]
+        CA[CallableTarget]
+        OAA[OpenAIAgentTarget]
+        VER[VercelAISdkTarget]
+    end
+    subgraph SIM["agent simulation"]
+        ORT[OrqResponsesTarget]
+        SIMF[simulate fn]
+        SR[SimulationResult]
+    end
+    subgraph RT["redteam"]
+        RTI[RedTeamInput]
+        ORCH[orchestrator]
+        TRN[Turn]
+        OR[OrchestratorResult]
+        AER[AttackEvaluationResult]
+        EP[EvaluationPayload]
+        UER[UnifiedEvaluationResult]
+        JOP[JobOutputPayload]
+        RTR[RedTeamResult]
+        REP[RedTeamReport]
+    end
+
+    LCC --> ORT
+    ORT -- send_prompt --> AR
+    ORT -- __call__ --> SIMF
+    SIMF --> SR
+    ORQ -. implements .-> AT
+    OAI -. implements .-> AT
+    LG -. implements .-> AT
+    CA -. implements .-> AT
+    OAA -. implements .-> AT
+    VER -. implements .-> AT
+    ORT -. implements .-> AT
+    RTI --> ORCH
+    AT -- send_prompt --> AR
+    AR --> ORCH
+    ORCH --> TRN
+    TRN --> OR
+    OR -- eval --> AER
+    AER --> EP
+    EP --> UER
+    OR -- serialized --> JOP
+    JOP -- converted --> RTR
+    UER --> RTR
+    RTR --> REP
+    AR --> OM
+</pre>
+  </div>
+</section>
+
+<section>
+  <h2>Ownership map</h2>
+  <table>
+    <thead><tr><th>Type</th><th>Home module</th><th>Region</th><th>Notes</th></tr></thead>
+    <tbody>
+      <tr><td><code>AgentResponse</code></td><td><code>evaluatorq.contracts</code></td><td><span class="pill eval">core</span></td><td>Frozen. <code>output</code> list preserves order. Legacy <code>text=</code> shorthand accepted</td></tr>
+      <tr><td><code>LLMCallConfig</code></td><td><code>evaluatorq.contracts</code></td><td><span class="pill eval">core</span></td><td><code>api</code> selects <code>chat_completions</code> vs <code>responses</code></td></tr>
+      <tr><td><code>ReasoningOutputItem</code></td><td><code>evaluatorq.contracts</code></td><td><span class="pill eval">core</span></td><td>For o-series / thinking models. Frozen</td></tr>
+      <tr><td><code>TextOutputItem</code></td><td><code>openresponses.convert_models.OutputTextContent</code></td><td><span class="pill eval">core</span></td><td>Alias. Frozen</td></tr>
+      <tr><td><code>ToolCallOutputItem</code></td><td><code>openresponses.convert_models.FunctionCall</code></td><td><span class="pill eval">core</span></td><td>Alias. Has both <code>id</code> (item) and <code>call_id</code> (correlation). <code>arguments</code> is JSON string — use <code>.arguments_dict</code></td></tr>
+      <tr><td><code>AgentTarget</code></td><td><code>redteam.backends.base</code></td><td><span class="pill rt">redteam</span></td><td>Protocol. <code>send_prompt</code> + <code>new</code> required</td></tr>
+      <tr><td><code>Message</code> (redteam)</td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td>5-field OpenAI format. Supports user/assistant/tool/system roles including tool-call and tool-response shapes</td></tr>
+      <tr><td><code>AttackerResponse</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td>Frozen. <code>generated_prompt</code> is what gets sent to target</td></tr>
+      <tr><td><code>Turn</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td>Frozen. Canonical per-turn record in <code>OrchestratorResult.turns</code></td></tr>
+      <tr><td><code>RedTeamInput</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td>Entry-point config for one static attack sample</td></tr>
+      <tr><td><code>AgentContext</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td>Describes target agent config (tools, memory, KB). Used for adaptive attack generation and stored in <code>RedTeamReport</code></td></tr>
+      <tr><td><code>LLMConfig</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td>Bundles attacker + evaluator <code>LLMCallConfig</code> plus retry/timeout/continuation settings</td></tr>
+      <tr><td><code>TokenUsage</code> (rt)</td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td>Has <code>calls</code>, <code>from_completion</code>, <code>__add__</code>. Not interchangeable with sim variant. <code>total=0</code> falls back to <code>prompt+completion</code></td></tr>
+      <tr><td><code>OrchestratorResult</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td>Canonical record is <code>turns: list[Turn]</code>. <code>conversation</code>, <code>final_response</code>, <code>n_turns</code> are derived properties. Split token usage: <code>token_usage_adversarial</code> + <code>token_usage_target</code></td></tr>
+      <tr><td><code>AttackOutput</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td>Extends <code>OrchestratorResult</code> with <code>category</code>/<code>vulnerability</code></td></tr>
+      <tr><td><code>ErrorInfo</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td>Structured view of flat error fields. Returned by <code>RedTeamResult.error_info</code> property</td></tr>
+      <tr><td><code>AttackEvaluationResult</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td><code>passed=True</code> = RESISTANT. Feeds evaluation chain</td></tr>
+      <tr><td><code>EvaluationPayload</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td>Shared schema for staged/static/hybrid outputs. Normalizes to <code>UnifiedEvaluationResult</code></td></tr>
+      <tr><td><code>UnifiedEvaluationResult</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td>Stored in <code>RedTeamResult.evaluation</code></td></tr>
+      <tr><td><code>JobOutputPayload</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td><code>extra='allow'</code> absorbs schema drift. <code>response_text</code> fallback chain: <code>final_response → response → output</code></td></tr>
+      <tr><td><code>AttackInfo</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td><code>delivery_methods</code> is always a list. Superset of static + dynamic fields</td></tr>
+      <tr><td><code>AgentInfo</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td>Target agent metadata stored on <code>RedTeamResult</code></td></tr>
+      <tr><td><code>ExecutionDetails</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td>Dynamic pipeline only. <code>None</code> for static runs</td></tr>
+      <tr><td><code>RedTeamResult</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td>Unified result. Carries <code>AgentInfo</code>, <code>ExecutionDetails</code>, <code>UnifiedEvaluationResult</code></td></tr>
+      <tr><td><code>RedTeamReport</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td>Multi-agent via <code>agent_contexts: dict[str, AgentContext]</code>. <code>agent_context</code> is legacy single-agent field</td></tr>
+      <tr><td><code>SendResult</code></td><td><code>redteam.contracts</code></td><td><span class="pill rt">redteam</span></td><td><em>Deprecated</em> → alias of <code>AgentResponse</code></td></tr>
+      <tr><td><code>ORQAgentTarget</code></td><td><code>redteam.backends.orq</code></td><td><span class="pill be">backend</span></td><td>Wraps Orq SDK. Generates <code>memory_entity_id</code> per instance for isolation</td></tr>
+      <tr><td><code>OpenAIModelTarget</code></td><td><code>redteam.backends.openai</code></td><td><span class="pill be">backend</span></td><td>Accumulates <code>_history: list[ChatCompletionMessageParam]</code> for multi-turn. <code>new()</code> resets to empty</td></tr>
+      <tr><td><code>BackendBundle</code></td><td><code>redteam.backends.base</code></td><td><span class="pill be">backend</span></td><td>Groups factory + context provider + cleanup + error mapper</td></tr>
+      <tr><td><code>LangGraphTarget</code></td><td><code>integrations.langgraph_integration</code></td><td><span class="pill be">backend</span></td><td>Thread ID = <code>memory_entity_id</code> for checkpointer isolation</td></tr>
+      <tr><td><code>CallableTarget</code></td><td><code>integrations.callable_integration</code></td><td><span class="pill be">backend</span></td><td>Escape hatch: wraps any <code>fn(str) → str</code></td></tr>
+      <tr><td><code>OpenAIAgentTarget</code></td><td><code>integrations.openai_agents_integration</code></td><td><span class="pill be">backend</span></td><td>Client-side <code>_history</code> via <code>Runner.run().to_input_list()</code></td></tr>
+      <tr><td><code>VercelAISdkTarget</code></td><td><code>integrations.vercel_ai_sdk_integration</code></td><td><span class="pill be">backend</span></td><td>HTTP wrapper. Stateless; <code>memory_entity_id=None</code></td></tr>
+      <tr><td><code>OrqResponsesTarget</code></td><td><code>simulation.target</code></td><td><span class="pill sim">sim</span></td><td>Dual-role, partial-stateless. <code>send_prompt</code> threads via <code>_previous_response_id</code> &amp; accumulates usage; <code>__call__</code> is stateless w.r.t. self (safe to mix on one instance)</td></tr>
+      <tr><td><code>TokenUsage</code> (sim)</td><td><code>simulation.types</code></td><td><span class="pill sim">sim</span></td><td>Slim — no <code>calls</code>, no arithmetic operators</td></tr>
+      <tr><td><code>Persona</code></td><td><code>simulation.types</code></td><td><span class="pill sim">sim</span></td><td>Includes <code>emotional_arc</code>, <code>cultural_context</code></td></tr>
+      <tr><td><code>Scenario</code></td><td><code>simulation.types</code></td><td><span class="pill sim">sim</span></td><td>Includes <code>ground_truth</code>, <code>input_format</code>, <code>conversation_strategy</code></td></tr>
+      <tr><td><code>Datapoint</code></td><td><code>simulation.types</code></td><td><span class="pill sim">sim</span></td><td>Input to <code>simulate()</code>. <code>user_system_prompt</code> is cached — runner always rebuilds from persona+scenario</td></tr>
+      <tr><td><code>Judgment</code></td><td><code>simulation.types</code></td><td><span class="pill sim">sim</span></td><td>Per-turn judge output. Includes <code>rules_broken</code>, all quality scores</td></tr>
+      <tr><td><code>TurnMetrics</code></td><td><code>simulation.types</code></td><td><span class="pill sim">sim</span></td><td>Aggregated from <code>Judgment</code> + token usage per turn</td></tr>
+      <tr><td><code>SimulationResult</code></td><td><code>simulation.types</code></td><td><span class="pill sim">sim</span></td><td>Includes <code>reason</code>, <code>rules_broken</code>, <code>criteria_results</code>, <code>metadata</code></td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section>
+  <h2>Key invariants</h2>
+  <ul>
+    <li><code>OrchestratorResult.turns</code> is the canonical record — <code>conversation</code>, <code>final_response</code>, <code>n_turns</code> are derived. Do not read from <code>conversation</code> if you need per-turn attacker/target pairing.</li>
+    <li><code>AgentResponse.output</code> preserves order. <code>.tool_calls</code> is a filtered view. Use <code>.output</code> when text/reasoning ordering matters.</li>
+    <li><code>ToolCallOutputItem</code> has two IDs: <code>id</code> (item identity) and <code>call_id</code> (tool call correlation across the function_call + function_call_output pair).</li>
+    <li><code>AgentTarget.new()</code> must return a fresh instance with clean state and a new <code>memory_entity_id</code> for persistent-memory targets.</li>
+    <li><code>AttackInfo.delivery_methods</code> is always a <code>list[DeliveryMethod]</code>, never singular.</li>
+    <li><code>JobOutputPayload</code> → <code>RedTeamResult</code> is the required conversion path. Do not construct <code>RedTeamResult</code> directly from <code>OrchestratorResult</code>.</li>
+    <li><code>JobOutputPayload.extra='allow'</code> — forward-compatible with new job output fields.</li>
+    <li>Two distinct <code>TokenUsage</code> types — redteam has <code>calls</code> + arithmetic, sim is slim. Not interchangeable.</li>
+    <li><code>OrqResponsesTarget.__call__</code> resets <code>_previous_response_id</code> per turn (full history passed by sim). Mixing <code>__call__</code> and <code>send_prompt</code> on the same instance corrupts threading.</li>
+    <li><code>RedTeamResult.execution</code> is <code>None</code> for static pipeline runs.</li>
+    <li><code>passed=True</code> means RESISTANT (attack failed to elicit the target behavior). Counterintuitive — read carefully.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Gotchas</h2>
+  <ul>
+    <li><strong><code>OrchestratorResult.conversation</code> is derived.</strong> It unpacks <code>turns</code> into a flat <code>list[Message]</code>. Modifying it has no effect on <code>turns</code>.</li>
+    <li><strong>Two <code>Message</code> types exist.</strong> <code>redteam.contracts.Message</code> (5 fields, supports <code>tool</code> role) vs <code>simulation.types.Message</code> (2 fields, no tool support). Do not swap them.</li>
+    <li><strong><code>OpenAIModelTarget</code> vs <code>OpenAIAgentTarget</code>.</strong> <code>OpenAIModelTarget</code> calls raw Chat Completions — stateless model, no tools/handoffs. <code>OpenAIAgentTarget</code> calls OpenAI Agents SDK — stateful via <code>_history</code>, supports tool use and multi-agent handoffs.</li>
+    <li><strong><code>AgentResponse.text</code> returns the last text item.</strong> Multi-text outputs lose earlier chunks. Read <code>.output</code> for full content.</li>
+    <li><strong><code>ToolCallOutputItem.arguments</code> is a JSON string.</strong> Use <code>.arguments_dict</code> — bad JSON silently becomes empty dict.</li>
+    <li><strong><code>TokenUsage.total_tokens=0</code> fallback.</strong> <code>from_completion</code> computes <code>prompt+completion</code> when provider reports zero total, preventing silent under-counting.</li>
+    <li><strong><code>LLMConfig.retry_config</code> returns <code>{}</code> in OpenAI mode.</strong> The <code>retry</code> param is ORQ-specific and rejected by OpenAI.</li>
+    <li><strong>Legacy migration is implicit.</strong> <code>scope</code> → <code>vulnerability_domain</code>, <code>framework='mixed'</code> → <code>'hybrid'</code>, <code>SendResult</code> → <code>AgentResponse</code>. All silent at validator time.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>FAQ</h2>
+  <details>
+    <summary>Why does OrchestratorResult use turns: list[Turn] instead of conversation: list[Message]?</summary>
+    <p>The canonical record preserves attacker/target pairing per turn — <code>Turn</code> holds both the <code>AttackerResponse</code> (with usage + truncation flag) and the <code>AgentResponse</code> (with full output items). A flat <code>Message</code> list loses this structure. <code>conversation</code> is a convenience property for code that only needs the OpenAI-format history.</p>
+  </details>
+  <details>
+    <summary>Why two TokenUsage types?</summary>
+    <p>Sim's predates the redteam variant; redteam needed <code>calls</code>, <code>from_completion</code>, and arithmetic operators for aggregation across multi-continuation ORQ calls. Merging requires migrating all sim aggregation sites.</p>
+  </details>
+  <details>
+    <summary>Why does JobOutputPayload exist between OrchestratorResult and RedTeamResult?</summary>
+    <p>It's the job I/O wire format — stored, returned via API, deserialized. <code>extra='allow'</code> makes it forward-compatible. <code>RedTeamResult</code> is the report-layer view built after eval enrichment and agent metadata are merged in.</p>
+  </details>
+  <details>
+    <summary>What's the difference between OpenAIModelTarget and OpenAIAgentTarget?</summary>
+    <p><code>OpenAIModelTarget</code>: calls raw Chat Completions API, takes a model name string, accumulates <code>_history</code> as plain message pairs. <code>OpenAIAgentTarget</code>: calls OpenAI Agents SDK <code>Runner.run()</code>, takes an <code>Agent</code> object, threads history via <code>to_input_list()</code>, supports tools and multi-agent handoffs. Use the model target for bare model red-teaming; use the agent target for Agents SDK apps.</p>
+  </details>
+  <details>
+    <summary>Which AgentTarget implementation should I use?</summary>
+    <p>ORQ-hosted agents → <code>ORQAgentTarget</code>. Raw OpenAI model → <code>OpenAIModelTarget</code>. LangGraph graph → <code>LangGraphTarget</code>. OpenAI Agents SDK → <code>OpenAIAgentTarget</code>. Vercel AI SDK HTTP endpoint → <code>VercelAISdkTarget</code>. Anything else → <code>CallableTarget</code> (wraps any <code>fn(str) → str</code>).</p>
+  </details>
+  <details>
+    <summary>Why is OrqResponsesTarget dual-role?</summary>
+    <p>Single implementation serves sim (<code>__call__</code> returning <code>str</code>) and redteam (<code>send_prompt</code> returning <code>AgentResponse</code>). Avoids duplicating Responses v3 client logic, retry, and usage accounting. State semantics differ: <code>__call__</code> is <b>stateless</b> w.r.t. self &mdash; never reads or writes <code>_previous_response_id</code> / <code>_accumulated_usage</code>, the sim runner owns the transcript and tracks usage independently. <code>send_prompt</code> is <b>stateful</b> &mdash; threads via <code>_previous_response_id</code> and accumulates usage on the instance. Internally both paths flow through a shared pure <code>_call_responses_api</code> helper via two private wrappers (<code>_invoke_stateless</code>, <code>_invoke_stateful</code>). A future ADR may split into two classes.</p>
+  </details>
+</section>
+
+<section>
+  <h2>Proposal — RES-844 protocol unification</h2>
+  <p><a href="https://linear.app/orqai/issue/RES-844">RES-844</a> promotes the <code>AgentTarget</code> protocol family out of <code>redteam/backends/base.py</code> so both red-team and simulation can consume the same contract, and unifies the sim/redteam target shapes. Below is the scope we landed on after design review (including an adversarial pass from <code>architecture-reviewer</code>) and three Orq-docs/codebase audits.</p>
+
+  <h3>Current state on main</h3>
+  <ul>
+    <li><code>AgentTarget</code> + <code>Supports*</code> family + <code>BackendBundle</code> + helpers live in <code>packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py</code> (lines 1–289). Nothing else in the repo defines them.</li>
+    <li><code>OrqResponsesTarget</code> already satisfies the protocol structurally — it carries <code>memory_entity_id</code>, <code>send_prompt</code>, <code>new()</code>, and <code>tests/redteam/test_orq_responses_target_as_agent_target.py</code> (17/17 passing) asserts <code>is_agent_target(OrqResponsesTarget) is True</code>.</li>
+    <li><code>simulation/runner/simulation.py:73</code> defines its own <code>TargetAgent</code> protocol with a different method shape (<code>respond(messages) -&gt; str</code>) — no shared contract with redteam today.</li>
+    <li><code>ORQAgentTarget</code> already uses the Responses route via <code>agents.responses.create</code> → <code>/v3/router/responses</code> (NOT the legacy <code>/v3/agents/execute-task</code> endpoint). State threading is via Orq-specific <code>task_id</code> + <code>memory_entity_id</code>; tool-call continuation is a client-side loop that re-POSTs synthetic <code>{kind:'tool_result'}</code> parts.</li>
+  </ul>
+
+  <h3>PR A — this cycle (S)</h3>
+  <p>Minimal, behavior-preserving consolidation. Unblocks <a href="https://linear.app/orqai/issue/RES-845">RES-845</a> (sim CLI), <a href="https://linear.app/orqai/issue/RES-846">RES-846</a> (sim reports), <a href="https://linear.app/orqai/issue/RES-847">RES-847</a> (sim hooks parity).</p>
+  <ul>
+    <li>Move <code>AgentTarget</code>, <code>SupportsTargetMetadata</code>, <code>SupportsAgentContext</code>, <code>SupportsTargetFactory</code>, <code>SupportsMemoryCleanup</code>, <code>SupportsErrorMapping</code>, <code>AgentTargetFactory</code>, <code>MemoryCleanup</code>, <code>ErrorMapper</code>, <code>BackendBundle</code>, plus helpers (<code>is_agent_target</code>, <code>adapt_legacy_target</code>, <code>validate_agent_target</code>, <code>DirectTargetFactory</code>, <code>NoopMemoryCleanup</code>, <code>DefaultErrorMapper</code>, <code>extract_status_code</code>, <code>extract_provider_error_code</code>) into <code>evaluatorq/contracts.py</code>. <em>Not</em> a new <code>common/</code> directory — <code>AgentResponse</code> + <code>LLMCallConfig</code> + <code>OutputMessage</code> already live in <code>contracts.py</code>, and a sibling junk-drawer module risks fragmenting "shared stuff" forever.</li>
+    <li><code>redteam/backends/base.py</code> becomes a thin re-export shim. All red-team-side imports (<code>backends/orq.py</code>, <code>backends/openai.py</code>, <code>backends/registry.py</code>, <code>runtime/orq_agent_job.py</code>) keep working unchanged.</li>
+    <li>Add an <em>optional</em> stateless method to <code>AgentTarget</code>: <code>async respond(messages: list[ChatMessage]) -&gt; AgentResponse</code>. Implement on <code>OrqResponsesTarget</code> by folding the current <code>__call__</code> path into it; <code>__call__</code> stays as a thin back-compat shim returning <code>.text</code>. Red-team backends do not implement <code>respond</code> in PR A.</li>
+    <li>Add adapter <code>as_target_callback(target: AgentTarget) -&gt; Callable[[list[ChatMessage]], Awaitable[str]]</code> in <code>contracts.py</code>. Internally extracts the last user message and calls <code>send_prompt</code> when <code>respond</code> is absent. Enables passing any red-team backend through the sim's <code>target_callback</code> entrypoint — closes acceptance criterion #2.</li>
+    <li>Replace <code>simulation/runner/simulation.py:73</code>'s ad-hoc <code>TargetAgent</code> protocol with <code>from evaluatorq.contracts import AgentTarget</code>. One protocol, one source.</li>
+    <li>Round-trip smoke test in <code>tests/common/test_target_protocol.py</code>: red-team backend through sim, sim target through red-team.</li>
+    <li><strong>Do not touch <code>ChatMessage</code></strong>. Stays as chat-completions <code>{role, content: str}</code> in <code>simulation/types.py:217</code>. Tool-call / tool-result transcript fidelity is PR B scope.</li>
+  </ul>
+
+  <h3>PR B — separate L ticket (deferred)</h3>
+  <p>True architectural unification on the Orq Responses input model. Should be filed as a new ticket so RES-844 stays small and reviewable.</p>
+  <ul>
+    <li>Adopt <code>openai.types.responses.ResponseInputItemParam</code> (or a sibling discriminated <code>InputItem</code> union in <code>contracts.py</code> following the proven <code>OutputMessage</code> pattern at <code>contracts.py:80–83</code>). Delete the hand-rolled TypedDicts in <code>openresponses/types.py</code>.</li>
+    <li>Migrate <em>all</em> red-team backends to a single <code>async respond(transcript: list[InputItem]) -&gt; AgentResponse</code>. Deprecate <code>send_prompt</code> with one minor's grace period.</li>
+    <li>Move <code>ORQAgentTarget</code>'s tool-continuation loop OUT of the target and into the orchestrator/caller, so targets stay pure functions of <code>(transcript) -&gt; AgentResponse</code>. Server returns aggregated usage per call; local accumulation today is an artifact of the client-side loop, not a requirement.</li>
+    <li>Introduce a <code>ThreadHandle</code> (or equivalent) only if red-team needs fork/rollback for crescendo attacks. Current behavior (per-attack <code>new()</code> instance) is enough for most cases.</li>
+    <li>Rewrite call sites in <code>redteam/runner.py:722, 1436</code>, <code>redteam/adaptive/pipeline.py:379</code>, <code>redteam/adaptive/orchestrator.py:652</code>, and every integration (<code>langgraph</code>, <code>callable</code>, <code>vercel_ai_sdk</code>, <code>openai_agents</code>).</li>
+  </ul>
+
+  <h3>Why split A vs B</h3>
+  <ul>
+    <li>PR A is purely additive + a directory move. No call-site rewrites, no protocol semantics change. Reviewable in one sitting.</li>
+    <li>PR B is the real architectural move — it touches every backend and every call site, and it requires extending the transcript data model. Smuggling it into a "promote protocol family" ticket would balloon RES-844 to L and block the downstream sim tickets.</li>
+    <li>The adversarial review surfaced four load-bearing concerns (silent <code>messages</code> ignore, concurrency footgun on <code>OrqResponsesTarget</code>, tool-result representation gap, <code>common/</code>-vs-<code>contracts</code> placement). PR A only addresses placement; the other three are scoped to PR B explicitly so they get the attention they need.</li>
+  </ul>
+
+  <h3>Decisions log</h3>
+  <ul>
+    <li><strong>Bandwidth is not a concern.</strong> Even if a stateless caller-owned-history flow re-uploads the full transcript every turn, we don't care. Rules out the cost-based objection to PR B's direction.</li>
+    <li><strong><code>previous_response_id</code> is not a token-cost optimization.</strong> LLM input tokens are billed identically whether you thread via <code>previous_response_id</code> or pass the full transcript inline. Only client→server upload bytes differ.</li>
+    <li><strong>ORQAgentTarget already uses the Responses route.</strong> The legacy <code>/v3/agents/execute-task</code> endpoint is not in play. <code>agents.responses.create</code> SDK method maps to <code>/v3/router/responses</code>.</li>
+    <li><strong>Server-side usage is aggregated per call.</strong> Local <code>_accumulated_usage</code> on <code>OrqResponsesTarget</code> and <code>ORQAgentTarget</code> exists only because of the client-side tool-continuation loop. Move the loop to the caller (PR B) and local accumulation drops out.</li>
+    <li><strong><code>ChatMessage</code> cannot represent Responses input items.</strong> It is OpenAI chat-completions shape (<code>{role, content: str}</code>) with no tool-call / tool-result / multi-part content. PR B copies the <code>OutputMessage</code> discriminated-union pattern from <code>contracts.py:80–83</code> rather than extending <code>ChatMessage</code> in-place.</li>
+    <li><strong>Protocol home is <code>evaluatorq.contracts</code>, not a new <code>common/</code> module.</strong> <code>AgentResponse</code> already lives there; making a second "shared stuff" directory creates a fragmentation we'll regret.</li>
+  </ul>
+
+  <h3>Target architecture (after PR A)</h3>
+  <div class="diagram">
+<pre class="mermaid">
+classDiagram
+    direction LR
+
+    class AgentTarget {
+        &lt;&lt;Protocol · evaluatorq.contracts&gt;&gt;
+        +str memory_entity_id
+        +send_prompt(prompt) AgentResponse «kept»
+        +respond(messages) AgentResponse «new, optional»
+        +new() AgentTarget
+    }
+    class redteam_backends_base {
+        &lt;&lt;shim&gt;&gt;
+        re-exports AgentTarget · Supports* · helpers
+    }
+    class ORQAgentTarget {
+        send_prompt(prompt) AgentResponse
+    }
+    class OpenAIModelTarget {
+        send_prompt(prompt) AgentResponse
+    }
+    class LangGraphTarget {
+        send_prompt(prompt) AgentResponse
+    }
+    class CallableTarget {
+        send_prompt(prompt) AgentResponse
+    }
+    class OpenAIAgentTarget {
+        send_prompt(prompt) AgentResponse
+    }
+    class VercelAISdkTarget {
+        send_prompt(prompt) AgentResponse
+    }
+    class OrqResponsesTarget {
+        send_prompt(prompt) AgentResponse «stateful»
+        respond(messages) AgentResponse «stateless»
+        __call__(messages) str «back-compat shim»
+    }
+    class as_target_callback {
+        &lt;&lt;adapter · evaluatorq.contracts&gt;&gt;
+        (target) =&gt; Callable~list~ChatMessage~,Awaitable~str~~
+    }
+    class TargetAgent_simulation {
+        &lt;&lt;removed — aliased to AgentTarget&gt;&gt;
+    }
+
+    redteam_backends_base ..&gt; AgentTarget : re-export
+    ORQAgentTarget ..|&gt; AgentTarget
+    OpenAIModelTarget ..|&gt; AgentTarget
+    LangGraphTarget ..|&gt; AgentTarget
+    CallableTarget ..|&gt; AgentTarget
+    OpenAIAgentTarget ..|&gt; AgentTarget
+    VercelAISdkTarget ..|&gt; AgentTarget
+    OrqResponsesTarget ..|&gt; AgentTarget
+    as_target_callback ..&gt; AgentTarget : wraps
+    TargetAgent_simulation ..&gt; AgentTarget : aliased
+</pre>
+  </div>
+  <p class="caption">Solid Protocol box marks the new home of the contract. Backends are unchanged; sim's <code>TargetAgent</code> protocol is deleted in favor of importing <code>AgentTarget</code> directly. <code>respond(messages)</code> is optional on the protocol in PR A — only <code>OrqResponsesTarget</code> implements it. PR B will make it required and deprecate <code>send_prompt</code>.</p>
+</section>
+
+<footer>
+  Source at <code>docs/types-uml.md</code>. Last refresh: main · 2026-05-22 · adds RES-844 proposal section.
+</footer>
+
+</div>
+<script>
+  mermaid.initialize({
+    startOnLoad: false,
+    theme: 'base',
+    themeVariables: {
+      fontFamily: 'system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif',
+      primaryColor: '#f0d9c9',
+      primaryTextColor: '#2b2f36',
+      primaryBorderColor: '#8e4623',
+      lineColor: '#7c8493',
+      secondaryColor: '#dde7d3',
+      tertiaryColor: '#d9e2eb',
+      background: '#ffffff',
+      mainBkg: '#f6f1e7',
+      nodeBorder: '#4a525e',
+      clusterBkg: '#ece4d2',
+      clusterBorder: '#d9d0bd',
+      titleColor: '#2b2f36',
+      edgeLabelBackground: '#f6f1e7',
+    },
+    flowchart: { curve: 'basis', padding: 16 },
+    class: { useMaxWidth: true },
+  });
+  // Wait for web fonts before mermaid measures text — fixes clipped class boxes.
+  (document.fonts && document.fonts.ready ? document.fonts.ready : Promise.resolve())
+    .then(() => mermaid.run());
+</script>
+</body>
+</html>

--- a/docs/types-uml.md
+++ b/docs/types-uml.md
@@ -1,6 +1,8 @@
 # Types UML — evaluatorq / redteam / agent simulation
 
-Four regions share one bridge: `AgentResponse`. Evaluatorq core owns the unified output contract; redteam owns the `AgentTarget` protocol, orchestration models, and job I/O boundary (`JobOutputPayload`); backends/integrations provide target implementations; agent simulation owns persona/scenario/result models.
+> Source-of-truth class map · main · 2026-05-22. Renders as `docs/types-uml.html`.
+
+Four regions share one bridge: `AgentResponse`. Evaluatorq core owns the unified output contract; redteam owns the `AgentTarget` protocol, orchestration models, and job I/O boundary (`JobOutputPayload`); backends/integrations provide target implementations; agent simulation owns persona/scenario/result models. **RES-844 proposal section at the bottom** captures the planned move of `AgentTarget` into `evaluatorq.contracts` and the optional stateless `respond(messages)` path.
 
 ## Class diagram — core & redteam contracts
 
@@ -57,6 +59,59 @@ classDiagram
     OutputMessage <|.. ReasoningOutputItem
     AgentResponse "1" *-- "many" OutputMessage
     AgentResponse ..> ToolCallOutputItem : filters in tool_calls
+
+    %% ── REDTEAM — TARGET PROTOCOL FAMILY ────────────
+    class AgentTarget {
+        <<Protocol · redteam.backends.base>>
+        +str memory_entity_id
+        +send_prompt(prompt) AgentResponse
+        +new() AgentTarget
+    }
+    class AgentTargetFactory {
+        <<Protocol>>
+        +create_target(agent_key) AgentTarget
+    }
+    class AgentContextProvider {
+        <<Protocol>>
+        +get_agent_context(agent_key) AgentContext
+    }
+    class MemoryCleanup {
+        <<Protocol>>
+        +cleanup_memory(ctx, entity_ids)
+    }
+    class ErrorMapper {
+        <<Protocol>>
+        +map_error(exc) tuple~str,str~
+    }
+    class BackendBundle {
+        <<dataclass · slots>>
+        +str name
+        +AgentTargetFactory target_factory
+        +AgentContextProvider context_provider
+        +MemoryCleanup memory_cleanup
+        +ErrorMapper error_mapper
+    }
+    class DirectTargetFactory {
+        +AgentTarget _target
+        +create_target(agent_key) AgentTarget
+    }
+    class NoopMemoryCleanup {
+        +cleanup_memory(ctx, entity_ids)
+    }
+    class DefaultErrorMapper {
+        +map_error(exc) tuple~str,str~
+    }
+
+    AgentTarget ..> AgentResponse : send_prompt returns
+    AgentTargetFactory ..> AgentTarget : creates
+    AgentContextProvider ..> AgentContext : returns
+    BackendBundle *-- AgentTargetFactory
+    BackendBundle *-- AgentContextProvider
+    BackendBundle *-- MemoryCleanup
+    BackendBundle *-- ErrorMapper
+    DirectTargetFactory ..|> AgentTargetFactory
+    NoopMemoryCleanup ..|> MemoryCleanup
+    DefaultErrorMapper ..|> ErrorMapper
 
     %% ── REDTEAM — CONVERSATION TYPES ────────────────
     class Message {
@@ -429,13 +484,6 @@ classDiagram
         +send_prompt(prompt) AgentResponse
         +new() OpenAIModelTarget
     }
-    class BackendBundle {
-        +str name
-        +AgentTargetFactory target_factory
-        +AgentContextProvider context_provider
-        +MemoryCleanup memory_cleanup
-        +ErrorMapper error_mapper
-    }
     class LangGraphTarget {
         +str memory_entity_id
         +send_prompt(prompt) AgentResponse
@@ -476,7 +524,6 @@ classDiagram
     OpenAIAgentTarget ..|> AgentTarget : implements
     VercelAISdkTarget ..|> AgentTarget : implements
     OrqResponsesTarget ..|> AgentTarget : implements
-    BackendBundle o-- AgentTarget
 ```
 
 ## Data flow
@@ -566,3 +613,115 @@ flowchart LR
 - `AgentContext` — describes target agent config (tools, memory, KB, model). Used for adaptive attack generation.
 - Two distinct `TokenUsage` types — redteam (`calls`, `from_completion`, arithmetic) vs sim (slim, no `calls`). Not interchangeable.
 - `SendResult` deprecated → alias of `AgentResponse`.
+
+---
+
+## Proposal — RES-844 protocol unification
+
+[RES-844](https://linear.app/orqai/issue/RES-844) promotes the `AgentTarget` protocol family out of `redteam/backends/base.py` so both red-team and simulation can consume the same contract, and unifies the sim/redteam target shapes. Scope landed on after design review (incl. an adversarial pass from `architecture-reviewer`) and three Orq-docs / codebase audits.
+
+### Current state on main
+
+- `AgentTarget` + `Supports*` family + `BackendBundle` + helpers live in `packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py` (lines 1–289). Nothing else in the repo defines them.
+- `OrqResponsesTarget` already satisfies the protocol structurally — carries `memory_entity_id`, `send_prompt`, `new()`, and `tests/redteam/test_orq_responses_target_as_agent_target.py` (17/17 passing) asserts `is_agent_target(OrqResponsesTarget) is True`.
+- `simulation/runner/simulation.py:73` defines its own `TargetAgent` protocol with a different shape (`respond(messages) -> str`). No shared contract.
+- `ORQAgentTarget` already uses the Responses route via `agents.responses.create` → `/v3/router/responses` (NOT the legacy `/v3/agents/execute-task` endpoint). State threading is via Orq-specific `task_id` + `memory_entity_id`; tool-call continuation is a client-side loop that re-POSTs synthetic `{kind:'tool_result'}` parts.
+
+### PR A — this cycle (S)
+
+Minimal, behavior-preserving consolidation. Unblocks [RES-845](https://linear.app/orqai/issue/RES-845) (sim CLI), [RES-846](https://linear.app/orqai/issue/RES-846) (sim reports), [RES-847](https://linear.app/orqai/issue/RES-847) (sim hooks parity).
+
+- Move `AgentTarget`, `SupportsTargetMetadata`, `SupportsAgentContext`, `SupportsTargetFactory`, `SupportsMemoryCleanup`, `SupportsErrorMapping`, `AgentTargetFactory`, `MemoryCleanup`, `ErrorMapper`, `BackendBundle`, plus helpers (`is_agent_target`, `adapt_legacy_target`, `validate_agent_target`, `DirectTargetFactory`, `NoopMemoryCleanup`, `DefaultErrorMapper`, `extract_status_code`, `extract_provider_error_code`) into `evaluatorq/contracts.py`. *Not* a new `common/` directory — `AgentResponse` + `LLMCallConfig` + `OutputMessage` already live there.
+- `redteam/backends/base.py` becomes a thin re-export shim. Red-team-side imports (`backends/orq.py`, `backends/openai.py`, `backends/registry.py`, `runtime/orq_agent_job.py`) unchanged.
+- Add optional `async respond(messages: list[ChatMessage]) -> AgentResponse` to `AgentTarget`. Implement on `OrqResponsesTarget` by folding `__call__` into it; `__call__` stays as a thin back-compat shim returning `.text`. Red-team backends do not implement `respond` in PR A.
+- Adapter `as_target_callback(target: AgentTarget) -> Callable[[list[ChatMessage]], Awaitable[str]]` in `contracts.py`. Closes acceptance criterion #2 (red-team backend usable as sim `target_callback`).
+- Replace `simulation/runner/simulation.py:73` `TargetAgent` protocol with `from evaluatorq.contracts import AgentTarget`. One protocol, one source.
+- Round-trip smoke test in `tests/common/test_target_protocol.py`.
+- **Do not touch `ChatMessage`.** Stays chat-completions `{role, content: str}` in `simulation/types.py:217`. Tool-call / tool-result transcript fidelity is PR B scope.
+
+### PR B — separate L ticket (deferred)
+
+True architectural unification on the Orq Responses input model.
+
+- Adopt `openai.types.responses.ResponseInputItemParam` (or a sibling discriminated `InputItem` union in `contracts.py` following the `OutputMessage` pattern at `contracts.py:80–83`). Delete the hand-rolled TypedDicts in `openresponses/types.py`.
+- Migrate all red-team backends to a single `async respond(transcript: list[InputItem]) -> AgentResponse`. Deprecate `send_prompt`.
+- Move `ORQAgentTarget`'s tool-continuation loop OUT of the target and into the orchestrator/caller, so targets stay pure functions of `(transcript) -> AgentResponse`. Server returns aggregated usage per call; local accumulation today is an artifact of the client-side loop.
+- Introduce `ThreadHandle` only if red-team needs fork/rollback for crescendo attacks.
+- Rewrite call sites in `redteam/runner.py:722, 1436`, `redteam/adaptive/pipeline.py:379`, `redteam/adaptive/orchestrator.py:652`, and every integration (`langgraph`, `callable`, `vercel_ai_sdk`, `openai_agents`).
+
+### Why split A vs B
+
+- PR A is additive + a directory move. No call-site rewrites, no protocol semantics change. Reviewable in one sitting.
+- PR B is the real architectural move — touches every backend and call site, and extends the transcript data model. Smuggling it into a "promote protocol family" ticket would balloon RES-844 to L and block RES-845/846/847.
+- Adversarial review surfaced four load-bearing concerns (silent `messages` ignore, concurrency footgun on `OrqResponsesTarget`, tool-result representation gap, `common/`-vs-`contracts` placement). PR A only addresses placement; the other three are scoped to PR B explicitly.
+
+### Decisions log
+
+- **Bandwidth is not a concern.** Stateless caller-owned-history flow re-uploading the full transcript every turn is fine. Rules out cost-based objection to PR B's direction.
+- **`previous_response_id` is not a token-cost optimization.** LLM input tokens are billed identically whether you thread via `previous_response_id` or pass the full transcript inline. Only client→server upload bytes differ.
+- **ORQAgentTarget already uses the Responses route.** Legacy `/v3/agents/execute-task` endpoint is not in play.
+- **Server-side usage is aggregated per call.** Local `_accumulated_usage` exists only because of the client-side tool-continuation loop. Move the loop to the caller (PR B) → local accumulation drops out.
+- **`ChatMessage` cannot represent Responses input items.** OpenAI chat-completions shape (`{role, content: str}`) — no tool-call / tool-result / multi-part content. PR B copies the `OutputMessage` discriminated-union pattern rather than extending `ChatMessage`.
+- **Protocol home is `evaluatorq.contracts`, not a new `common/` module.** `AgentResponse` already lives there.
+
+### Target architecture (after PR A)
+
+```mermaid
+classDiagram
+    direction LR
+
+    class AgentTarget {
+        <<Protocol · evaluatorq.contracts>>
+        +str memory_entity_id
+        +send_prompt(prompt) AgentResponse «kept»
+        +respond(messages) AgentResponse «new, optional»
+        +new() AgentTarget
+    }
+    class redteam_backends_base {
+        <<shim>>
+        re-exports AgentTarget · Supports* · helpers
+    }
+    class ORQAgentTarget {
+        send_prompt(prompt) AgentResponse
+    }
+    class OpenAIModelTarget {
+        send_prompt(prompt) AgentResponse
+    }
+    class LangGraphTarget {
+        send_prompt(prompt) AgentResponse
+    }
+    class CallableTarget {
+        send_prompt(prompt) AgentResponse
+    }
+    class OpenAIAgentTarget {
+        send_prompt(prompt) AgentResponse
+    }
+    class VercelAISdkTarget {
+        send_prompt(prompt) AgentResponse
+    }
+    class OrqResponsesTarget {
+        send_prompt(prompt) AgentResponse «stateful»
+        respond(messages) AgentResponse «stateless»
+        __call__(messages) str «back-compat shim»
+    }
+    class as_target_callback {
+        <<adapter · evaluatorq.contracts>>
+        (target) => Callable~list~ChatMessage~,Awaitable~str~~
+    }
+    class TargetAgent_simulation {
+        <<removed — aliased to AgentTarget>>
+    }
+
+    redteam_backends_base ..> AgentTarget : re-export
+    ORQAgentTarget ..|> AgentTarget
+    OpenAIModelTarget ..|> AgentTarget
+    LangGraphTarget ..|> AgentTarget
+    CallableTarget ..|> AgentTarget
+    OpenAIAgentTarget ..|> AgentTarget
+    VercelAISdkTarget ..|> AgentTarget
+    OrqResponsesTarget ..|> AgentTarget
+    as_target_callback ..> AgentTarget : wraps
+    TargetAgent_simulation ..> AgentTarget : aliased
+```
+
+Solid Protocol box marks the new home of the contract. Backends unchanged; sim's `TargetAgent` deleted in favor of importing `AgentTarget` directly. `respond(messages)` is optional in PR A — only `OrqResponsesTarget` implements it. PR B makes it required and deprecates `send_prompt`.


### PR DESCRIPTION
## Summary

Two related docs landing together:

- **RES-808** design spec + 4-PR implementation plan (collapse → relocate → unify, with PR4 tracked under [RES-877](https://linear.app/orqai/issue/RES-877)). Spec covers Backend ABC collapse, AgentTarget relocation to `evaluatorq.contracts`, and unification on `respond(messages)`. Plan is 2941 lines, bite-sized tasks with TDD + commit hooks, hate-review applied (commits 310ba41 + b399c56).
- **RES-844** types-uml doc refreshed against `main` + new "Proposal — RES-844 protocol unification" section (PR A/PR B split, decisions log, mermaid). Regenerated companion `docs/types-uml.html` via html-artifacts.

No code changes — pure planning artifacts.

## Commits

- 7347f4f docs(res-808): design spec for collapse + relocate + unify
- 9c79b07 docs(redteam): add RES-808 implementation plan
- 2d534ae docs(redteam): PR3 keeps OpenAIModelTarget._history; add PR4 (RES-877)
- 310ba41 docs(redteam): apply hate-review fixes to plan
- b399c56 docs(res-808): apply hate-review fixes to spec
- 8cbb9e7 docs(types-uml): refresh + add RES-844 proposal section

## Test plan

- [ ] Spec reviewers (Karina/Amina/Arian) ack the PR1/PR2/PR3 split + ORQAgentTarget endpoint decision
- [ ] Open `docs/types-uml.html` in browser, confirm mermaid renders + RES-844 section is present
- [ ] Confirm plan tasks reference correct file paths (spot-check Task 1.7 PreparedTarget refs at runner.py:1015, :1480, :1563, :1774)

🤖 Generated with [Claude Code](https://claude.com/claude-code)