### PR TITLE
RES-808 (PR1/3): collapse redteam backend abstractions to Backend + AgentTarget ABCs

### DIFF
--- a/packages/evaluatorq-py/src/evaluatorq/integrations/callable_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/callable_integration/target.py
@@ -51,10 +51,6 @@ class CallableTarget(AgentTarget):
         config = DynamicRunConfig(targets=[target])
     """
 
-    memory_entity_id: str | None = None
-    """Callables are opaque — the wrapper cannot manage memory isolation.
-    If the wrapped callable holds state, use ``reset_fn`` to clear it."""
-
     def __init__(
         self,
         fn: AgentCallable,
@@ -78,7 +74,10 @@ class CallableTarget(AgentTarget):
                 pipeline uses this for capability-aware strategy filtering —
                 without it, all strategies (including nonsensical ones) will be
                 applied. If not provided, a minimal context is returned.
+        Callables are opaque — the wrapper cannot manage memory isolation.
+        If the wrapped callable holds state, use ``reset_fn`` to clear it.
         """
+        super().__init__(memory_entity_id=None)
         self._fn = fn
         self._is_async = asyncio.iscoroutinefunction(fn)
         self._reset_fn = reset_fn

--- a/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
@@ -143,9 +143,9 @@ class LangGraphTarget(AgentTarget):
                 introspects the compiled graph (tools from a ``ToolNode``,
                 checkpointer presence) on a best-effort basis.
         """
+        super().__init__(memory_entity_id=uuid4().hex)
         self._graph = graph
         self._extra_config = config or {}
-        self.memory_entity_id: str = uuid4().hex
         self._agent_context = agent_context
         # Tracks how many messages were in the LangGraph thread before this turn.
         # Not safe for concurrent send_prompt calls on the same instance —

--- a/packages/evaluatorq-py/src/evaluatorq/integrations/openai_agents_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/openai_agents_integration/target.py
@@ -35,10 +35,6 @@ class OpenAIAgentTarget(AgentTarget):
         config = DynamicRunConfig(targets=[target])
     """
 
-    memory_entity_id: str | None = None
-    """OpenAI Agents SDK keeps conversation state client-side in ``_history``;
-    there is no server-side memory entity to isolate across parallel jobs."""
-
     def __init__(self, agent: Agent, *, run_kwargs: dict[str, Any] | None = None) -> None:
         """Create an OpenAI Agents SDK red teaming target.
 
@@ -46,7 +42,10 @@ class OpenAIAgentTarget(AgentTarget):
             agent: An OpenAI Agents SDK Agent instance.
             run_kwargs: Optional extra keyword arguments passed to ``Runner.run()``
                 (e.g. ``{"max_turns": 10}``).
+        OpenAI Agents SDK keeps conversation state client-side in ``_history``;
+        there is no server-side memory entity to isolate across parallel jobs.
         """
+        super().__init__(memory_entity_id=None)
         self._agent = agent
         self._run_kwargs = run_kwargs or {}
         self._history: list[Any] = []

--- a/packages/evaluatorq-py/src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py
@@ -47,10 +47,6 @@ class VercelAISdkTarget(AgentTarget):
         config = DynamicRunConfig(targets=[target])
     """
 
-    memory_entity_id: str | None = None
-    """Vercel AI SDK state lives inside the HTTP handler (stateless to us);
-    conversation history is tracked client-side in ``_history``."""
-
     def __init__(
         self,
         url: str,
@@ -75,7 +71,10 @@ class VercelAISdkTarget(AgentTarget):
                 nonsensical ones) will be applied. The HTTP handler cannot
                 be introspected from Python, so this must be supplied by
                 the caller when capability-aware filtering matters.
+        Vercel AI SDK state lives inside the HTTP handler (stateless to us);
+        conversation history is tracked client-side in ``_history``.
         """
+        super().__init__(memory_entity_id=None)
         self._url = url
         self._headers = headers or {}
         self._extra_body = extra_body or {}

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/__init__.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/__init__.py
@@ -39,12 +39,6 @@ from evaluatorq.redteam.adaptive.strategy_registry import (
 )
 from evaluatorq.redteam.backends.base import (
     AgentTarget,
-    DirectTargetFactory,
-    SupportsAgentContext,
-    SupportsErrorMapping,
-    SupportsMemoryCleanup,
-    SupportsTargetFactory,
-    is_agent_target,
 )
 from evaluatorq.redteam.backends.openai import OpenAIModelTarget
 from evaluatorq.redteam.backends.registry import register_backend
@@ -156,7 +150,6 @@ __all__ = [
     "DeliveryMethod",
     "DeliveryMethodSummary",
     "DimensionSummary",
-    "DirectTargetFactory",
     "DomainSummary",
     # Error model
     "ErrorInfo",
@@ -200,10 +193,6 @@ __all__ = [
     "TextOutputItem",
     "ToolCallOutputItem",
     "SeveritySummary",
-    "SupportsAgentContext",
-    "SupportsErrorMapping",
-    "SupportsMemoryCleanup",
-    "SupportsTargetFactory",
     "TargetConfig",
     "TechniqueSummary",
     "TokenUsage",
@@ -220,7 +209,6 @@ __all__ = [
     "VulnerabilitySummary",
     "get_category_info",
     "get_vulnerability_name",
-    "is_agent_target",
     # Vulnerability introspection
     "list_available_vulnerabilities",
     # Category introspection

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/agent_context.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/agent_context.py
@@ -5,17 +5,11 @@ from typing import Any
 
 from evaluatorq.redteam.contracts import AgentContext
 
-try:
-    from evaluatorq.redteam.backends.orq import ORQContextProvider as _ORQContextProvider
-    _orq_context_provider_cls: Any = _ORQContextProvider
-except ImportError:
-    _orq_context_provider_cls = None
-
 
 async def retrieve_agent_context(orq_client: Any, agent_key: str) -> AgentContext:
     """Retrieve agent context from ORQ API.
 
-    Delegates to :class:`ORQContextProvider`.
+    Delegates to :class:`ORQAgentTarget.get_agent_context`.
 
     Args:
         orq_client: ORQ SDK client instance
@@ -24,9 +18,12 @@ async def retrieve_agent_context(orq_client: Any, agent_key: str) -> AgentContex
     Returns:
         AgentContext with parsed and enriched agent configuration
     """
-    if _orq_context_provider_cls is None:
+    try:
+        from evaluatorq.redteam.backends.orq import ORQAgentTarget
+    except ImportError:
         raise ImportError("orq_ai_sdk is required for ORQ context retrieval. Install with: pip install orq-ai-sdk")
-    return await _orq_context_provider_cls(orq_client).get_agent_context(agent_key)
+    probe = ORQAgentTarget(agent_key=agent_key, orq_client=orq_client)
+    return await probe.get_agent_context()
 
 
 def retrieve_agent_context_sync(orq_client: Any, agent_key: str) -> AgentContext:

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/orchestrator.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/orchestrator.py
@@ -20,7 +20,11 @@ from typing_extensions import Self
 
 from evaluatorq.common.sanitize import xml_escape
 from evaluatorq.contracts import AgentResponse, TextOutputItem
-from evaluatorq.redteam.backends.base import AgentTarget, DefaultErrorMapper, ErrorMapper, _coerce_to_agent_response
+from evaluatorq.redteam.backends.base import AgentTarget, Backend, _coerce_to_agent_response
+
+
+def _default_map_error(exc: Exception) -> tuple[str, str]:
+    return "target_error", f"{type(exc).__name__}: {exc}"
 from evaluatorq.redteam.contracts import (
     DEFAULT_PIPELINE_MODEL,
     PIPELINE_CONFIG,
@@ -299,7 +303,7 @@ class MultiTurnOrchestrator:
         self,
         llm_client: AsyncOpenAI,
         model: str = DEFAULT_PIPELINE_MODEL,
-        error_mapper: ErrorMapper | None = None,
+        backend: Backend | None = None,
         attacker_instructions: str | None = None,
         verbosity: int = 0,
         llm_kwargs: dict[str, Any] | None = None,
@@ -310,7 +314,7 @@ class MultiTurnOrchestrator:
         Args:
             llm_client: OpenAI-compatible async client for adversarial LLM
             model: Model to use for adversarial prompt generation
-            error_mapper: Optional custom error mapper
+            backend: Optional Backend for error mapping
             attacker_instructions: Optional domain-specific context to steer attack generation
             verbosity: Verbosity level (0=silent, 1=summary progress bar, 2=per-attack progress bars)
             llm_kwargs: Deprecated — merged into pipeline_config.attacker.extra_kwargs at init. Use LLMCallConfig.extra_kwargs instead.
@@ -318,7 +322,7 @@ class MultiTurnOrchestrator:
         """
         self.llm_client = llm_client
         self.model = model
-        self.error_mapper = error_mapper or DefaultErrorMapper()
+        self._backend = backend
         self.attacker_instructions = attacker_instructions
         self.verbosity = verbosity
         self._cfg = pipeline_config or PIPELINE_CONFIG
@@ -698,7 +702,7 @@ class MultiTurnOrchestrator:
                             break
                     except Exception as e:
                         consecutive_agent_errors += 1
-                        mapped_code, error_msg = self.error_mapper.map_error(e)
+                        mapped_code, error_msg = self._backend.map_error(e) if self._backend is not None else _default_map_error(e)
                         agent_response = f'[ERROR: {error_msg}]'
                         _tgt_result = AgentResponse(output=[TextOutputItem(text=agent_response, annotations=[])])
                         logger.warning(f'Target agent error on turn {turn + 1}/{max_turns}: {error_msg}')

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/orchestrator.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/orchestrator.py
@@ -21,10 +21,6 @@ from typing_extensions import Self
 from evaluatorq.common.sanitize import xml_escape
 from evaluatorq.contracts import AgentResponse, TextOutputItem
 from evaluatorq.redteam.backends.base import AgentTarget, Backend, _coerce_to_agent_response
-
-
-def _default_map_error(exc: Exception) -> tuple[str, str]:
-    return "target_error", f"{type(exc).__name__}: {exc}"
 from evaluatorq.redteam.contracts import (
     DEFAULT_PIPELINE_MODEL,
     PIPELINE_CONFIG,
@@ -47,6 +43,12 @@ from evaluatorq.redteam.utils import safe_substitute
 
 if TYPE_CHECKING:
     from openai.types.chat import ChatCompletionMessageParam
+
+
+def _default_map_error(exc: Exception) -> tuple[str, str]:
+    """Fallback error mapping for the no-backend path; mirrors ``Backend.map_error``."""
+    return "target_error", f"{type(exc).__name__}: {exc}"
+
 
 _ui_console = Console(stderr=True)
 _PROGRESS_LABEL_MAX_LEN = 52

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/pipeline.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/pipeline.py
@@ -30,7 +30,7 @@ from evaluatorq.redteam.adaptive.strategy_planner import (
     plan_strategies_for_categories,
     plan_strategies_for_vulnerabilities,
 )
-from evaluatorq.redteam.backends.base import DefaultErrorMapper, _coerce_to_agent_response
+from evaluatorq.redteam.backends.base import Backend, _coerce_to_agent_response
 from evaluatorq.redteam.backends.registry import create_async_llm_client, resolve_backend
 from evaluatorq.redteam.contracts import (
     DEFAULT_PIPELINE_MODEL,
@@ -58,11 +58,7 @@ from evaluatorq.redteam.vulnerability_registry import (
 if TYPE_CHECKING:
     from openai import AsyncOpenAI
 
-    from evaluatorq.redteam.backends.base import (
-        AgentTargetFactory,
-        ErrorMapper,
-        MemoryCleanup,
-    )
+    from evaluatorq.redteam.backends.base import MemoryCleanup
     from evaluatorq.redteam.contracts import AgentContext
     from evaluatorq.types import ScorerParameter
 
@@ -273,8 +269,7 @@ def create_dynamic_redteam_job(
     agent_context: AgentContext,
     red_team_model: str = DEFAULT_PIPELINE_MODEL,
     max_turns: int = 5,
-    target_factory: AgentTargetFactory | None = None,
-    error_mapper: ErrorMapper | None = None,
+    backend: Backend | None = None,
     attack_llm_client: AsyncOpenAI | None = None,
     memory_entity_ids: list[str] | None = None,
     attacker_instructions: str | None = None,
@@ -301,13 +296,12 @@ def create_dynamic_redteam_job(
         agent_context: Pre-retrieved agent context
         red_team_model: Model for adversarial prompt generation
         max_turns: Maximum turns for multi-turn attacks
-        target_factory: Factory for creating AgentTarget instances. Defaults to ORQ.
+        backend: Backend for creating targets and mapping errors. Defaults to ORQ.
     """
     cfg = pipeline_config or PIPELINE_CONFIG
-    resolved_factory: AgentTargetFactory = (
-        target_factory if target_factory is not None else resolve_backend('orq', pipeline_config=cfg).target_factory
+    resolved_backend: Backend = (
+        backend if backend is not None else resolve_backend('orq', pipeline_config=cfg)
     )
-    resolved_error_mapper = error_mapper or DefaultErrorMapper()
     safe_agent_key = ''.join(ch if ch.isalnum() or ch in {'-', '_'} else '-' for ch in agent_key).strip('-')
     job_name = f'redteam:dynamic:{safe_agent_key or "agent"}'
 
@@ -331,7 +325,7 @@ def create_dynamic_redteam_job(
                 'orq.redteam.max_turns': effective_max_turns,
             },
         ) as attack_span, contextlib.AsyncExitStack() as cleanup_stack:
-            target = resolved_factory.create_target(agent_key=agent_key)
+            target = resolved_backend.create_target(agent_key=agent_key)
             # Register HTTP-client cleanup for targets that own a client
             # (e.g. OrqResponsesTarget). Plain callable targets have no
             # close(); duck-type to avoid coupling.
@@ -400,7 +394,7 @@ def create_dynamic_redteam_job(
                 except Exception as e:
                     if isinstance(e, (TypeError, AttributeError, ImportError, NameError)):
                         raise
-                    mapped_code, mapped_msg = resolved_error_mapper.map_error(e)
+                    mapped_code, mapped_msg = resolved_backend.map_error(e)
                     logger.error(f'Single-turn attack failed for {category}/{strategy.name}: {mapped_msg}')
                     response = f'[ERROR: {mapped_msg}]'
                     error = mapped_msg
@@ -452,7 +446,7 @@ def create_dynamic_redteam_job(
             orchestrator = MultiTurnOrchestrator(
                 llm_client,
                 model=red_team_model,
-                error_mapper=resolved_error_mapper,
+                backend=resolved_backend,
                 attacker_instructions=attacker_instructions,
                 verbosity=verbosity,
                 llm_kwargs=llm_kwargs,
@@ -469,7 +463,7 @@ def create_dynamic_redteam_job(
                 )
             except asyncio.TimeoutError as e:
                 tb = traceback.format_exc(limit=8)
-                mapped_code, mapped_msg = resolved_error_mapper.map_error(e)
+                mapped_code, mapped_msg = resolved_backend.map_error(e)
                 logger.error(f'Orchestrator timed out for {category}/{strategy.name}: {mapped_msg}\n{tb}')
                 result = OrchestratorResult(
                     objective_achieved=False,
@@ -492,7 +486,7 @@ def create_dynamic_redteam_job(
                 if isinstance(e, (TypeError, AttributeError, KeyError, IndexError, ImportError, NameError)):
                     raise
                 tb = traceback.format_exc(limit=8)
-                mapped_code, mapped_msg = resolved_error_mapper.map_error(e)
+                mapped_code, mapped_msg = resolved_backend.map_error(e)
                 logger.error(f'Unexpected orchestrator error for {category}/{strategy.name}: {mapped_msg}\n{tb}')
                 result = OrchestratorResult(
                     objective_achieved=False,

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/pipeline.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/pipeline.py
@@ -58,7 +58,6 @@ from evaluatorq.redteam.vulnerability_registry import (
 if TYPE_CHECKING:
     from openai import AsyncOpenAI
 
-    from evaluatorq.redteam.backends.base import MemoryCleanup
     from evaluatorq.redteam.contracts import AgentContext
     from evaluatorq.types import ScorerParameter
 
@@ -633,7 +632,7 @@ def create_dynamic_evaluator(
 async def cleanup_memory_entities(
     agent_context: AgentContext,
     entity_ids: list[str],
-    memory_cleanup: MemoryCleanup | None = None,
+    memory_cleanup: Backend | None = None,
     pipeline_config: LLMConfig | None = None,
 ) -> str | None:
     """Delete memory entities created during a red teaming run.
@@ -654,7 +653,7 @@ async def cleanup_memory_entities(
             return None
         # Default fallback keeps existing ORQ behavior.
         await asyncio.wait_for(
-            resolve_backend('orq').memory_cleanup.cleanup_memory(agent_context, entity_ids),
+            resolve_backend('orq').cleanup_memory(agent_context, entity_ids),
             timeout=cleanup_timeout_s,
         )
     except asyncio.TimeoutError:

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/_errors.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/_errors.py
@@ -51,6 +51,10 @@ def extract_provider_error_code(exc: Exception) -> str | None:
             if isinstance(value, str) and value.strip():
                 return value.strip().lower()
 
+    # Text-based fallback only — patterns may match Python type annotations or
+    # generic words in non-provider exceptions (e.g. "TypeError: type=<class 'str'>"),
+    # yielding misleading `orq.code.<name>` codes. Structured attribute checks above
+    # cover all production SDK errors; this is a best-effort last resort.
     text = str(exc)
     patterns = [
         r'\b(?:error_)?code\s*[=:]\s*["\']?([a-z0-9_.-]+)["\']?',

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/_errors.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/_errors.py
@@ -1,0 +1,63 @@
+"""Backend-internal exception extraction helpers.
+
+Module-private. Used by ``ORQBackend.map_error`` and ``OpenAIBackend.map_error``.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def extract_status_code(exc: Exception) -> int | None:
+    """Extract HTTP-like status code from structured exception fields or text."""
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None)
+    if isinstance(status_code, int) and 100 <= status_code <= 599:
+        return status_code
+
+    for attr in ("status_code", "status"):
+        value = getattr(exc, attr, None)
+        if isinstance(value, int) and 100 <= value <= 599:
+            return value
+
+    text = str(exc)
+    patterns = [
+        r"\bstatus(?:_code)?\s*[=:]\s*(\d{3})\b",
+        r"\bHTTP\s*(\d{3})\b",
+        r"\bcode\s*[=:]\s*(\d{3})\b",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if not match:
+            continue
+        code = int(match.group(1))
+        if 100 <= code <= 599:
+            return code
+    return None
+
+
+def extract_provider_error_code(exc: Exception) -> str | None:
+    """Extract provider-specific symbolic error code if present."""
+    for attr in ("code", "error_code", "type"):
+        value = getattr(exc, attr, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        error = body.get("error") if isinstance(body.get("error"), dict) else body
+        for key in ("code", "type", "error_code"):
+            value = error.get(key) if isinstance(error, dict) else None
+            if isinstance(value, str) and value.strip():
+                return value.strip().lower()
+
+    text = str(exc)
+    patterns = [
+        r'\b(?:error_)?code\s*[=:]\s*["\']?([a-z0-9_.-]+)["\']?',
+        r'\btype\s*[=:]\s*["\']?([a-z0-9_.-]+)["\']?',
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if match:
+            return match.group(1).strip().lower()
+    return None

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
@@ -7,7 +7,6 @@ subclass. The ORQ implementation lives in ``backends.orq``; other backends
 
 from __future__ import annotations
 
-import asyncio
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
@@ -23,10 +22,11 @@ class AgentTarget(ABC):
     """Abstract base class for agent targets that can receive prompts.
 
     Subclasses must implement ``send_prompt`` and ``new``. Targets that back a
-    server-side memory store override ``get_agent_context``; otherwise the
-    default minimal context is returned. ``memory_entity_id`` is an instance
-    attribute (set in ``__init__``) so subclasses can mutate it without
-    shadowing a class default.
+    server-side memory store override ``get_agent_context`` (self-describing),
+    ``cleanup_memory`` (release created entities), and ``map_error``
+    (provider-specific error codes); stateless targets inherit the safe
+    defaults. ``memory_entity_id`` is an instance attribute (set in
+    ``__init__``) so subclasses can mutate it without shadowing a class default.
     """
 
     def __init__(self, memory_entity_id: str | None = None) -> None:
@@ -46,6 +46,18 @@ class AgentTarget(ABC):
         """Default: minimal context. Override for platform-backed targets."""
         from evaluatorq.redteam.contracts import AgentContext
         return AgentContext(key=getattr(self, "agent_key", "unknown"))
+
+    async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
+        """Release any memory entities this target created. Default: no-op (stateless)."""
+        return
+
+    def map_error(self, exc: Exception) -> tuple[str, str] | None:
+        """Map an exception to a provider-specific ``(code, message)``.
+
+        Return ``None`` to defer to the backend's default mapping. Stateless
+        targets inherit this no-opinion default.
+        """
+        return None
 
 
 def _coerce_to_agent_response(raw: Any) -> AgentResponse:
@@ -105,8 +117,12 @@ class Backend(ABC):
         """Return normalized ``(error_code, error_message)``."""
         return "target_error", f"{type(exc).__name__}: {exc}"
 
-    async def get_agent_context(self, agent_key: str) -> AgentContext:
-        """Default: probe a target once and cache. Subclasses may override."""
+    async def resolve_context(self, agent_key: str) -> AgentContext:
+        """Resolve agent context for a key by probing a target once, then caching.
+
+        Distinct from ``AgentTarget.get_agent_context()`` (no args, self-describing):
+        a backend resolves context for *any* key, a target describes *itself*.
+        """
         if agent_key in self._ctx_cache:
             return self._ctx_cache[agent_key]
         probe = self.create_target(agent_key)
@@ -131,33 +147,16 @@ class BareTargetBackend(Backend):
         return self._target.new()
 
     async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
-        cleanup = getattr(self._target, "cleanup_memory", None)
-        if callable(cleanup):
-            result = cleanup(ctx, entity_ids)
-            if asyncio.iscoroutine(result):
-                await result
-        elif entity_ids:
-            # Target accumulated memory entities but exposes no cleanup hook;
+        if entity_ids and type(self._target).cleanup_memory is AgentTarget.cleanup_memory:
+            # Target created memory entities but inherits the no-op cleanup default;
             # adversarial data may persist. Surface loudly (matches ORQ path).
             logger.warning(
-                f"BareTargetBackend: {type(self._target).__name__} has no cleanup_memory "
-                f"but {len(entity_ids)} memory entity id(s) were created; they may persist. "
-                "Implement cleanup_memory on the target to release them."
+                f"BareTargetBackend: {type(self._target).__name__} created "
+                f"{len(entity_ids)} memory entity id(s) but does not override cleanup_memory; "
+                "they may persist. Implement cleanup_memory on the target to release them."
             )
-        else:
-            logger.debug(
-                f"BareTargetBackend: {type(self._target).__name__} has no "
-                "cleanup_memory; nothing to clean"
-            )
+        await self._target.cleanup_memory(ctx, entity_ids)
 
     def map_error(self, exc: Exception) -> tuple[str, str]:
-        mapper = getattr(self._target, "map_error", None)
-        if callable(mapper):
-            result = mapper(exc)
-            if isinstance(result, tuple) and len(result) == 2:
-                return result  # type: ignore[return-value]
-            logger.warning(
-                f"BareTargetBackend: {type(self._target).__name__}.map_error returned "
-                f"{type(result).__name__}, expected (code, message) tuple; using default mapping."
-            )
-        return super().map_error(exc)
+        result = self._target.map_error(exc)
+        return result if result is not None else super().map_error(exc)

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
@@ -1,8 +1,8 @@
-"""Backend protocols for dynamic red teaming agent targets.
+"""Backend abstract base classes for dynamic red teaming agent targets.
 
-Defines the abstract interfaces that any agent backend must implement.
-The ORQ implementation lives in ``backends.orq``; other backends (HTTP,
-LangChain, custom callables) can implement these protocols independently.
+Defines the ABCs (``AgentTarget``, ``Backend``) that any agent backend must
+subclass. The ORQ implementation lives in ``backends.orq``; other backends
+(HTTP, LangChain, custom callables) subclass these independently.
 """
 
 from __future__ import annotations
@@ -89,6 +89,7 @@ class Backend(ABC):
 
     def __init__(self, name: str) -> None:
         self.name = name
+        self._ctx_cache: dict[str, AgentContext] = {}
 
     @abstractmethod
     def create_target(self, agent_key: str) -> AgentTarget:
@@ -106,13 +107,11 @@ class Backend(ABC):
 
     async def get_agent_context(self, agent_key: str) -> AgentContext:
         """Default: probe a target once and cache. Subclasses may override."""
-        cached = getattr(self, "_ctx_cache", None) or {}
-        if agent_key in cached:
-            return cached[agent_key]
+        if agent_key in self._ctx_cache:
+            return self._ctx_cache[agent_key]
         probe = self.create_target(agent_key)
         ctx = await probe.get_agent_context()
-        cached[agent_key] = ctx
-        self._ctx_cache = cached  # type: ignore[attr-defined]
+        self._ctx_cache[agent_key] = ctx
         return ctx
 
 
@@ -137,10 +136,18 @@ class BareTargetBackend(Backend):
             result = cleanup(ctx, entity_ids)
             if asyncio.iscoroutine(result):
                 await result
+        elif entity_ids:
+            # Target accumulated memory entities but exposes no cleanup hook;
+            # adversarial data may persist. Surface loudly (matches ORQ path).
+            logger.warning(
+                f"BareTargetBackend: {type(self._target).__name__} has no cleanup_memory "
+                f"but {len(entity_ids)} memory entity id(s) were created; they may persist. "
+                "Implement cleanup_memory on the target to release them."
+            )
         else:
             logger.debug(
                 f"BareTargetBackend: {type(self._target).__name__} has no "
-                f"cleanup_memory; skipping ({len(entity_ids)} entity ids)"
+                "cleanup_memory; nothing to clean"
             )
 
     def map_error(self, exc: Exception) -> tuple[str, str]:
@@ -149,4 +156,8 @@ class BareTargetBackend(Backend):
             result = mapper(exc)
             if isinstance(result, tuple) and len(result) == 2:
                 return result  # type: ignore[return-value]
+            logger.warning(
+                f"BareTargetBackend: {type(self._target).__name__}.map_error returned "
+                f"{type(result).__name__}, expected (code, message) tuple; using default mapping."
+            )
         return super().map_error(exc)

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
@@ -8,6 +8,7 @@ LangChain, custom callables) can implement these protocols independently.
 from __future__ import annotations
 
 import re
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -290,3 +291,29 @@ def extract_provider_error_code(exc: Exception) -> str | None:
         if match:
             return match.group(1).strip().lower()
     return None
+
+
+class Backend(ABC):
+    """Backend ABC. Owns target construction, memory cleanup, and error mapping.
+
+    Subclasses must implement ``create_target`` and ``cleanup_memory``.
+    ``map_error`` has a sensible default; override for provider-specific
+    HTTP/status-code mapping.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    @abstractmethod
+    def create_target(self, agent_key: str) -> AgentTarget:
+        """Create a new AgentTarget for the given agent key."""
+        ...
+
+    @abstractmethod
+    async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
+        """Delete memory entities created during a red teaming run."""
+        ...
+
+    def map_error(self, exc: Exception) -> tuple[str, str]:
+        """Return normalized ``(error_code, error_message)``."""
+        return "target_error", f"{type(exc).__name__}: {exc}"

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
@@ -256,3 +256,14 @@ class Backend(ABC):
     def map_error(self, exc: Exception) -> tuple[str, str]:
         """Return normalized ``(error_code, error_message)``."""
         return "target_error", f"{type(exc).__name__}: {exc}"
+
+    async def get_agent_context(self, agent_key: str) -> AgentContext:
+        """Default: probe a target once and cache. Subclasses may override."""
+        cached = getattr(self, "_ctx_cache", None) or {}
+        if agent_key in cached:
+            return cached[agent_key]
+        probe = self.create_target(agent_key)
+        ctx = await probe.get_agent_context()
+        cached[agent_key] = ctx
+        self._ctx_cache = cached  # type: ignore[attr-defined]
+        return ctx

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
@@ -267,3 +267,35 @@ class Backend(ABC):
         cached[agent_key] = ctx
         self._ctx_cache = cached  # type: ignore[attr-defined]
         return ctx
+
+
+class BareTargetBackend(Backend):
+    """Adapter wrapping a bare ``AgentTarget`` so it satisfies the ``Backend`` ABC.
+
+    Used by the runner's bring-your-own-target path. Absorbs the duck-typed
+    capability checks (``cleanup_memory``, ``map_error``) that used to scatter
+    across ``runner.py``.
+    """
+
+    def __init__(self, target: AgentTarget) -> None:
+        super().__init__(name=type(target).__name__)
+        self._target = target
+
+    def create_target(self, agent_key: str) -> AgentTarget:
+        return self._target.new()
+
+    async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
+        cleanup = getattr(self._target, "cleanup_memory", None)
+        if callable(cleanup):
+            await cleanup(ctx, entity_ids)
+        else:
+            logger.debug(
+                f"BareTargetBackend: {type(self._target).__name__} has no "
+                f"cleanup_memory; skipping ({len(entity_ids)} entity ids)"
+            )
+
+    def map_error(self, exc: Exception) -> tuple[str, str]:
+        mapper = getattr(self._target, "map_error", None)
+        if callable(mapper):
+            return mapper(exc)
+        return super().map_error(exc)

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
@@ -7,16 +7,16 @@ LangChain, custom callables) can implement these protocols independently.
 
 from __future__ import annotations
 
+import asyncio
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
 from evaluatorq.redteam.contracts import AgentResponse
 
 if TYPE_CHECKING:
-    from evaluatorq.redteam.contracts import AgentContext, TokenUsage
+    from evaluatorq.redteam.contracts import AgentContext
 
 
 class AgentTarget(ABC):
@@ -61,81 +61,6 @@ def _coerce_to_agent_response(raw: Any) -> AgentResponse:
     return AgentResponse(output=[text_item])
 
 
-class SupportsClone(Protocol):
-    """Optional hook for target cloning per parallel job.
-
-    Note: The runner detects this via duck-typing (``getattr``/``callable``),
-    not ``isinstance``.  Implementing this protocol is recommended for
-    documentation and static analysis but not strictly required.
-
-    Clones are expected to own their own ``memory_entity_id`` (fresh one when
-    the target backs a persistent memory store; ``None`` otherwise).
-    """
-
-    def clone(self) -> AgentTarget:
-        """Return a fresh target instance with isolated state."""
-        ...
-
-
-class SupportsTokenUsage(Protocol):
-    """Optional hook for exposing token usage from last target call.
-
-    Deprecated: ``AgentResponse.usage`` is the canonical channel for token usage.
-    Implementing this protocol is no longer required.
-    """
-
-    def consume_last_token_usage(self) -> 'TokenUsage | None':
-        """Return and clear usage from last call."""
-        ...
-
-
-class SupportsTargetMetadata(Protocol):
-    """Optional hook for backend-specific target metadata."""
-
-    def target_metadata(self) -> dict[str, object]:
-        """Return provider/target metadata for diagnostics."""
-        ...
-
-
-class SupportsAgentContext(Protocol):
-    """Optional: target provides its own agent context."""
-
-    async def get_agent_context(self) -> AgentContext: ...
-
-
-class SupportsTargetFactory(Protocol):
-    """Optional: target can create per-job instances.
-
-    The factory owns no memory-entity concern. Targets that manage persistent
-    memory generate their own ``memory_entity_id`` when constructed; callers
-    read it off the resulting target.
-    """
-
-    def create_target(self, agent_key: str) -> AgentTarget: ...
-
-
-class SupportsMemoryCleanup(Protocol):
-    """Optional: target can clean up memory entities."""
-
-    async def cleanup_memory(self, agent_context: AgentContext, entity_ids: list[str]) -> None: ...
-
-
-class SupportsErrorMapping(Protocol):
-    """Optional: target provides custom error classification."""
-
-    def map_error(self, exc: Exception) -> tuple[str, str]: ...
-
-
-def is_agent_target(obj: object) -> bool:
-    """Return True if obj satisfies the AgentTarget protocol at runtime.
-
-    Checks for ``send_prompt`` and ``new``.
-    """
-    has_send = callable(getattr(obj, 'send_prompt', None))
-    has_new = callable(getattr(obj, 'new', None))
-    return has_send and has_new
-
-
 def validate_agent_target(obj: object) -> None:
     """Raise ``TypeError`` if ``obj`` implements only the removed ``clone()`` API.
 
@@ -152,84 +77,6 @@ def validate_agent_target(obj: object) -> None:
             f"{type(obj).__name__} implements 'clone()' which was removed in evaluatorq 1.3. "
             "Rename it to 'new(self) -> AgentTarget' — signature is the same, no memory_entity_id param."
         )
-
-
-class DirectTargetFactory:
-    """Fallback factory that wraps a bare AgentTarget."""
-
-    def __init__(self, target: AgentTarget) -> None:
-        self._target = target
-
-    def create_target(self, agent_key: str) -> AgentTarget:
-        result = self._target.new()
-        if result is None:  # pyright: ignore[reportUnnecessaryComparison]
-            raise TypeError(
-                f"{type(self._target).__name__}.new() returned None. "
-                "It must return a fresh AgentTarget instance."
-            )
-        return result
-
-
-class NoopMemoryCleanup:
-    """No-op memory cleanup for targets that do not manage memory stores."""
-
-    async def cleanup_memory(self, agent_context: AgentContext, entity_ids: list[str]) -> None:
-        logger.debug('Skipping memory cleanup: target does not manage memory stores')
-
-
-class AgentContextProvider(Protocol):
-    """Protocol for retrieving agent context (tools, memory, system prompt)."""
-
-    async def get_agent_context(self, agent_key: str) -> AgentContext:
-        """Retrieve full agent context for the given key."""
-        ...
-
-
-class AgentTargetFactory(Protocol):
-    """Protocol for creating AgentTarget instances per job.
-
-    The returned target owns its own ``memory_entity_id`` (auto-generated for
-    targets with persistent memory, ``None`` otherwise). Callers read the
-    attribute off the target rather than passing an ID in.
-    """
-
-    def create_target(self, agent_key: str) -> AgentTarget:
-        """Create a new AgentTarget for the given agent key."""
-        ...
-
-
-class MemoryCleanup(Protocol):
-    """Protocol for cleaning up memory entities created during red teaming."""
-
-    async def cleanup_memory(self, agent_context: AgentContext, entity_ids: list[str]) -> None:
-        """Delete memory entities created during a red teaming run."""
-        ...
-
-
-class ErrorMapper(Protocol):
-    """Protocol for backend-specific exception normalization."""
-
-    def map_error(self, exc: Exception) -> tuple[str, str]:
-        """Return normalized (error_code, error_message)."""
-        ...
-
-
-@dataclass(slots=True)
-class BackendBundle:
-    """Bundle of backend components used by dynamic runtime."""
-
-    name: str
-    target_factory: AgentTargetFactory
-    context_provider: AgentContextProvider
-    memory_cleanup: MemoryCleanup
-    error_mapper: ErrorMapper
-
-
-class DefaultErrorMapper:
-    """Fallback error mapper for unknown backends."""
-
-    def map_error(self, exc: Exception) -> tuple[str, str]:
-        return 'target_error', f'{type(exc).__name__}: {exc}'
 
 
 class Backend(ABC):
@@ -287,7 +134,9 @@ class BareTargetBackend(Backend):
     async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
         cleanup = getattr(self._target, "cleanup_memory", None)
         if callable(cleanup):
-            await cleanup(ctx, entity_ids)
+            result = cleanup(ctx, entity_ids)
+            if asyncio.iscoroutine(result):
+                await result
         else:
             logger.debug(
                 f"BareTargetBackend: {type(self._target).__name__} has no "
@@ -297,5 +146,7 @@ class BareTargetBackend(Backend):
     def map_error(self, exc: Exception) -> tuple[str, str]:
         mapper = getattr(self._target, "map_error", None)
         if callable(mapper):
-            return mapper(exc)
+            result = mapper(exc)
+            if isinstance(result, tuple) and len(result) == 2:
+                return result  # type: ignore[return-value]
         return super().map_error(exc)

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
@@ -19,34 +19,33 @@ if TYPE_CHECKING:
     from evaluatorq.redteam.contracts import AgentContext, TokenUsage
 
 
-class AgentTarget(Protocol):
-    """Protocol for agent targets that can receive prompts.
+class AgentTarget(ABC):
+    """Abstract base class for agent targets that can receive prompts.
 
-    Targets that maintain persistent memory (server-side entities, LangGraph
-    checkpointer threads, etc.) expose the isolation key as ``memory_entity_id``.
-    Targets without persistent memory set it to ``None``. The red teaming
-    pipeline reads this attribute after target creation to track entities for
-    cleanup — it does not inject the value into the target.
-
-    Backends must implement ``send_prompt`` returning :class:`AgentResponse`.
-    ``AgentResponse`` carries both the ordered output items (text + tool calls)
-    and the per-call LLM metadata (``usage``, ``model``, ``response_id``,
-    ``finish_reason``) that previously lived on the now-removed ``SendResult``.
+    Subclasses must implement ``send_prompt`` and ``new``. Targets that back a
+    server-side memory store override ``get_agent_context``; otherwise the
+    default minimal context is returned. ``memory_entity_id`` is an instance
+    attribute (set in ``__init__``) so subclasses can mutate it without
+    shadowing a class default.
     """
 
-    memory_entity_id: str | None
+    def __init__(self, memory_entity_id: str | None = None) -> None:
+        self.memory_entity_id = memory_entity_id
 
-    async def send_prompt(self, prompt: str) -> 'AgentResponse':
-        """Send a prompt and return the response (output items + token usage)."""
+    @abstractmethod
+    async def send_prompt(self, prompt: str) -> AgentResponse:
+        """Send a prompt; return the response."""
         ...
 
+    @abstractmethod
     def new(self) -> AgentTarget:
-        """Return a fresh target instance with isolated state for a new attack.
-
-        Each call must produce an independent instance — own ``memory_entity_id``
-        for memory-backed targets, ``None`` otherwise.
-        """
+        """Return a fresh independent instance for a new attack."""
         ...
+
+    async def get_agent_context(self) -> AgentContext:
+        """Default: minimal context. Override for platform-backed targets."""
+        from evaluatorq.redteam.contracts import AgentContext
+        return AgentContext(key=getattr(self, "agent_key", "unknown"))
 
 
 def _coerce_to_agent_response(raw: Any) -> AgentResponse:

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
@@ -144,6 +144,7 @@ class BareTargetBackend(Backend):
         self._target = target
 
     def create_target(self, agent_key: str) -> AgentTarget:
+        """Ignore ``agent_key`` — target was pre-configured at construction time."""
         return self._target.new()
 
     async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
@@ -7,7 +7,6 @@ LangChain, custom callables) can implement these protocols independently.
 
 from __future__ import annotations
 
-import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
@@ -232,65 +231,6 @@ class DefaultErrorMapper:
 
     def map_error(self, exc: Exception) -> tuple[str, str]:
         return 'target_error', f'{type(exc).__name__}: {exc}'
-
-
-def extract_status_code(exc: Exception) -> int | None:
-    """Extract HTTP-like status code from structured exception fields or text."""
-    # Structured response.status_code (httpx/openai-like)
-    response = getattr(exc, 'response', None)
-    status_code = getattr(response, 'status_code', None)
-    if isinstance(status_code, int) and 100 <= status_code <= 599:
-        return status_code
-
-    # Some SDKs expose status/status_code directly on exception.
-    for attr in ('status_code', 'status'):
-        value = getattr(exc, attr, None)
-        if isinstance(value, int) and 100 <= value <= 599:
-            return value
-
-    # Fallback to regex on raw error text.
-    text = str(exc)
-    patterns = [
-        r'\bstatus(?:_code)?\s*[=:]\s*(\d{3})\b',
-        r'\bHTTP\s*(\d{3})\b',
-        r'\bcode\s*[=:]\s*(\d{3})\b',
-    ]
-    for pattern in patterns:
-        match = re.search(pattern, text, flags=re.IGNORECASE)
-        if not match:
-            continue
-        code = int(match.group(1))
-        if 100 <= code <= 599:
-            return code
-    return None
-
-
-def extract_provider_error_code(exc: Exception) -> str | None:
-    """Extract provider-specific symbolic error code if present."""
-    # Common structured fields.
-    for attr in ('code', 'error_code', 'type'):
-        value = getattr(exc, attr, None)
-        if isinstance(value, str) and value.strip():
-            return value.strip().lower()
-
-    body = getattr(exc, 'body', None)
-    if isinstance(body, dict):
-        error = body.get('error') if isinstance(body.get('error'), dict) else body
-        for key in ('code', 'type', 'error_code'):
-            value = error.get(key) if isinstance(error, dict) else None
-            if isinstance(value, str) and value.strip():
-                return value.strip().lower()
-
-    text = str(exc)
-    patterns = [
-        r'\b(?:error_)?code\s*[=:]\s*["\']?([a-z0-9_.-]+)["\']?',
-        r'\btype\s*[=:]\s*["\']?([a-z0-9_.-]+)["\']?',
-    ]
-    for pattern in patterns:
-        match = re.search(pattern, text, flags=re.IGNORECASE)
-        if match:
-            return match.group(1).strip().lower()
-    return None
 
 
 class Backend(ABC):

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/openai.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/openai.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from loguru import logger
 
-from evaluatorq.redteam.backends.base import extract_provider_error_code, extract_status_code
+from evaluatorq.redteam.backends._errors import extract_provider_error_code, extract_status_code
 from evaluatorq.redteam.contracts import (
     DEFAULT_TARGET_MAX_TOKENS,
     DEFAULT_TARGET_TIMEOUT_MS,

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/openai.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/openai.py
@@ -40,6 +40,24 @@ def create_async_llm_client(role_config=None) -> AsyncOpenAI:
     return _create(role_config)
 
 
+def _openai_map_error(exc: Exception) -> tuple[str, str]:
+    """Map an OpenAI exception to a normalized (error_code, error_message) tuple."""
+    name = type(exc).__name__.lower()
+    status_code = extract_status_code(exc)
+    provider_code = extract_provider_error_code(exc)
+    if status_code is not None:
+        return f'openai.http.{status_code}', f'{type(exc).__name__}: {exc}'
+    if provider_code:
+        return f'openai.code.{provider_code}', f'{type(exc).__name__}: {exc}'
+    if 'ratelimit' in name:
+        return 'openai.rate_limit', f'{type(exc).__name__}: {exc}'
+    if 'authentication' in name:
+        return 'openai.auth', f'{type(exc).__name__}: {exc}'
+    if 'timeout' in name:
+        return 'openai.timeout', f'{type(exc).__name__}: {exc}'
+    return 'openai.unknown', f'{type(exc).__name__}: {exc}'
+
+
 class OpenAIModelTarget(AgentTarget):
     """Target adapter that treats ``agent_key`` as an OpenAI model identifier."""
 
@@ -167,81 +185,9 @@ class OpenAIModelTarget(AgentTarget):
             model=self.model,
         )
 
-    def create_target(self, agent_key: str) -> OpenAIModelTarget:
-        """Create a new OpenAI model target for the given model name."""
-        return OpenAIModelTarget(model=agent_key, system_prompt=self.system_prompt, client=self.client, max_tokens=self.max_tokens, timeout_ms=self.timeout_ms)
-
     def map_error(self, exc: Exception) -> tuple[str, str]:
         """Map an OpenAI exception to a normalized error code and message tuple."""
-        return OpenAIErrorMapper().map_error(exc)
-
-
-class OpenAIContextProvider:
-    """Context provider for plain model targets.
-
-    There is no tool/memory/KB metadata in raw model mode.
-    """
-
-    def __init__(self, system_prompt: str | None = None):
-        """Initialize the context provider with an optional system prompt override."""
-        self._system_prompt = system_prompt
-
-    async def get_agent_context(self, agent_key: str) -> AgentContext:
-        """Return agent context for the specified OpenAI model."""
-        logger.debug(f'Using OpenAI model target context for model={agent_key}')
-        return AgentContext(
-            key=agent_key,
-            display_name=agent_key,
-            description='OpenAI model target',
-            system_prompt=self._system_prompt,
-            tools=[],
-            memory_stores=[],
-            knowledge_bases=[],
-            model=agent_key,
-        )
-
-
-class OpenAITargetFactory:
-    """Factory creating OpenAI model targets."""
-
-    def __init__(self, client: AsyncOpenAI, system_prompt: str | None = None, max_tokens: int | None = None, timeout_ms: int | None = None):
-        """Initialize the factory with a shared async OpenAI client and optional system prompt."""
-        self._client = client
-        self._system_prompt = system_prompt
-        self._max_tokens = max_tokens
-        self._timeout_ms = timeout_ms
-
-    def create_target(self, agent_key: str) -> OpenAIModelTarget:
-        """Create a new OpenAI model target instance."""
-        return OpenAIModelTarget(
-            model=agent_key,
-            system_prompt=self._system_prompt,
-            client=self._client,
-            max_tokens=self._max_tokens,
-            timeout_ms=self._timeout_ms,
-        )
-
-
-class OpenAIErrorMapper:
-    """Normalize OpenAI exceptions into runtime error taxonomy."""
-
-    def map_error(self, exc: Exception) -> tuple[str, str]:
-        """Map an OpenAI exception to a normalized error code and message tuple."""
-        name = type(exc).__name__.lower()
-        status_code = extract_status_code(exc)
-        provider_code = extract_provider_error_code(exc)
-
-        if status_code is not None:
-            return f'openai.http.{status_code}', f'{type(exc).__name__}: {exc}'
-        if provider_code:
-            return f'openai.code.{provider_code}', f'{type(exc).__name__}: {exc}'
-        if 'ratelimit' in name:
-            return 'openai.rate_limit', f'{type(exc).__name__}: {exc}'
-        if 'authentication' in name:
-            return 'openai.auth', f'{type(exc).__name__}: {exc}'
-        if 'timeout' in name:
-            return 'openai.timeout', f'{type(exc).__name__}: {exc}'
-        return 'openai.unknown', f'{type(exc).__name__}: {exc}'
+        return _openai_map_error(exc)
 
 
 class OpenAIBackend(Backend):
@@ -278,18 +224,4 @@ class OpenAIBackend(Backend):
         logger.debug('OpenAI backend has no memory store; cleanup is a no-op')
 
     def map_error(self, exc: Exception) -> tuple[str, str]:
-        name = type(exc).__name__.lower()
-        status_code = extract_status_code(exc)
-        provider_code = extract_provider_error_code(exc)
-
-        if status_code is not None:
-            return f'openai.http.{status_code}', f'{type(exc).__name__}: {exc}'
-        if provider_code:
-            return f'openai.code.{provider_code}', f'{type(exc).__name__}: {exc}'
-        if 'ratelimit' in name:
-            return 'openai.rate_limit', f'{type(exc).__name__}: {exc}'
-        if 'authentication' in name:
-            return 'openai.auth', f'{type(exc).__name__}: {exc}'
-        if 'timeout' in name:
-            return 'openai.timeout', f'{type(exc).__name__}: {exc}'
-        return 'openai.unknown', f'{type(exc).__name__}: {exc}'
+        return _openai_map_error(exc)

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/openai.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/openai.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 from loguru import logger
 
 from evaluatorq.redteam.backends._errors import extract_provider_error_code, extract_status_code
+from evaluatorq.redteam.backends.base import AgentTarget
 from evaluatorq.redteam.contracts import (
     DEFAULT_TARGET_MAX_TOKENS,
     DEFAULT_TARGET_TIMEOUT_MS,
@@ -39,11 +40,8 @@ def create_async_llm_client(role_config=None) -> AsyncOpenAI:
     return _create(role_config)
 
 
-class OpenAIModelTarget:
+class OpenAIModelTarget(AgentTarget):
     """Target adapter that treats ``agent_key`` as an OpenAI model identifier."""
-
-    memory_entity_id: str | None = None
-    """OpenAI models are stateless — no server-side memory to isolate."""
 
     def __init__(
         self,
@@ -58,7 +56,9 @@ class OpenAIModelTarget:
 
         If ``client`` is not provided, one is created automatically via
         :func:`~evaluatorq.redteam.backends.registry.create_async_llm_client`.
+        OpenAI models are stateless — no server-side memory to isolate.
         """
+        super().__init__(memory_entity_id=None)
         self.model = model
         self.client = client or create_async_llm_client()
         self.system_prompt = system_prompt or 'You are a helpful assistant.'

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/openai.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/openai.py
@@ -165,7 +165,7 @@ class OpenAIModelTarget(AgentTarget):
         )
 
     def new(self) -> OpenAIModelTarget:
-        """Return a fresh target instance for parallel job safety (satisfies ``AgentTarget`` protocol)."""
+        """Return a fresh target instance for parallel job safety (satisfies the ``AgentTarget`` ABC)."""
         return OpenAIModelTarget(model=self.model, system_prompt=self.system_prompt, client=self.client, max_tokens=self.max_tokens, timeout_ms=self.timeout_ms)
 
     target_kind: TargetKind = TargetKind.OPENAI

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/openai.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/openai.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 from loguru import logger
 
 from evaluatorq.redteam.backends._errors import extract_provider_error_code, extract_status_code
-from evaluatorq.redteam.backends.base import AgentTarget
+from evaluatorq.redteam.backends.base import AgentTarget, Backend
 from evaluatorq.redteam.contracts import (
     DEFAULT_TARGET_MAX_TOKENS,
     DEFAULT_TARGET_TIMEOUT_MS,
@@ -227,6 +227,57 @@ class OpenAIErrorMapper:
 
     def map_error(self, exc: Exception) -> tuple[str, str]:
         """Map an OpenAI exception to a normalized error code and message tuple."""
+        name = type(exc).__name__.lower()
+        status_code = extract_status_code(exc)
+        provider_code = extract_provider_error_code(exc)
+
+        if status_code is not None:
+            return f'openai.http.{status_code}', f'{type(exc).__name__}: {exc}'
+        if provider_code:
+            return f'openai.code.{provider_code}', f'{type(exc).__name__}: {exc}'
+        if 'ratelimit' in name:
+            return 'openai.rate_limit', f'{type(exc).__name__}: {exc}'
+        if 'authentication' in name:
+            return 'openai.auth', f'{type(exc).__name__}: {exc}'
+        if 'timeout' in name:
+            return 'openai.timeout', f'{type(exc).__name__}: {exc}'
+        return 'openai.unknown', f'{type(exc).__name__}: {exc}'
+
+
+class OpenAIBackend(Backend):
+    """Backend for direct OpenAI model targets.
+
+    Targets are stateless. ``cleanup_memory`` is a no-op (OpenAI models do not
+    own server-side memory).
+    """
+
+    def __init__(
+        self,
+        *,
+        client: AsyncOpenAI | None = None,
+        system_prompt: str | None = None,
+        max_tokens: int | None = None,
+        timeout_ms: int | None = None,
+    ) -> None:
+        super().__init__(name="openai")
+        self._client = client or create_async_llm_client()
+        self._system_prompt = system_prompt
+        self._max_tokens = max_tokens
+        self._timeout_ms = timeout_ms
+
+    def create_target(self, agent_key: str) -> OpenAIModelTarget:
+        return OpenAIModelTarget(
+            model=agent_key,
+            system_prompt=self._system_prompt,
+            client=self._client,
+            max_tokens=self._max_tokens,
+            timeout_ms=self._timeout_ms,
+        )
+
+    async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
+        logger.debug('OpenAI backend has no memory store; cleanup is a no-op')
+
+    def map_error(self, exc: Exception) -> tuple[str, str]:
         name = type(exc).__name__.lower()
         status_code = extract_status_code(exc)
         provider_code = extract_provider_error_code(exc)

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/orq.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/orq.py
@@ -12,7 +12,7 @@ import asyncio
 import json
 import os
 import uuid
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 from loguru import logger
 
@@ -44,6 +44,7 @@ def _get_orq_server_url() -> str:
 
 
 from evaluatorq.redteam.backends._errors import extract_provider_error_code, extract_status_code
+from evaluatorq.redteam.backends.base import AgentTarget
 from evaluatorq.redteam.contracts import (
     PIPELINE_CONFIG,
     AgentContext,
@@ -58,11 +59,8 @@ from evaluatorq.redteam.contracts import (
 )
 from evaluatorq.redteam.tracing import record_token_usage, set_span_attrs, truncate_for_span, with_redteam_span
 
-if TYPE_CHECKING:
-    from evaluatorq.redteam.backends.base import AgentTarget
 
-
-class ORQAgentTarget:
+class ORQAgentTarget(AgentTarget):
     """Target adapter for ORQ agents.
 
     Wraps the ORQ SDK to provide the AgentTarget protocol.
@@ -83,12 +81,12 @@ class ORQAgentTarget:
         if not provided, one is generated. The pipeline reads this attribute
         after construction to track entities for cleanup.
         """
+        if memory_entity_id is None:
+            memory_entity_id = f'red-team-{uuid.uuid4().hex[:12]}'
+        super().__init__(memory_entity_id=memory_entity_id)
         timeout_ms = timeout_ms or PIPELINE_CONFIG.target_agent_timeout_ms
         self.agent_key = agent_key
         self.orq_client = orq_client
-        self.memory_entity_id: str | None = (
-            memory_entity_id if memory_entity_id is not None else f'red-team-{uuid.uuid4().hex[:12]}'
-        )
         self.model = model
         self._timeout_ms = timeout_ms
         self._task_id: str | None = None

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/orq.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/orq.py
@@ -60,6 +60,45 @@ from evaluatorq.redteam.contracts import (
 from evaluatorq.redteam.tracing import record_token_usage, set_span_attrs, truncate_for_span, with_redteam_span
 
 
+async def _orq_cleanup_memory(orq_client: Any, ctx: AgentContext, entity_ids: list[str]) -> None:
+    """Delete memory entities for each memory store × entity_id combination."""
+    for ms in ctx.memory_stores:
+        if not ms.key:
+            logger.warning(f'Memory store {ms.id} has no key, skipping cleanup')
+            continue
+        for entity_id in entity_ids:
+            try:
+                await asyncio.to_thread(
+                    orq_client.memory_stores.delete_memory,
+                    memory_store_key=ms.key,
+                    memory_entity_id=entity_id,
+                )
+                logger.debug(f'Deleted memory entity {entity_id} from store {ms.key}')
+            except Exception as e:  # noqa: PERF203
+                if extract_status_code(e) == 404:
+                    continue
+                logger.warning(f'Failed to cleanup memory entity {entity_id} from {ms.key}: {e}')
+
+
+def _orq_map_error(exc: Exception) -> tuple[str, str]:
+    """Map an ORQ exception to a normalized (error_code, error_message) tuple."""
+    name = type(exc).__name__.lower()
+    text = str(exc).lower()
+    status_code = extract_status_code(exc)
+    provider_code = extract_provider_error_code(exc)
+    if status_code is not None:
+        return f'orq.http.{status_code}', f'{type(exc).__name__}: {exc}'
+    if provider_code:
+        return f'orq.code.{provider_code}', f'{type(exc).__name__}: {exc}'
+    if 'timeout' in name or 'timed out' in text:
+        return 'orq.timeout', f'{type(exc).__name__}: {exc}'
+    if 'auth' in name or 'unauthorized' in text or 'forbidden' in text:
+        return 'orq.auth', f'{type(exc).__name__}: {exc}'
+    if 'ratelimit' in name or '429' in text:
+        return 'orq.rate_limit', f'{type(exc).__name__}: {exc}'
+    return 'orq.unknown', f'{type(exc).__name__}: {exc}'
+
+
 class ORQAgentTarget(AgentTarget):
     """Target adapter for ORQ agents.
 
@@ -90,6 +129,7 @@ class ORQAgentTarget(AgentTarget):
         self.model = model
         self._timeout_ms = timeout_ms
         self._task_id: str | None = None
+        self._cached_context: AgentContext | None = None
 
     async def send_prompt(self, prompt: str) -> AgentResponse:
         """Send a prompt to the ORQ agent and return the response with usage + any tool calls.
@@ -319,53 +359,16 @@ class ORQAgentTarget(AgentTarget):
         """Return the agent key as the display name for reports and tracing."""
         return self.agent_key
 
-    # -- SupportsAgentContext --
     async def get_agent_context(self) -> AgentContext:
         """Return agent context for this target's agent key."""
-        return await ORQContextProvider(self.orq_client).get_agent_context(self.agent_key)
-
-    # -- SupportsTargetFactory --
-    def create_target(self, agent_key: str) -> ORQAgentTarget:
-        """Create a new ORQAgentTarget for the given agent key.
-
-        The new target generates its own ``memory_entity_id``; callers can
-        read it via the attribute after construction.
-        """
-        return ORQAgentTarget(
-            agent_key=agent_key,
-            orq_client=self.orq_client,
-            model=self.model,
-            timeout_ms=self._timeout_ms,
-        )
-
-    # -- SupportsMemoryCleanup --
-    async def cleanup_memory(self, agent_context: AgentContext, entity_ids: list[str]) -> None:
-        """Clean up memory entities created during red teaming."""
-        await ORQMemoryCleanup(orq_client=self.orq_client).cleanup_memory(agent_context, entity_ids)
-
-    # -- SupportsErrorMapping --
-    def map_error(self, exc: Exception) -> tuple[str, str]:
-        """Map an exception to a normalized error code and message tuple."""
-        return ORQErrorMapper().map_error(exc)
-
-
-class ORQContextProvider:
-    """Retrieves agent context from the ORQ API."""
-
-    def __init__(self, orq_client: Any):
-        """Initialize the context provider with an ORQ SDK client."""
-        self.orq_client = orq_client
-
-    async def get_agent_context(self, agent_key: str) -> AgentContext:
-        """Retrieve full agent context from ORQ API."""
-        logger.debug(f'Retrieving agent context for: {agent_key}')
-
+        if self._cached_context is not None:
+            return self._cached_context
+        logger.debug(f'Retrieving agent context for: {self.agent_key}')
         agent_data = await asyncio.to_thread(
             self.orq_client.agents.retrieve,
-            agent_key=agent_key,
+            agent_key=self.agent_key,
         )
 
-        # Parse tools from settings.tools
         tools: list[ToolInfo] = []
         settings = getattr(agent_data, 'settings', None)
         if settings and hasattr(settings, 'tools') and settings.tools:
@@ -378,7 +381,6 @@ class ORQContextProvider:
                 for tool in settings.tools
             )
 
-        # Extract raw IDs for enrichment
         raw_kb_ids: list[str] = []
         if hasattr(agent_data, 'knowledge_bases') and agent_data.knowledge_bases:
             raw_kb_ids = [getattr(kb, 'knowledge_id', None) or str(kb) for kb in agent_data.knowledge_bases]
@@ -387,20 +389,18 @@ class ORQContextProvider:
         if hasattr(agent_data, 'memory_stores') and agent_data.memory_stores:
             raw_ms_ids = [ms if isinstance(ms, str) else getattr(ms, 'key', str(ms)) for ms in agent_data.memory_stores]
 
-        # Enrich knowledge bases and memory stores concurrently
         enrichment_tasks: list[Any] = [self._enrich_knowledge_base(kb_id) for kb_id in raw_kb_ids]
         enrichment_tasks.extend(self._enrich_memory_store(ms_id) for ms_id in raw_ms_ids)
 
         enriched_results = await asyncio.gather(*enrichment_tasks) if enrichment_tasks else []
-
         knowledge_bases = [r for r in enriched_results if isinstance(r, KnowledgeBaseInfo)]
         memory_stores = [r for r in enriched_results if isinstance(r, MemoryStoreInfo)]
 
         model_raw = getattr(agent_data, 'model', None)
         model_id = getattr(model_raw, 'id', None) if model_raw is not None else None
 
-        context = AgentContext(
-            key=agent_key,
+        self._cached_context = AgentContext(
+            key=self.agent_key,
             display_name=getattr(agent_data, 'display_name', None),
             description=getattr(agent_data, 'description', None),
             system_prompt=getattr(agent_data, 'system_prompt', None),
@@ -410,13 +410,7 @@ class ORQContextProvider:
             knowledge_bases=knowledge_bases,
             model=model_id,
         )
-
-        logger.debug(
-            f'Retrieved context: {len(tools)} tools, {len(memory_stores)} memory stores, '
-            f'{len(knowledge_bases)} knowledge bases'
-        )
-
-        return context
+        return self._cached_context
 
     async def _enrich_knowledge_base(self, kb_id: str) -> KnowledgeBaseInfo:
         """Retrieve full knowledge base details from ORQ API."""
@@ -448,109 +442,13 @@ class ORQContextProvider:
             logger.warning(f'Failed to enrich memory store {ms_key}: {e} — attack strategies will use limited context')
             return MemoryStoreInfo(id=ms_key)
 
-
-class ORQTargetFactory:
-    """Creates ORQAgentTarget instances, one per job."""
-
-    def __init__(
-        self,
-        orq_client: Any = None,
-        model: str | None = None,
-        timeout_ms: int | None = None,
-    ):
-        """Initialize the factory, creating an ORQ client from environment if none is provided."""
-        timeout_ms = timeout_ms or PIPELINE_CONFIG.target_agent_timeout_ms
-        self._timeout_ms = timeout_ms
-        if orq_client is not None:
-            self._orq_client = orq_client
-        else:
-            if _orq_cls is None:
-                msg = 'ORQ backend requires the orq-ai-sdk package. Install with: pip install evaluatorq[orq]'
-                raise ImportError(msg)
-            self._orq_client = _orq_cls(
-                api_key=_get_orq_api_key(),
-                server_url=_get_orq_server_url(),
-                timeout_ms=self._timeout_ms,
-            )
-        self._model = model
-
-    def create_target(self, agent_key: str) -> AgentTarget:
-        """Create a new ORQAgentTarget for the given agent key.
-
-        The new target generates its own ``memory_entity_id``; callers can
-        read it via the attribute after construction.
-        """
-        return ORQAgentTarget(
-            agent_key=agent_key,
-            orq_client=self._orq_client,
-            model=self._model,
-            timeout_ms=self._timeout_ms,
-        )
-
-
-class ORQMemoryCleanup:
-    """Cleans up memory entities created during red teaming via ORQ SDK."""
-
-    def __init__(self, orq_client: Any = None, timeout_ms: int | None = None):
-        """Initialize the cleanup handler, creating an ORQ client from environment if none is provided."""
-        timeout_ms = timeout_ms or PIPELINE_CONFIG.target_agent_timeout_ms
-        if orq_client is not None:
-            self._orq_client = orq_client
-        else:
-            if _orq_cls is None:
-                msg = 'ORQ backend requires the orq-ai-sdk package. Install with: pip install evaluatorq[orq]'
-                raise ImportError(msg)
-            self._orq_client = _orq_cls(
-                api_key=_get_orq_api_key(),
-                server_url=_get_orq_server_url(),
-                timeout_ms=timeout_ms,
-            )
-
-    async def cleanup_memory(self, agent_context: AgentContext, entity_ids: list[str]) -> None:
-        """Delete memory entities for each memory store x entity_id combination."""
-        for ms in agent_context.memory_stores:
-            if not ms.key:
-                logger.warning(f'Memory store {ms.id} has no key, skipping cleanup')
-                continue
-            for entity_id in entity_ids:
-                try:
-                    await asyncio.to_thread(
-                        self._orq_client.memory_stores.delete_memory,
-                        memory_store_key=ms.key,
-                        memory_entity_id=entity_id,
-                    )
-                    logger.debug(f'Deleted memory entity {entity_id} from store {ms.key}')
-                except Exception as e:  # noqa: PERF203
-                    if extract_status_code(e) == 404:
-                        continue
-                    logger.warning(f'Failed to cleanup memory entity {entity_id} from {ms.key}: {e}')
-
-        logger.debug(
-            f'Memory cleanup complete ({len(entity_ids)} entities across {len(agent_context.memory_stores)} stores)'
-        )
-
-
-class ORQErrorMapper:
-    """Normalize ORQ SDK/HTTP failures into runtime error taxonomy."""
-
     def map_error(self, exc: Exception) -> tuple[str, str]:
-        """Map an exception to a (error_code, error_message) tuple."""
-        name = type(exc).__name__.lower()
-        text = str(exc).lower()
-        status_code = extract_status_code(exc)
-        provider_code = extract_provider_error_code(exc)
+        """Map an exception to a normalized error code and message tuple."""
+        return _orq_map_error(exc)
 
-        if status_code is not None:
-            return f'orq.http.{status_code}', f'{type(exc).__name__}: {exc}'
-        if provider_code:
-            return f'orq.code.{provider_code}', f'{type(exc).__name__}: {exc}'
-        if 'timeout' in name or 'timed out' in text:
-            return 'orq.timeout', f'{type(exc).__name__}: {exc}'
-        if 'auth' in name or 'unauthorized' in text or 'forbidden' in text:
-            return 'orq.auth', f'{type(exc).__name__}: {exc}'
-        if 'ratelimit' in name or '429' in text:
-            return 'orq.rate_limit', f'{type(exc).__name__}: {exc}'
-        return 'orq.unknown', f'{type(exc).__name__}: {exc}'
+    async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
+        """Clean up memory entities created during red teaming."""
+        await _orq_cleanup_memory(self.orq_client, ctx, entity_ids)
 
 
 class ORQBackend(Backend):
@@ -587,40 +485,10 @@ class ORQBackend(Backend):
         )
 
     async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
-        for ms in ctx.memory_stores:
-            if not ms.key:
-                logger.warning(f'Memory store {ms.id} has no key, skipping cleanup')
-                continue
-            for entity_id in entity_ids:
-                try:
-                    await asyncio.to_thread(
-                        self._orq_client.memory_stores.delete_memory,
-                        memory_store_key=ms.key,
-                        memory_entity_id=entity_id,
-                    )
-                    logger.debug(f'Deleted memory entity {entity_id} from store {ms.key}')
-                except Exception as e:  # noqa: PERF203
-                    if extract_status_code(e) == 404:
-                        continue
-                    logger.warning(f'Failed to cleanup memory entity {entity_id} from {ms.key}: {e}')
+        await _orq_cleanup_memory(self._orq_client, ctx, entity_ids)
 
     def map_error(self, exc: Exception) -> tuple[str, str]:
-        name = type(exc).__name__.lower()
-        text = str(exc).lower()
-        status_code = extract_status_code(exc)
-        provider_code = extract_provider_error_code(exc)
-
-        if status_code is not None:
-            return f'orq.http.{status_code}', f'{type(exc).__name__}: {exc}'
-        if provider_code:
-            return f'orq.code.{provider_code}', f'{type(exc).__name__}: {exc}'
-        if 'timeout' in name or 'timed out' in text:
-            return 'orq.timeout', f'{type(exc).__name__}: {exc}'
-        if 'auth' in name or 'unauthorized' in text or 'forbidden' in text:
-            return 'orq.auth', f'{type(exc).__name__}: {exc}'
-        if 'ratelimit' in name or '429' in text:
-            return 'orq.rate_limit', f'{type(exc).__name__}: {exc}'
-        return 'orq.unknown', f'{type(exc).__name__}: {exc}'
+        return _orq_map_error(exc)
 
 
 def create_orq_agent_target(
@@ -639,35 +507,3 @@ def create_orq_agent_target(
             timeout_ms=timeout_ms,
         )
     return ORQAgentTarget(agent_key=agent_key, orq_client=orq_client, timeout_ms=timeout_ms)
-
-
-def create_orq_backend(
-    orq_client: Any = None,
-    timeout_ms: int | None = None,
-) -> tuple[ORQTargetFactory, ORQContextProvider, ORQMemoryCleanup]:
-    """Convenience function returning all three ORQ backend components.
-
-    Args:
-        orq_client: Optional pre-configured ORQ SDK client. If None, one is created
-                    from environment config.
-        timeout_ms: Timeout in milliseconds for target agent calls.
-
-    Returns:
-        Tuple of (target_factory, context_provider, memory_cleanup)
-    """
-    timeout_ms = timeout_ms or PIPELINE_CONFIG.target_agent_timeout_ms
-    if orq_client is None:
-        if _orq_cls is None:
-            msg = 'ORQ backend requires the orq-ai-sdk package. Install with: pip install evaluatorq[orq]'
-            raise ImportError(msg)
-        orq_client = _orq_cls(
-            api_key=_get_orq_api_key(),
-            server_url=_get_orq_server_url(),
-            timeout_ms=timeout_ms,
-        )
-
-    return (
-        ORQTargetFactory(orq_client, timeout_ms=timeout_ms),
-        ORQContextProvider(orq_client),
-        ORQMemoryCleanup(orq_client, timeout_ms=timeout_ms),
-    )

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/orq.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/orq.py
@@ -43,7 +43,7 @@ def _get_orq_server_url() -> str:
     return url.rstrip('/').removesuffix('/v2/router')
 
 
-from evaluatorq.redteam.backends.base import extract_provider_error_code, extract_status_code
+from evaluatorq.redteam.backends._errors import extract_provider_error_code, extract_status_code
 from evaluatorq.redteam.contracts import (
     PIPELINE_CONFIG,
     AgentContext,

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/orq.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/orq.py
@@ -44,7 +44,7 @@ def _get_orq_server_url() -> str:
 
 
 from evaluatorq.redteam.backends._errors import extract_provider_error_code, extract_status_code
-from evaluatorq.redteam.backends.base import AgentTarget
+from evaluatorq.redteam.backends.base import AgentTarget, Backend
 from evaluatorq.redteam.contracts import (
     PIPELINE_CONFIG,
     AgentContext,
@@ -535,6 +535,76 @@ class ORQErrorMapper:
 
     def map_error(self, exc: Exception) -> tuple[str, str]:
         """Map an exception to a (error_code, error_message) tuple."""
+        name = type(exc).__name__.lower()
+        text = str(exc).lower()
+        status_code = extract_status_code(exc)
+        provider_code = extract_provider_error_code(exc)
+
+        if status_code is not None:
+            return f'orq.http.{status_code}', f'{type(exc).__name__}: {exc}'
+        if provider_code:
+            return f'orq.code.{provider_code}', f'{type(exc).__name__}: {exc}'
+        if 'timeout' in name or 'timed out' in text:
+            return 'orq.timeout', f'{type(exc).__name__}: {exc}'
+        if 'auth' in name or 'unauthorized' in text or 'forbidden' in text:
+            return 'orq.auth', f'{type(exc).__name__}: {exc}'
+        if 'ratelimit' in name or '429' in text:
+            return 'orq.rate_limit', f'{type(exc).__name__}: {exc}'
+        return 'orq.unknown', f'{type(exc).__name__}: {exc}'
+
+
+class ORQBackend(Backend):
+    """Backend for ORQ-hosted agents.
+
+    Owns the ORQ SDK client. Creates ``ORQAgentTarget`` instances per job.
+    Performs memory cleanup via the SDK. Maps ORQ exceptions to a normalized
+    error taxonomy.
+    """
+
+    def __init__(self, *, orq_client: Any = None, timeout_ms: int | None = None) -> None:
+        super().__init__(name="orq")
+        timeout_ms = timeout_ms or PIPELINE_CONFIG.target_agent_timeout_ms
+        self._timeout_ms = timeout_ms
+        if orq_client is not None:
+            self._orq_client = orq_client
+        else:
+            if _orq_cls is None:
+                raise ImportError(
+                    "ORQ backend requires the orq-ai-sdk package. "
+                    "Install with: pip install evaluatorq[orq]"
+                )
+            self._orq_client = _orq_cls(
+                api_key=_get_orq_api_key(),
+                server_url=_get_orq_server_url(),
+                timeout_ms=self._timeout_ms,
+            )
+
+    def create_target(self, agent_key: str) -> ORQAgentTarget:
+        return ORQAgentTarget(
+            agent_key=agent_key,
+            orq_client=self._orq_client,
+            timeout_ms=self._timeout_ms,
+        )
+
+    async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
+        for ms in ctx.memory_stores:
+            if not ms.key:
+                logger.warning(f'Memory store {ms.id} has no key, skipping cleanup')
+                continue
+            for entity_id in entity_ids:
+                try:
+                    await asyncio.to_thread(
+                        self._orq_client.memory_stores.delete_memory,
+                        memory_store_key=ms.key,
+                        memory_entity_id=entity_id,
+                    )
+                    logger.debug(f'Deleted memory entity {entity_id} from store {ms.key}')
+                except Exception as e:  # noqa: PERF203
+                    if extract_status_code(e) == 404:
+                        continue
+                    logger.warning(f'Failed to cleanup memory entity {entity_id} from {ms.key}: {e}')
+
+    def map_error(self, exc: Exception) -> tuple[str, str]:
         name = type(exc).__name__.lower()
         text = str(exc).lower()
         status_code = extract_status_code(exc)

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/orq.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/orq.py
@@ -1,8 +1,8 @@
 """ORQ backend implementation for dynamic red teaming.
 
-Consolidates all ORQ SDK-specific agent code behind the backend protocols
+Consolidates all ORQ SDK-specific agent code behind the backend ABCs
 defined in ``backends.base``. Other modules import these concrete classes
-when they need ORQ-specific behavior, or accept the protocols when they
+when they need ORQ-specific behavior, or accept the base classes when they
 want to be backend-agnostic.
 """
 
@@ -61,7 +61,7 @@ from evaluatorq.redteam.tracing import record_token_usage, set_span_attrs, trunc
 
 
 async def _orq_cleanup_memory(orq_client: Any, ctx: AgentContext, entity_ids: list[str]) -> None:
-    """Delete memory entities for each memory store × entity_id combination."""
+    """Delete memory entities for each (memory store, entity_id) combination."""
     for ms in ctx.memory_stores:
         if not ms.key:
             logger.warning(f'Memory store {ms.id} has no key, skipping cleanup')
@@ -102,7 +102,7 @@ def _orq_map_error(exc: Exception) -> tuple[str, str]:
 class ORQAgentTarget(AgentTarget):
     """Target adapter for ORQ agents.
 
-    Wraps the ORQ SDK to provide the AgentTarget protocol.
+    Wraps the ORQ SDK to satisfy the ``AgentTarget`` ABC.
     """
 
     def __init__(

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/registry.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/registry.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from evaluatorq.redteam.backends.base import Backend
 from evaluatorq.redteam.exceptions import BackendError, CredentialError
 
 if TYPE_CHECKING:
@@ -15,6 +14,7 @@ if TYPE_CHECKING:
 
     from openai import AsyncOpenAI
 
+    from evaluatorq.redteam.backends.base import Backend
     from evaluatorq.redteam.contracts import LLMCallConfig, LLMConfig, TargetConfig
 
 

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/registry.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/registry.py
@@ -7,12 +7,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from evaluatorq.redteam.backends.base import BackendBundle, NoopMemoryCleanup
-from evaluatorq.redteam.backends.openai import (
-    OpenAIContextProvider,
-    OpenAIErrorMapper,
-    OpenAITargetFactory,
-)
+from evaluatorq.redteam.backends.base import Backend
 from evaluatorq.redteam.exceptions import BackendError, CredentialError
 
 if TYPE_CHECKING:
@@ -76,74 +71,55 @@ def create_async_llm_client(role_config: LLMCallConfig | None = None) -> AsyncOp
     raise CredentialError(msg)
 
 
-_BACKEND_REGISTRY: dict[str, Callable[..., BackendBundle]] = {}
+_BACKEND_REGISTRY: dict[str, Callable[..., Backend]] = {}
 
 
-def register_backend(name: str, factory: Callable[..., BackendBundle]) -> None:
+def register_backend(name: str, factory: Callable[..., Backend]) -> None:
     """Register a backend factory for use with resolve_backend()."""
     _BACKEND_REGISTRY[name.strip().lower()] = factory
 
 
 def resolve_backend(
     backend: str = "orq",
+    *,
     llm_client: AsyncOpenAI | None = None,
     target_config: TargetConfig | None = None,
     pipeline_config: LLMConfig | None = None,
-) -> BackendBundle:
-    """Resolve runtime backend bundle with lazy optional imports.
-
-    Args:
-        backend: Backend name (e.g. ``"orq"`` or ``"openai"``).
-        llm_client: Pre-configured client for the OpenAI backend.
-            When provided, skips ``create_async_llm_client()`` for
-            the ``"openai"`` backend.
-        target_config: Optional target configuration (e.g. system prompt).
-        pipeline_config: Optional LLMConfig instance. Defaults to module-level PIPELINE_CONFIG.
-    """
+) -> Backend:
+    """Resolve a backend by name."""
     normalized = backend.strip().lower()
     factory = _BACKEND_REGISTRY.get(normalized)
-    if factory is not None:
-        return factory(llm_client=llm_client, target_config=target_config, pipeline_config=pipeline_config)
-    raise BackendError(f"Unsupported backend: {backend!r}. Available: {sorted(_BACKEND_REGISTRY)}")
+    if factory is None:
+        raise BackendError(
+            f"Unsupported backend: {backend!r}. Available: {sorted(_BACKEND_REGISTRY)}"
+        )
+    return factory(llm_client=llm_client, target_config=target_config, pipeline_config=pipeline_config)
 
 
 def _create_openai_backend(
     llm_client: AsyncOpenAI | None = None,
     target_config: TargetConfig | None = None,
-    **kwargs: object,
-) -> BackendBundle:
+    **_: object,
+) -> Backend:
+    from evaluatorq.redteam.backends.openai import OpenAIBackend
+
     system_prompt = target_config.system_prompt if target_config else None
-    client = llm_client or create_async_llm_client()
-    return BackendBundle(
-        name="openai",
-        target_factory=OpenAITargetFactory(client, system_prompt=system_prompt),
-        context_provider=OpenAIContextProvider(system_prompt=system_prompt),
-        memory_cleanup=NoopMemoryCleanup(),
-        error_mapper=OpenAIErrorMapper(),
-    )
+    return OpenAIBackend(client=llm_client, system_prompt=system_prompt)
 
 
 def _create_orq_backend(
     llm_client: AsyncOpenAI | None = None,
     target_config: TargetConfig | None = None,
     pipeline_config: LLMConfig | None = None,
-    **kwargs: object,
-) -> BackendBundle:
+    **_: object,
+) -> Backend:
     try:
-        from evaluatorq.redteam.backends.orq import ORQErrorMapper, create_orq_backend
+        from evaluatorq.redteam.backends.orq import ORQBackend
     except ImportError as exc:
-        msg = "ORQ backend requested but ORQ dependencies are unavailable."
-        raise BackendError(msg) from exc
-    target_factory, context_provider, memory_cleanup = create_orq_backend(
-        timeout_ms=pipeline_config.target_agent_timeout_ms if pipeline_config else None,
-    )
-    return BackendBundle(
-        name="orq",
-        target_factory=target_factory,
-        context_provider=context_provider,
-        memory_cleanup=memory_cleanup,
-        error_mapper=ORQErrorMapper(),
-    )
+        raise BackendError("ORQ backend requested but ORQ dependencies are unavailable.") from exc
+
+    timeout_ms = pipeline_config.target_agent_timeout_ms if pipeline_config else None
+    return ORQBackend(timeout_ms=timeout_ms)
 
 
 register_backend("openai", _create_openai_backend)

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -829,7 +829,7 @@ async def _prepare_target(
         agent_context = prefetched_agent_context
     else:
         hooks.on_stage_start(PipelineStage.CONTEXT_RETRIEVAL, {"target": target_value})
-        agent_context = await backend.get_agent_context(target_value)
+        agent_context = await backend.resolve_context(target_value)
         hooks.on_stage_end(PipelineStage.CONTEXT_RETRIEVAL, {
             "num_tools": len(agent_context.tools) if agent_context.tools else 0,
             "num_memory_stores": len(agent_context.memory_stores) if agent_context.memory_stores else 0,
@@ -1097,7 +1097,7 @@ async def _run_dynamic_or_hybrid(
         resolved_hooks.on_stage_start(PipelineStage.CONTEXT_RETRIEVAL, {"targets": all_target_labels})
         for target_str in targets:
             _kind, value = _parse_target(target_str)
-            ctx = await orq_backend.get_agent_context(value)
+            ctx = await orq_backend.resolve_context(value)
             all_agent_contexts[target_str] = ctx
             resolved_hooks.on_stage_end(PipelineStage.CONTEXT_RETRIEVAL, {
                 "target": value,
@@ -1953,7 +1953,7 @@ async def _run_static(
         for t in targets:
             _kind, value = _parse_target(t)
             try:
-                ctx = await static_backend.get_agent_context(value)
+                ctx = await static_backend.resolve_context(value)
                 agent_contexts[value] = ctx
             except Exception:
                 logger.debug(f'Could not retrieve agent context for {value} — skipping')

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -36,13 +36,14 @@ from evaluatorq.redteam.adaptive.strategy_registry import (
 from evaluatorq.redteam.backends.base import (
     AgentTarget,
     Backend,
+    BareTargetBackend,
     _coerce_to_agent_response,
 )
 from evaluatorq.redteam.backends.registry import create_async_llm_client, resolve_backend
 from evaluatorq.redteam.contracts import (
+    PIPELINE_CONFIG,
     AgentContext,
     LLMConfig,
-    PIPELINE_CONFIG,
     Pipeline,
     PipelineStage,
     RedTeamReport,
@@ -243,7 +244,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
     from openai import AsyncOpenAI
-
 
 
 # ---------------------------------------------------------------------------
@@ -1323,8 +1323,6 @@ async def _run_dynamic_or_hybrid(
             for at in resolved_agent_targets:
                 at_label = agent_target_labels[id(at)]
                 at_ctx = at_contexts[id(at)]
-
-                from evaluatorq.redteam.backends.base import BareTargetBackend  # added in Task 1.9 — lazy import keeps module load OK
 
                 at_backend = BareTargetBackend(at)
                 at_mem_ids: list[str] = []

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -34,9 +34,9 @@ from evaluatorq.redteam.adaptive.strategy_registry import (
     select_applicable_strategies_for_vulnerability,
 )
 from evaluatorq.redteam.backends.base import (
+    AgentTarget,
     Backend,
     _coerce_to_agent_response,
-    is_agent_target,
 )
 from evaluatorq.redteam.backends.registry import create_async_llm_client, resolve_backend
 from evaluatorq.redteam.contracts import (
@@ -244,7 +244,6 @@ if TYPE_CHECKING:
 
     from openai import AsyncOpenAI
 
-    from evaluatorq.redteam.backends.base import AgentTarget
 
 
 # ---------------------------------------------------------------------------
@@ -410,7 +409,7 @@ async def red_team(
 
     if isinstance(target, list):
         raw_targets: list[str | AgentTarget] = list(target)
-    elif isinstance(target, str) or is_agent_target(target):
+    elif isinstance(target, (str, AgentTarget)):
         raw_targets = [target]
     else:
         raise TypeError(f'Invalid target type: {type(target).__name__}. Expected str or AgentTarget.')
@@ -425,7 +424,7 @@ async def red_team(
     for t in raw_targets:
         if isinstance(t, str):
             string_targets.append(t)
-        elif is_agent_target(t):
+        elif isinstance(t, AgentTarget):
             agent_targets.append(t)
         else:
             raise TypeError(f'Invalid target type: {type(t).__name__}. Expected str or AgentTarget.')

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -34,12 +34,7 @@ from evaluatorq.redteam.adaptive.strategy_registry import (
     select_applicable_strategies_for_vulnerability,
 )
 from evaluatorq.redteam.backends.base import (
-    AgentTargetFactory,
-    DefaultErrorMapper,
-    DirectTargetFactory,
-    ErrorMapper,
-    MemoryCleanup,
-    NoopMemoryCleanup,
+    Backend,
     _coerce_to_agent_response,
     is_agent_target,
 )
@@ -274,7 +269,7 @@ class PreparedTarget:
     all_datapoints: list[DataPoint]
     job: Callable[..., Any]  # the @job-decorated callable for this target
     dynamic_job: Callable[..., Any]  # raw inner dynamic job
-    resolved_memory_cleanup: MemoryCleanup
+    backend: Backend
     resolved_llm_client: AsyncOpenAI | None
     filtering_metadata: dict[str, Any]
     memory_entity_ids: list[str]  # runtime-accumulated entity IDs for cleanup
@@ -828,17 +823,14 @@ async def _prepare_target(
     target_kind, target_value = _parse_target(target)
     safe_target = _make_safe_target(target_value)
 
-    backend_bundle = resolve_backend('orq', llm_client=llm_client, target_config=target_config, pipeline_config=pipeline_config)
-    resolved_factory = backend_bundle.target_factory
-    resolved_error_mapper = DefaultErrorMapper()
-    resolved_memory_cleanup_t = backend_bundle.memory_cleanup
+    backend = resolve_backend('orq', llm_client=llm_client, target_config=target_config, pipeline_config=pipeline_config)
 
     # Context retrieval (skip if already fetched for the confirm step)
     if prefetched_agent_context is not None:
         agent_context = prefetched_agent_context
     else:
         hooks.on_stage_start(PipelineStage.CONTEXT_RETRIEVAL, {"target": target_value})
-        agent_context = await backend_bundle.context_provider.get_agent_context(target_value)
+        agent_context = await backend.get_agent_context(target_value)
         hooks.on_stage_end(PipelineStage.CONTEXT_RETRIEVAL, {
             "num_tools": len(agent_context.tools) if agent_context.tools else 0,
             "num_memory_stores": len(agent_context.memory_stores) if agent_context.memory_stores else 0,
@@ -909,8 +901,7 @@ async def _prepare_target(
         agent_context=agent_context,
         red_team_model=attack_model,
         max_turns=max_turns,
-        target_factory=resolved_factory,
-        error_mapper=resolved_error_mapper,
+        backend=backend,
         attack_llm_client=resolved_llm_client,
         memory_entity_ids=memory_entity_ids,
         attacker_instructions=attacker_instructions,
@@ -1012,7 +1003,7 @@ async def _prepare_target(
         all_datapoints=all_datapoints,
         job=target_job,
         dynamic_job=dynamic_job,
-        resolved_memory_cleanup=resolved_memory_cleanup_t,
+        backend=backend,
         resolved_llm_client=resolved_llm_client,
         filtering_metadata=filtering_metadata,
         memory_entity_ids=memory_entity_ids,
@@ -1102,12 +1093,12 @@ async def _run_dynamic_or_hybrid(
 
         # Step 1: Retrieve agent context for all targets (cheap) so we
         # can show capabilities in the confirmation prompt before expensive generation.
-        bundle = resolve_backend('orq', llm_client=llm_client, target_config=target_config, pipeline_config=pipeline_config)
+        orq_backend = resolve_backend('orq', llm_client=llm_client, target_config=target_config, pipeline_config=pipeline_config)
         all_agent_contexts: dict[str, AgentContext] = {}
         resolved_hooks.on_stage_start(PipelineStage.CONTEXT_RETRIEVAL, {"targets": all_target_labels})
         for target_str in targets:
             _kind, value = _parse_target(target_str)
-            ctx = await bundle.context_provider.get_agent_context(value)
+            ctx = await orq_backend.get_agent_context(value)
             all_agent_contexts[target_str] = ctx
             resolved_hooks.on_stage_end(PipelineStage.CONTEXT_RETRIEVAL, {
                 "target": value,
@@ -1334,22 +1325,17 @@ async def _run_dynamic_or_hybrid(
                 at_label = agent_target_labels[id(at)]
                 at_ctx = at_contexts[id(at)]
 
-                # For direct targets, always use DirectTargetFactory (which uses clone()).
-                # The target's create_target() expects an external agent_key string,
-                # which doesn't apply when the key is embedded in the object.
-                at_factory = DirectTargetFactory(at)
-                at_mapper = at if callable(getattr(at, 'map_error', None)) else DefaultErrorMapper()
-                at_cleanup = at if callable(getattr(at, 'cleanup_memory', None)) else NoopMemoryCleanup()
+                from evaluatorq.redteam.backends.base import BareTargetBackend  # added in Task 1.9 — lazy import keeps module load OK
 
+                at_backend = BareTargetBackend(at)
                 at_mem_ids: list[str] = []
-                all_at_cleanup_info.append((at_ctx, at_mem_ids, at_cleanup))
+                all_at_cleanup_info.append((at_ctx, at_mem_ids, at_backend))
                 at_dyn_job = create_dynamic_redteam_job(
                     agent_key=at_label,
                     agent_context=at_ctx,
                     red_team_model=attack_model,
                     max_turns=max_turns,
-                    target_factory=cast("AgentTargetFactory", at_factory),
-                    error_mapper=cast("ErrorMapper", at_mapper),
+                    backend=at_backend,
                     attack_llm_client=at_llm_client,
                     memory_entity_ids=at_mem_ids,
                     attacker_instructions=attacker_instructions,
@@ -1412,12 +1398,12 @@ async def _run_dynamic_or_hybrid(
                         dp.inputs['hybrid_source'] = 'static'
 
                     # Build a static job that invokes the AgentTarget directly
-                    # Reuse the same DirectTargetFactory created for the dynamic job
+                    # Reuse the same BareTargetBackend created for the dynamic job
                     @job(f'redteam:static:{at_safe}')
                     async def at_static_job(
                         data: DataPoint,
                         _row: int,
-                        _factory: Any = at_factory,
+                        _backend: Any = at_backend,
                         _label: str = at_label,
                     ) -> Any:
                         """Send a static datapoint to the AgentTarget via send_prompt."""
@@ -1432,7 +1418,7 @@ async def _run_dynamic_or_hybrid(
                                 f'Static datapoint {sample_id!r} for target {_label!r} '
                                 f'produced an empty prompt ({len(messages)} messages, none with user content).'
                             )
-                        target_instance = _factory.create_target(_label)
+                        target_instance = _backend.create_target(_label)
                         raw = await target_instance.send_prompt(prompt)
                         result = _coerce_to_agent_response(raw)
                         active_progress = _get_active_progress()
@@ -1477,7 +1463,7 @@ async def _run_dynamic_or_hybrid(
                     all_datapoints=at_all_dps,
                     job=at_target_job,
                     dynamic_job=at_dyn_job,
-                    resolved_memory_cleanup=cast("MemoryCleanup", at_cleanup),
+                    backend=at_backend,
                     resolved_llm_client=at_llm_client,
                     filtering_metadata=at_filter_meta,
                     memory_entity_ids=at_mem_ids,
@@ -1560,13 +1546,13 @@ async def _run_dynamic_or_hybrid(
                         entity_ids = pt.memory_entity_ids
                         if entity_ids:
                             await cleanup_memory_entities(
-                                pt.agent_context, entity_ids, memory_cleanup=pt.resolved_memory_cleanup
+                                pt.agent_context, entity_ids, memory_cleanup=pt.backend
                             )
                     # Also clean up AgentTarget memory entities not yet in prepared_targets
                     prepared_mem_id_lists = {id(pt.memory_entity_ids) for pt in prepared_targets}
-                    for at_ctx_c, at_mem_c, at_cleanup_c in all_at_cleanup_info:
+                    for at_ctx_c, at_mem_c, at_backend_c in all_at_cleanup_info:
                         if id(at_mem_c) not in prepared_mem_id_lists and at_mem_c:
-                            await cleanup_memory_entities(at_ctx_c, at_mem_c, memory_cleanup=at_cleanup_c)
+                            await cleanup_memory_entities(at_ctx_c, at_mem_c, memory_cleanup=at_backend_c)
                 raise
 
         resolved_hooks.on_stage_end(PipelineStage.ATTACK_EXECUTION, {"num_results": len(results)})
@@ -1771,7 +1757,7 @@ async def _run_dynamic_or_hybrid(
                         "orq.redteam.memory_cleanup",
                         {"orq.redteam.num_entities": len(entity_ids)},
                     ) as cleanup_span:
-                        cleanup_error = await cleanup_memory_entities(pt.agent_context, entity_ids, memory_cleanup=pt.resolved_memory_cleanup)
+                        cleanup_error = await cleanup_memory_entities(pt.agent_context, entity_ids, memory_cleanup=pt.backend)
                         set_span_attrs(cleanup_span, {
                             "orq.redteam.num_stores": len(pt.agent_context.memory_stores) if pt.agent_context.memory_stores else 0,
                         })
@@ -1966,11 +1952,11 @@ async def _run_static(
     # Fetch agent contexts for all targets (best-effort)
     agent_contexts: dict[str, AgentContext] = {}
     try:
-        backend_bundle = resolve_backend('orq', llm_client=llm_client, target_config=target_config, pipeline_config=pipeline_config)
+        static_backend = resolve_backend('orq', llm_client=llm_client, target_config=target_config, pipeline_config=pipeline_config)
         for t in targets:
             _kind, value = _parse_target(t)
             try:
-                ctx = await backend_bundle.context_provider.get_agent_context(value)
+                ctx = await static_backend.get_agent_context(value)
                 agent_contexts[value] = ctx
             except Exception:
                 logger.debug(f'Could not retrieve agent context for {value} — skipping')

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/target.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from evaluatorq.contracts import AgentResponse, LLMCallConfig
+from evaluatorq.redteam.backends.base import AgentTarget
 from evaluatorq.simulation._client import build_simulation_client, extract_responses_output
 from evaluatorq.simulation.types import ChatMessage, TokenUsage
 from evaluatorq.simulation.utils.retry import with_retry
@@ -31,7 +32,7 @@ class _ResponsesCallResult:
     usage: TokenUsage | None
 
 
-class OrqResponsesTarget:
+class OrqResponsesTarget(AgentTarget):
     """Wraps the Orq Responses v3 API as a simulation target.
 
     Implements two interfaces with different state semantics:
@@ -51,9 +52,6 @@ class OrqResponsesTarget:
     path is safe to invoke concurrently because it mutates nothing on self.
     """
 
-    memory_entity_id: str | None
-    threading_disabled: bool
-
     def __init__(
         self,
         config: LLMCallConfig,
@@ -63,10 +61,10 @@ class OrqResponsesTarget:
         memory_entity_id: str | None = None,
         client: AsyncOpenAI | None = None,
     ) -> None:
+        super().__init__(memory_entity_id=memory_entity_id)
         self.config = config
         self.instructions = instructions
         self.tools = tools
-        self.memory_entity_id = memory_entity_id
         self.threading_disabled = False
         self._previous_response_id: str | None = None
         self._accumulated_usage = TokenUsage()

--- a/packages/evaluatorq-py/tests/redteam/e2e/conftest.py
+++ b/packages/evaluatorq-py/tests/redteam/e2e/conftest.py
@@ -199,7 +199,7 @@ class MockBackend(Backend):
         self.created_targets.append(target)
         return target
 
-    async def get_agent_context(self, agent_key: str) -> AgentContext:
+    async def resolve_context(self, agent_key: str) -> AgentContext:
         return self._context
 
     async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:

--- a/packages/evaluatorq-py/tests/redteam/e2e/conftest.py
+++ b/packages/evaluatorq-py/tests/redteam/e2e/conftest.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import pytest
 
-from evaluatorq.redteam.backends.base import BackendBundle
+from evaluatorq.redteam.backends.base import Backend
 from evaluatorq.redteam.contracts import (
     AgentContext,
     AgentResponse,
@@ -185,6 +185,30 @@ class MockErrorMapper:
         return "test_error", f"{type(exc).__name__}: {exc}"
 
 
+class MockBackend(Backend):
+    """Concrete Backend for E2E tests — combines factory, context, cleanup, and error mapping."""
+
+    def __init__(self, context: AgentContext) -> None:
+        super().__init__("mock")
+        self._context = context
+        self.cleaned_entity_ids: list[str] = []
+        self.created_targets: list[MockAgentTarget] = []
+
+    def create_target(self, agent_key: str) -> MockAgentTarget:
+        target = MockAgentTarget(agent_key)
+        self.created_targets.append(target)
+        return target
+
+    async def get_agent_context(self, agent_key: str) -> AgentContext:
+        return self._context
+
+    async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
+        self.cleaned_entity_ids.extend(entity_ids)
+
+    def map_error(self, exc: Exception) -> tuple[str, str]:
+        return "test_error", f"{type(exc).__name__}: {exc}"
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -232,15 +256,9 @@ def agent_context() -> AgentContext:
 
 
 @pytest.fixture()
-def mock_backend_bundle(agent_context: AgentContext) -> BackendBundle:
-    """Assembles mock backend components into a BackendBundle."""
-    return BackendBundle(
-        name="mock",
-        target_factory=MockTargetFactory(),
-        context_provider=MockContextProvider(agent_context),
-        memory_cleanup=MockMemoryCleanup(),
-        error_mapper=MockErrorMapper(),
-    )
+def mock_backend_bundle(agent_context: AgentContext) -> MockBackend:
+    """Returns a MockBackend instance for patching resolve_backend."""
+    return MockBackend(context=agent_context)
 
 
 @pytest.fixture()

--- a/packages/evaluatorq-py/tests/redteam/e2e/conftest.py
+++ b/packages/evaluatorq-py/tests/redteam/e2e/conftest.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import pytest
 
-from evaluatorq.redteam.backends.base import Backend
+from evaluatorq.redteam.backends.base import AgentTarget, Backend
 from evaluatorq.redteam.contracts import (
     AgentContext,
     AgentResponse,
@@ -128,12 +128,12 @@ class DeterministicAsyncOpenAI:
 # ---------------------------------------------------------------------------
 
 
-class MockAgentTarget:
+class MockAgentTarget(AgentTarget):
     """Deterministic agent target with leak/refuse/safe logic."""
 
     def __init__(self, agent_key: str) -> None:
+        super().__init__(memory_entity_id=f"red-team-{uuid.uuid4().hex[:12]}")
         self.agent_key = agent_key
-        self.memory_entity_id: str | None = f"red-team-{uuid.uuid4().hex[:12]}"
         self._conversation: list[dict[str, str]] = []
 
     async def send_prompt(self, prompt: str) -> AgentResponse:

--- a/packages/evaluatorq-py/tests/redteam/e2e/test_dynamic_pipeline.py
+++ b/packages/evaluatorq-py/tests/redteam/e2e/test_dynamic_pipeline.py
@@ -10,17 +10,15 @@ import pytest
 from openai import AsyncOpenAI
 
 from evaluatorq.redteam import red_team
-from evaluatorq.redteam.backends.base import BackendBundle
-
 from .conftest import (
     DeterministicAsyncOpenAI,
-    MockMemoryCleanup,
+    MockBackend,
     validate_report_structure,
 )
 
 
 @contextmanager
-def _dynamic_patches(mock_backend_bundle: BackendBundle):
+def _dynamic_patches(mock_backend_bundle: MockBackend):
     """Patch lazy imports used by _run_dynamic and _run_hybrid."""
     with (
         patch("evaluatorq.redteam.runner.resolve_backend", return_value=mock_backend_bundle),
@@ -33,7 +31,7 @@ def _dynamic_patches(mock_backend_bundle: BackendBundle):
 @pytest.mark.asyncio
 async def test_full_dynamic_run(
     mock_llm_client: DeterministicAsyncOpenAI,
-    mock_backend_bundle: BackendBundle,
+    mock_backend_bundle: MockBackend,
 ) -> None:
     """Full dynamic pipeline run with a single category, no strategy generation."""
     with _dynamic_patches(mock_backend_bundle):
@@ -55,7 +53,7 @@ async def test_full_dynamic_run(
 @pytest.mark.asyncio
 async def test_dynamic_with_strategy_generation(
     mock_llm_client: DeterministicAsyncOpenAI,
-    mock_backend_bundle: BackendBundle,
+    mock_backend_bundle: MockBackend,
 ) -> None:
     """Dynamic run with strategy generation enabled."""
     with _dynamic_patches(mock_backend_bundle):
@@ -77,7 +75,7 @@ async def test_dynamic_with_strategy_generation(
 @pytest.mark.asyncio
 async def test_dynamic_datapoint_capping(
     mock_llm_client: DeterministicAsyncOpenAI,
-    mock_backend_bundle: BackendBundle,
+    mock_backend_bundle: MockBackend,
 ) -> None:
     """max_dynamic_datapoints=2 should cap results."""
     with _dynamic_patches(mock_backend_bundle):
@@ -97,7 +95,7 @@ async def test_dynamic_datapoint_capping(
 @pytest.mark.asyncio
 async def test_dynamic_memory_cleanup(
     mock_llm_client: DeterministicAsyncOpenAI,
-    mock_backend_bundle: BackendBundle,
+    mock_backend_bundle: MockBackend,
 ) -> None:
     """Memory cleanup should be invoked when agent has memory stores."""
     with _dynamic_patches(mock_backend_bundle):
@@ -111,5 +109,4 @@ async def test_dynamic_memory_cleanup(
             llm_client=cast(AsyncOpenAI, cast(object, mock_llm_client)),
         )
 
-    cleanup: MockMemoryCleanup = cast(MockMemoryCleanup, mock_backend_bundle.memory_cleanup)
-    assert len(cleanup.cleaned_entity_ids) > 0, "Expected memory cleanup to be called"
+    assert len(mock_backend_bundle.cleaned_entity_ids) > 0, "Expected memory cleanup to be called"

--- a/packages/evaluatorq-py/tests/redteam/e2e/test_hybrid_pipeline.py
+++ b/packages/evaluatorq-py/tests/redteam/e2e/test_hybrid_pipeline.py
@@ -11,13 +11,11 @@ import pytest
 from openai import AsyncOpenAI
 
 from evaluatorq.redteam import red_team
-from evaluatorq.redteam.backends.base import BackendBundle
-
-from .conftest import DeterministicAsyncOpenAI, validate_report_structure
+from .conftest import DeterministicAsyncOpenAI, MockBackend, validate_report_structure
 
 
 @contextmanager
-def _hybrid_patches(mock_backend_bundle: BackendBundle):
+def _hybrid_patches(mock_backend_bundle: MockBackend):
     """Patch lazy imports used by _run_hybrid."""
     with (
         patch("evaluatorq.redteam.runner.resolve_backend", return_value=mock_backend_bundle),
@@ -30,7 +28,7 @@ def _hybrid_patches(mock_backend_bundle: BackendBundle):
 @pytest.mark.asyncio
 async def test_full_hybrid_run(
     mock_llm_client: DeterministicAsyncOpenAI,
-    mock_backend_bundle: BackendBundle,
+    mock_backend_bundle: MockBackend,
     static_dataset_path: Path,
 ) -> None:
     """Full hybrid pipeline: dynamic + static merged."""
@@ -60,7 +58,7 @@ async def test_full_hybrid_run(
 @pytest.mark.asyncio
 async def test_hybrid_independent_caps(
     mock_llm_client: DeterministicAsyncOpenAI,
-    mock_backend_bundle: BackendBundle,
+    mock_backend_bundle: MockBackend,
     static_dataset_path: Path,
 ) -> None:
     """Independent capping: max_dynamic_datapoints=1 + max_static_datapoints=1."""

--- a/packages/evaluatorq-py/tests/redteam/e2e/test_pipeline_options.py
+++ b/packages/evaluatorq-py/tests/redteam/e2e/test_pipeline_options.py
@@ -11,12 +11,11 @@ import pytest
 from openai import AsyncOpenAI
 
 from evaluatorq.redteam import red_team
-from evaluatorq.redteam.backends.base import BackendBundle
 from evaluatorq.redteam.contracts import SaveMode
 from evaluatorq.redteam.exceptions import CancelledError
 from evaluatorq.redteam.hooks import ConfirmPayload, DefaultHooks
 
-from .conftest import DeterministicAsyncOpenAI
+from .conftest import DeterministicAsyncOpenAI, MockBackend
 
 
 class _CancellingHooks(DefaultHooks):
@@ -31,7 +30,7 @@ class _CancellingHooks(DefaultHooks):
 
 
 @contextmanager
-def _dynamic_patches(mock_backend_bundle: BackendBundle):
+def _dynamic_patches(mock_backend_bundle: MockBackend):
     with (
         patch("evaluatorq.redteam.runner.resolve_backend", return_value=mock_backend_bundle),
         patch("evaluatorq.redteam.runner.init_tracing_if_needed", return_value=None),
@@ -48,7 +47,7 @@ def _dynamic_patches(mock_backend_bundle: BackendBundle):
 @pytest.mark.asyncio
 async def test_hooks_on_confirm_cancels_dynamic(
     mock_llm_client: DeterministicAsyncOpenAI,
-    mock_backend_bundle: BackendBundle,
+    mock_backend_bundle: MockBackend,
 ) -> None:
     """on_confirm returning False should raise RuntimeError."""
     hooks = _CancellingHooks()
@@ -72,7 +71,7 @@ async def test_hooks_on_confirm_cancels_dynamic(
 @pytest.mark.asyncio
 async def test_hooks_on_confirm_cancels_hybrid(
     mock_llm_client: DeterministicAsyncOpenAI,
-    mock_backend_bundle: BackendBundle,
+    mock_backend_bundle: MockBackend,
     static_dataset_path: Path,
 ) -> None:
     """on_confirm returning False in hybrid mode should raise RuntimeError."""
@@ -133,7 +132,7 @@ async def test_static_output_artifacts(
 @pytest.mark.asyncio
 async def test_dynamic_output_artifacts(
     mock_llm_client: DeterministicAsyncOpenAI,
-    mock_backend_bundle: BackendBundle,
+    mock_backend_bundle: MockBackend,
     tmp_path: Path,
 ) -> None:
     """Dynamic mode should write artifact files via the unified pipeline."""

--- a/packages/evaluatorq-py/tests/redteam/test_backend_abc.py
+++ b/packages/evaluatorq-py/tests/redteam/test_backend_abc.py
@@ -79,24 +79,24 @@ class _CountingBackend(Backend):
 
 
 @pytest.mark.asyncio
-async def test_get_agent_context_caches_per_key():
-    """Default get_agent_context probes once per key, then serves from cache."""
+async def test_resolve_context_caches_per_key():
+    """Default resolve_context probes once per key, then serves from cache."""
     backend = _CountingBackend()
 
-    first = await backend.get_agent_context("agent-a")
-    second = await backend.get_agent_context("agent-a")
+    first = await backend.resolve_context("agent-a")
+    second = await backend.resolve_context("agent-a")
 
     assert first is second, "cache hit must return the same AgentContext instance"
     assert backend.create_calls == 1, "second call must not re-probe a new target"
 
 
 @pytest.mark.asyncio
-async def test_get_agent_context_caches_distinct_keys_independently():
+async def test_resolve_context_caches_distinct_keys_independently():
     """Distinct agent keys are probed and cached separately."""
     backend = _CountingBackend()
 
-    ctx_a = await backend.get_agent_context("agent-a")
-    ctx_b = await backend.get_agent_context("agent-b")
+    ctx_a = await backend.resolve_context("agent-a")
+    ctx_b = await backend.resolve_context("agent-b")
 
     assert ctx_a.key == "agent-a"
     assert ctx_b.key == "agent-b"

--- a/packages/evaluatorq-py/tests/redteam/test_backend_abc.py
+++ b/packages/evaluatorq-py/tests/redteam/test_backend_abc.py
@@ -30,3 +30,16 @@ def test_default_map_error_returns_target_error_tuple():
     assert code == "target_error"
     assert "RuntimeError" in msg
     assert "boom" in msg
+
+
+def test_orq_backend_map_error_includes_status_code():
+    from evaluatorq.redteam.backends.orq import ORQBackend
+
+    class _HTTPError(Exception):
+        def __init__(self):
+            super().__init__("boom")
+            self.status_code = 429
+
+    backend = ORQBackend(orq_client=object(), timeout_ms=1000)
+    code, _ = backend.map_error(_HTTPError())
+    assert code == "orq.http.429"

--- a/packages/evaluatorq-py/tests/redteam/test_backend_abc.py
+++ b/packages/evaluatorq-py/tests/redteam/test_backend_abc.py
@@ -55,3 +55,49 @@ def test_openai_backend_map_error_returns_openai_prefix():
     backend = OpenAIBackend(client=MagicMock(), system_prompt=None)
     code, _ = backend.map_error(TimeoutError("slow"))
     assert code.startswith("openai.")
+
+
+class _CountingBackend(Backend):
+    """Backend whose create_target is counted, returning a target with a fixed context."""
+
+    def __init__(self):
+        super().__init__(name="counting")
+        self.create_calls = 0
+
+    def create_target(self, agent_key):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from evaluatorq.redteam.contracts import AgentContext
+
+        self.create_calls += 1
+        target = MagicMock()
+        target.get_agent_context = AsyncMock(return_value=AgentContext(key=agent_key))
+        return target
+
+    async def cleanup_memory(self, ctx, entity_ids):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_get_agent_context_caches_per_key():
+    """Default get_agent_context probes once per key, then serves from cache."""
+    backend = _CountingBackend()
+
+    first = await backend.get_agent_context("agent-a")
+    second = await backend.get_agent_context("agent-a")
+
+    assert first is second, "cache hit must return the same AgentContext instance"
+    assert backend.create_calls == 1, "second call must not re-probe a new target"
+
+
+@pytest.mark.asyncio
+async def test_get_agent_context_caches_distinct_keys_independently():
+    """Distinct agent keys are probed and cached separately."""
+    backend = _CountingBackend()
+
+    ctx_a = await backend.get_agent_context("agent-a")
+    ctx_b = await backend.get_agent_context("agent-b")
+
+    assert ctx_a.key == "agent-a"
+    assert ctx_b.key == "agent-b"
+    assert backend.create_calls == 2

--- a/packages/evaluatorq-py/tests/redteam/test_backend_abc.py
+++ b/packages/evaluatorq-py/tests/redteam/test_backend_abc.py
@@ -1,0 +1,32 @@
+"""Tests for Backend ABC in redteam.backends.base."""
+from __future__ import annotations
+
+import pytest
+
+from evaluatorq.redteam.backends.base import Backend
+
+
+class _MinimalBackend(Backend):
+    def create_target(self, agent_key):
+        raise NotImplementedError
+
+    async def cleanup_memory(self, ctx, entity_ids):
+        return None
+
+
+def test_backend_is_abstract():
+    with pytest.raises(TypeError):
+        Backend("x")  # type: ignore[abstract]
+
+
+def test_backend_subclass_sets_name():
+    b = _MinimalBackend("orq")
+    assert b.name == "orq"
+
+
+def test_default_map_error_returns_target_error_tuple():
+    b = _MinimalBackend("orq")
+    code, msg = b.map_error(RuntimeError("boom"))
+    assert code == "target_error"
+    assert "RuntimeError" in msg
+    assert "boom" in msg

--- a/packages/evaluatorq-py/tests/redteam/test_backend_abc.py
+++ b/packages/evaluatorq-py/tests/redteam/test_backend_abc.py
@@ -16,7 +16,7 @@ class _MinimalBackend(Backend):
 
 def test_backend_is_abstract():
     with pytest.raises(TypeError):
-        Backend("x")  # type: ignore[abstract]
+        Backend("x")  # pyright: ignore[reportAbstractUsage]
 
 
 def test_backend_subclass_sets_name():

--- a/packages/evaluatorq-py/tests/redteam/test_backend_abc.py
+++ b/packages/evaluatorq-py/tests/redteam/test_backend_abc.py
@@ -43,3 +43,15 @@ def test_orq_backend_map_error_includes_status_code():
     backend = ORQBackend(orq_client=object(), timeout_ms=1000)
     code, _ = backend.map_error(_HTTPError())
     assert code == "orq.http.429"
+
+
+def test_openai_backend_map_error_returns_openai_prefix():
+    from unittest.mock import MagicMock
+
+    from evaluatorq.redteam.backends.openai import OpenAIBackend
+
+    # Pass MagicMock as client — constructor's ``client or create_async_llm_client()``
+    # would otherwise trigger CredentialError when no API key is set in the test env.
+    backend = OpenAIBackend(client=MagicMock(), system_prompt=None)
+    code, _ = backend.map_error(TimeoutError("slow"))
+    assert code.startswith("openai.")

--- a/packages/evaluatorq-py/tests/redteam/test_backends.py
+++ b/packages/evaluatorq-py/tests/redteam/test_backends.py
@@ -237,7 +237,7 @@ class TestOpenAIModelTarget:
 
 
 # ===========================================================================
-# backends/openai.py — OpenAIErrorMapper
+# backends/openai.py — _openai_map_error
 # ===========================================================================
 
 
@@ -307,7 +307,7 @@ class TestOpenAIErrorMapper:
 
 
 # ===========================================================================
-# backends/orq.py — ORQErrorMapper
+# backends/orq.py — _orq_map_error
 # ===========================================================================
 
 

--- a/packages/evaluatorq-py/tests/redteam/test_backends.py
+++ b/packages/evaluatorq-py/tests/redteam/test_backends.py
@@ -242,76 +242,66 @@ class TestOpenAIModelTarget:
 
 
 class TestOpenAIErrorMapper:
-    """Tests for OpenAIErrorMapper.map_error()."""
+    """Tests for _openai_map_error()."""
 
     def test_maps_http_status_code(self):
-        from evaluatorq.redteam.backends.openai import OpenAIErrorMapper
+        from evaluatorq.redteam.backends.openai import _openai_map_error
 
-        mapper = OpenAIErrorMapper()
         exc = _make_exc(status_code=429)
-        code, msg = mapper.map_error(exc)
+        code, msg = _openai_map_error(exc)
         assert code == "openai.http.429"
         assert "Exception" in msg
 
     def test_maps_provider_error_code(self):
-        from evaluatorq.redteam.backends.openai import OpenAIErrorMapper
+        from evaluatorq.redteam.backends.openai import _openai_map_error
 
-        mapper = OpenAIErrorMapper()
         exc = _make_exc(code="content_filter")
-        code, msg = mapper.map_error(exc)
+        code, msg = _openai_map_error(exc)
         assert code == "openai.code.content_filter"
 
     def test_maps_rate_limit_by_exception_name(self):
-        from evaluatorq.redteam.backends.openai import OpenAIErrorMapper
-
-        mapper = OpenAIErrorMapper()
+        from evaluatorq.redteam.backends.openai import _openai_map_error
 
         class RateLimitError(Exception):
             pass
 
         exc = RateLimitError("rate limit hit")
-        code, msg = mapper.map_error(exc)
+        code, msg = _openai_map_error(exc)
         assert code == "openai.rate_limit"
 
     def test_maps_authentication_error_by_exception_name(self):
-        from evaluatorq.redteam.backends.openai import OpenAIErrorMapper
-
-        mapper = OpenAIErrorMapper()
+        from evaluatorq.redteam.backends.openai import _openai_map_error
 
         class AuthenticationError(Exception):
             pass
 
         exc = AuthenticationError("bad key")
-        code, msg = mapper.map_error(exc)
+        code, msg = _openai_map_error(exc)
         assert code == "openai.auth"
 
     def test_maps_timeout_by_exception_name(self):
-        from evaluatorq.redteam.backends.openai import OpenAIErrorMapper
-
-        mapper = OpenAIErrorMapper()
+        from evaluatorq.redteam.backends.openai import _openai_map_error
 
         class TimeoutError(Exception):
             pass
 
         exc = TimeoutError("timed out")
-        code, msg = mapper.map_error(exc)
+        code, msg = _openai_map_error(exc)
         assert code == "openai.timeout"
 
     def test_maps_unknown_fallback(self):
-        from evaluatorq.redteam.backends.openai import OpenAIErrorMapper
+        from evaluatorq.redteam.backends.openai import _openai_map_error
 
-        mapper = OpenAIErrorMapper()
         exc = Exception("something unexpected")
-        code, msg = mapper.map_error(exc)
+        code, msg = _openai_map_error(exc)
         assert code == "openai.unknown"
         assert "Exception" in msg
 
     def test_message_includes_exception_type_and_text(self):
-        from evaluatorq.redteam.backends.openai import OpenAIErrorMapper
+        from evaluatorq.redteam.backends.openai import _openai_map_error
 
-        mapper = OpenAIErrorMapper()
         exc = ValueError("bad value encountered")
-        code, msg = mapper.map_error(exc)
+        code, msg = _openai_map_error(exc)
         assert "ValueError" in msg
         assert "bad value encountered" in msg
 
@@ -322,108 +312,94 @@ class TestOpenAIErrorMapper:
 
 
 class TestORQErrorMapper:
-    """Tests for ORQErrorMapper.map_error()."""
+    """Tests for _orq_map_error()."""
 
     def test_maps_http_status_code(self):
-        from evaluatorq.redteam.backends.orq import ORQErrorMapper
+        from evaluatorq.redteam.backends.orq import _orq_map_error
 
-        mapper = ORQErrorMapper()
         exc = _make_exc(status_code=503)
-        code, msg = mapper.map_error(exc)
+        code, msg = _orq_map_error(exc)
         assert code == "orq.http.503"
 
     def test_maps_provider_error_code(self):
-        from evaluatorq.redteam.backends.orq import ORQErrorMapper
+        from evaluatorq.redteam.backends.orq import _orq_map_error
 
-        mapper = ORQErrorMapper()
         exc = _make_exc(code="model_unavailable")
-        code, msg = mapper.map_error(exc)
+        code, msg = _orq_map_error(exc)
         assert code == "orq.code.model_unavailable"
 
     def test_maps_timeout_by_exception_name(self):
-        from evaluatorq.redteam.backends.orq import ORQErrorMapper
-
-        mapper = ORQErrorMapper()
+        from evaluatorq.redteam.backends.orq import _orq_map_error
 
         class TimeoutError(Exception):
             pass
 
         exc = TimeoutError("request timed out")
-        code, msg = mapper.map_error(exc)
+        code, msg = _orq_map_error(exc)
         assert code == "orq.timeout"
 
     def test_maps_timeout_by_text(self):
-        from evaluatorq.redteam.backends.orq import ORQErrorMapper
+        from evaluatorq.redteam.backends.orq import _orq_map_error
 
-        mapper = ORQErrorMapper()
         exc = Exception("connection timed out after 30s")
-        code, msg = mapper.map_error(exc)
+        code, msg = _orq_map_error(exc)
         assert code == "orq.timeout"
 
     def test_maps_auth_by_exception_name(self):
-        from evaluatorq.redteam.backends.orq import ORQErrorMapper
-
-        mapper = ORQErrorMapper()
+        from evaluatorq.redteam.backends.orq import _orq_map_error
 
         class AuthError(Exception):
             pass
 
         exc = AuthError("invalid credentials")
-        code, msg = mapper.map_error(exc)
+        code, msg = _orq_map_error(exc)
         assert code == "orq.auth"
 
     def test_maps_auth_by_unauthorized_text(self):
-        from evaluatorq.redteam.backends.orq import ORQErrorMapper
+        from evaluatorq.redteam.backends.orq import _orq_map_error
 
-        mapper = ORQErrorMapper()
         exc = Exception("unauthorized access to resource")
-        code, msg = mapper.map_error(exc)
+        code, msg = _orq_map_error(exc)
         assert code == "orq.auth"
 
     def test_maps_auth_by_forbidden_text(self):
-        from evaluatorq.redteam.backends.orq import ORQErrorMapper
+        from evaluatorq.redteam.backends.orq import _orq_map_error
 
-        mapper = ORQErrorMapper()
         exc = Exception("forbidden - insufficient permissions")
-        code, msg = mapper.map_error(exc)
+        code, msg = _orq_map_error(exc)
         assert code == "orq.auth"
 
     def test_maps_rate_limit_by_exception_name(self):
-        from evaluatorq.redteam.backends.orq import ORQErrorMapper
-
-        mapper = ORQErrorMapper()
+        from evaluatorq.redteam.backends.orq import _orq_map_error
 
         class RateLimitError(Exception):
             pass
 
         exc = RateLimitError("too many requests")
-        code, msg = mapper.map_error(exc)
+        code, msg = _orq_map_error(exc)
         assert code == "orq.rate_limit"
 
     def test_maps_rate_limit_by_429_in_text(self):
         """When '429' appears in error text without a structured status pattern,
         the ratelimit keyword check catches it as orq.rate_limit."""
-        from evaluatorq.redteam.backends.orq import ORQErrorMapper
+        from evaluatorq.redteam.backends.orq import _orq_map_error
 
-        mapper = ORQErrorMapper()
         exc = Exception("received 429 from server")
-        code, msg = mapper.map_error(exc)
+        code, msg = _orq_map_error(exc)
         assert code == "orq.rate_limit"
 
     def test_maps_unknown_fallback(self):
-        from evaluatorq.redteam.backends.orq import ORQErrorMapper
+        from evaluatorq.redteam.backends.orq import _orq_map_error
 
-        mapper = ORQErrorMapper()
         exc = Exception("something else entirely")
-        code, msg = mapper.map_error(exc)
+        code, msg = _orq_map_error(exc)
         assert code == "orq.unknown"
 
     def test_message_contains_exception_type_and_text(self):
-        from evaluatorq.redteam.backends.orq import ORQErrorMapper
+        from evaluatorq.redteam.backends.orq import _orq_map_error
 
-        mapper = ORQErrorMapper()
         exc = RuntimeError("runtime failure")
-        code, msg = mapper.map_error(exc)
+        code, msg = _orq_map_error(exc)
         assert "RuntimeError" in msg
         assert "runtime failure" in msg
 

--- a/packages/evaluatorq-py/tests/redteam/test_backends.py
+++ b/packages/evaluatorq-py/tests/redteam/test_backends.py
@@ -54,55 +54,55 @@ class TestExtractStatusCode:
     """Tests for extract_status_code()."""
 
     def test_from_response_status_code_attribute(self):
-        from evaluatorq.redteam.backends.base import extract_status_code
+        from evaluatorq.redteam.backends._errors import extract_status_code
 
         exc = _make_exc(response_status_code=429)
         assert extract_status_code(exc) == 429
 
     def test_from_exc_status_code_direct(self):
-        from evaluatorq.redteam.backends.base import extract_status_code
+        from evaluatorq.redteam.backends._errors import extract_status_code
 
         exc = _make_exc(status_code=500)
         assert extract_status_code(exc) == 500
 
     def test_from_exc_status_direct(self):
-        from evaluatorq.redteam.backends.base import extract_status_code
+        from evaluatorq.redteam.backends._errors import extract_status_code
 
         exc = _make_exc(status=403)
         assert extract_status_code(exc) == 403
 
     def test_from_regex_http_prefix(self):
-        from evaluatorq.redteam.backends.base import extract_status_code
+        from evaluatorq.redteam.backends._errors import extract_status_code
 
         exc = Exception("Request failed: HTTP 429 Too Many Requests")
         assert extract_status_code(exc) == 429
 
     def test_from_regex_status_code_equals(self):
-        from evaluatorq.redteam.backends.base import extract_status_code
+        from evaluatorq.redteam.backends._errors import extract_status_code
 
         exc = Exception("status_code=500 Internal Server Error")
         assert extract_status_code(exc) == 500
 
     def test_from_regex_code_equals(self):
-        from evaluatorq.redteam.backends.base import extract_status_code
+        from evaluatorq.redteam.backends._errors import extract_status_code
 
         exc = Exception("code=403 Forbidden")
         assert extract_status_code(exc) == 403
 
     def test_returns_none_when_no_code(self):
-        from evaluatorq.redteam.backends.base import extract_status_code
+        from evaluatorq.redteam.backends._errors import extract_status_code
 
         exc = Exception("some generic error with no status")
         assert extract_status_code(exc) is None
 
     def test_returns_none_for_out_of_range_code(self):
-        from evaluatorq.redteam.backends.base import extract_status_code
+        from evaluatorq.redteam.backends._errors import extract_status_code
 
         exc = Exception("code=999 not a valid HTTP status")
         assert extract_status_code(exc) is None
 
     def test_response_status_code_out_of_range_falls_through(self):
-        from evaluatorq.redteam.backends.base import extract_status_code
+        from evaluatorq.redteam.backends._errors import extract_status_code
 
         # response.status_code is out of 100-599 range; should fall through
         exc = _make_exc(message="error")
@@ -113,20 +113,20 @@ class TestExtractStatusCode:
         assert extract_status_code(exc) is None
 
     def test_response_status_code_lower_boundary(self):
-        from evaluatorq.redteam.backends.base import extract_status_code
+        from evaluatorq.redteam.backends._errors import extract_status_code
 
         exc = _make_exc(response_status_code=100)
         assert extract_status_code(exc) == 100
 
     def test_response_status_code_upper_boundary(self):
-        from evaluatorq.redteam.backends.base import extract_status_code
+        from evaluatorq.redteam.backends._errors import extract_status_code
 
         exc = _make_exc(response_status_code=599)
         assert extract_status_code(exc) == 599
 
     def test_prefers_response_status_code_over_direct(self):
         """response.status_code is checked first and wins over exc.status_code."""
-        from evaluatorq.redteam.backends.base import extract_status_code
+        from evaluatorq.redteam.backends._errors import extract_status_code
 
         exc = _make_exc(response_status_code=503, status_code=429)
         assert extract_status_code(exc) == 503
@@ -141,68 +141,68 @@ class TestExtractProviderErrorCode:
     """Tests for extract_provider_error_code()."""
 
     def test_from_exc_code_attribute(self):
-        from evaluatorq.redteam.backends.base import extract_provider_error_code
+        from evaluatorq.redteam.backends._errors import extract_provider_error_code
 
         exc = _make_exc(code="rate_limit_exceeded")
         assert extract_provider_error_code(exc) == "rate_limit_exceeded"
 
     def test_from_exc_error_code_attribute(self):
-        from evaluatorq.redteam.backends.base import extract_provider_error_code
+        from evaluatorq.redteam.backends._errors import extract_provider_error_code
 
         exc = _make_exc(error_code="invalid_api_key")
         assert extract_provider_error_code(exc) == "invalid_api_key"
 
     def test_from_exc_type_attribute(self):
-        from evaluatorq.redteam.backends.base import extract_provider_error_code
+        from evaluatorq.redteam.backends._errors import extract_provider_error_code
 
         exc = _make_exc(type_attr="authentication_error")
         assert extract_provider_error_code(exc) == "authentication_error"
 
     def test_from_body_error_code(self):
-        from evaluatorq.redteam.backends.base import extract_provider_error_code
+        from evaluatorq.redteam.backends._errors import extract_provider_error_code
 
         exc = _make_exc(body={"error": {"code": "content_filter", "message": "blocked"}})
         assert extract_provider_error_code(exc) == "content_filter"
 
     def test_from_body_direct_code(self):
-        from evaluatorq.redteam.backends.base import extract_provider_error_code
+        from evaluatorq.redteam.backends._errors import extract_provider_error_code
 
         exc = _make_exc(body={"code": "model_not_found"})
         assert extract_provider_error_code(exc) == "model_not_found"
 
     def test_from_body_error_type(self):
-        from evaluatorq.redteam.backends.base import extract_provider_error_code
+        from evaluatorq.redteam.backends._errors import extract_provider_error_code
 
         exc = _make_exc(body={"error": {"type": "invalid_request_error"}})
         assert extract_provider_error_code(exc) == "invalid_request_error"
 
     def test_from_regex_in_error_text(self):
-        from evaluatorq.redteam.backends.base import extract_provider_error_code
+        from evaluatorq.redteam.backends._errors import extract_provider_error_code
 
         exc = Exception("Request failed: error_code=rate_limit_exceeded")
         result = extract_provider_error_code(exc)
         assert result == "rate_limit_exceeded"
 
     def test_returns_none_when_no_code(self):
-        from evaluatorq.redteam.backends.base import extract_provider_error_code
+        from evaluatorq.redteam.backends._errors import extract_provider_error_code
 
         exc = Exception("Something went wrong")
         assert extract_provider_error_code(exc) is None
 
     def test_strips_whitespace_from_code(self):
-        from evaluatorq.redteam.backends.base import extract_provider_error_code
+        from evaluatorq.redteam.backends._errors import extract_provider_error_code
 
         exc = _make_exc(code="  rate_limit  ")
         assert extract_provider_error_code(exc) == "rate_limit"
 
     def test_lowercases_code(self):
-        from evaluatorq.redteam.backends.base import extract_provider_error_code
+        from evaluatorq.redteam.backends._errors import extract_provider_error_code
 
         exc = _make_exc(code="RateLimitExceeded")
         assert extract_provider_error_code(exc) == "ratelimitexceeded"
 
     def test_empty_string_code_ignored(self):
-        from evaluatorq.redteam.backends.base import extract_provider_error_code
+        from evaluatorq.redteam.backends._errors import extract_provider_error_code
 
         exc = _make_exc(code="   ")
         # Whitespace-only code should be treated as missing

--- a/packages/evaluatorq-py/tests/redteam/test_bare_target_backend.py
+++ b/packages/evaluatorq-py/tests/redteam/test_bare_target_backend.py
@@ -1,0 +1,62 @@
+"""Tests for BareTargetBackend adapter."""
+from __future__ import annotations
+
+import pytest
+
+from evaluatorq.redteam.backends.base import AgentTarget, BareTargetBackend
+from evaluatorq.redteam.contracts import AgentContext, AgentResponse
+
+
+class _StubTarget(AgentTarget):
+    def __init__(self, memory_entity_id: str | None = None) -> None:
+        super().__init__(memory_entity_id=memory_entity_id)
+
+    async def send_prompt(self, prompt: str) -> AgentResponse:
+        return AgentResponse(text="ok")
+
+    def new(self) -> "_StubTarget":
+        return _StubTarget()
+
+
+class _TargetWithCleanup(_StubTarget):
+    def __init__(self):
+        super().__init__()
+        self.cleaned: list[str] = []
+
+    async def cleanup_memory(self, ctx, entity_ids):
+        self.cleaned.extend(entity_ids)
+
+
+class _TargetWithMapping(_StubTarget):
+    def map_error(self, exc):
+        return ("byo.error", str(exc))
+
+
+@pytest.mark.asyncio
+async def test_bare_backend_delegates_cleanup_when_target_supports_it():
+    target = _TargetWithCleanup()
+    backend = BareTargetBackend(target)
+    await backend.cleanup_memory(AgentContext(key="x"), ["a", "b"])
+    assert target.cleaned == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_bare_backend_cleanup_noop_when_target_lacks_it():
+    backend = BareTargetBackend(_StubTarget())
+    # Must not raise.
+    await backend.cleanup_memory(AgentContext(key="x"), ["a"])
+
+
+def test_bare_backend_delegates_map_error_when_target_supports_it():
+    target = _TargetWithMapping()
+    backend = BareTargetBackend(target)
+    code, _ = backend.map_error(RuntimeError("boom"))
+    assert code == "byo.error"
+
+
+def test_bare_backend_create_target_returns_target_new():
+    target = _StubTarget()
+    backend = BareTargetBackend(target)
+    fresh = backend.create_target("ignored-agent-key")
+    assert isinstance(fresh, _StubTarget)
+    assert fresh is not target

--- a/packages/evaluatorq-py/tests/redteam/test_dynamic_job.py
+++ b/packages/evaluatorq-py/tests/redteam/test_dynamic_job.py
@@ -113,12 +113,18 @@ def _make_target(memory_entity_id: str | None = None) -> MagicMock:
     return target
 
 
-def _make_target_factory(target: MagicMock | None = None) -> MagicMock:
+def _make_backend(target: MagicMock | None = None) -> MagicMock:
     if target is None:
         target = _make_target()
-    factory = MagicMock()
-    factory.create_target = MagicMock(return_value=target)
-    return factory
+    backend = MagicMock()
+    backend.create_target = MagicMock(return_value=target)
+    backend.map_error = MagicMock(side_effect=lambda exc: ("target_error", f"{type(exc).__name__}: {exc}"))
+    return backend
+
+
+# Backward-compat alias used in some tests
+def _make_target_factory(target: MagicMock | None = None) -> MagicMock:
+    return _make_backend(target)
 
 
 def _make_orchestrator_result(*, error: str | None = None) -> OrchestratorResult:
@@ -215,7 +221,7 @@ class TestTemplateSingleTurnPath:
             job_fn = create_dynamic_redteam_job(
                 agent_key="test-agent",
                 agent_context=agent_context,
-                target_factory=factory,
+                backend=factory,
             )
 
             with patch(
@@ -256,7 +262,7 @@ class TestTemplateSingleTurnPath:
         job_fn = create_dynamic_redteam_job(
             agent_key="test-agent",
             agent_context=agent_context,
-            target_factory=factory,
+            backend=factory,
         )
 
         with patch(
@@ -298,7 +304,7 @@ class TestTemplateSingleTurnPath:
         job_fn = create_dynamic_redteam_job(
             agent_key="test-agent",
             agent_context=agent_context,
-            target_factory=factory,
+            backend=factory,
         )
 
         with patch(
@@ -350,7 +356,7 @@ class TestDynamicMultiTurnPath:
                 job_fn = create_dynamic_redteam_job(
                     agent_key="test-agent",
                     agent_context=agent_context,
-                    target_factory=factory,
+                    backend=factory,
                 )
 
                 output = await _call_dynamic_job(job_fn, datapoint)
@@ -388,7 +394,7 @@ class TestDynamicMultiTurnPath:
                 job_fn = create_dynamic_redteam_job(
                     agent_key="test-agent",
                     agent_context=agent_context,
-                    target_factory=factory,
+                    backend=factory,
                 )
 
                 output = await _call_dynamic_job(job_fn, datapoint)
@@ -426,7 +432,7 @@ class TestDynamicMultiTurnPath:
                 job_fn = create_dynamic_redteam_job(
                     agent_key="test-agent",
                     agent_context=agent_context,
-                    target_factory=factory,
+                    backend=factory,
                 )
                 await _call_dynamic_job(job_fn, datapoint)
 
@@ -463,7 +469,7 @@ class TestDynamicMultiTurnPath:
                 job_fn = create_dynamic_redteam_job(
                     agent_key="test-agent",
                     agent_context=agent_context,
-                    target_factory=factory,
+                    backend=factory,
                     attack_llm_client=custom_llm_client,
                 )
                 await _call_dynamic_job(job_fn, datapoint)
@@ -514,7 +520,7 @@ class TestProgrammingErrorsPropagate:
                 job_fn = create_dynamic_redteam_job(
                     agent_key="test-agent",
                     agent_context=agent_context,
-                    target_factory=factory,
+                    backend=factory,
                 )
 
                 # The @job wrapper re-wraps as JobError; the original is a TypeError
@@ -556,7 +562,7 @@ class TestProgrammingErrorsPropagate:
                 job_fn = create_dynamic_redteam_job(
                     agent_key="test-agent",
                     agent_context=agent_context,
-                    target_factory=factory,
+                    backend=factory,
                 )
 
                 with pytest.raises((AttributeError, JobError)) as exc_info:
@@ -592,7 +598,7 @@ class TestProgrammingErrorsPropagate:
         job_fn = create_dynamic_redteam_job(
             agent_key="test-agent",
             agent_context=agent_context,
-            target_factory=factory,
+            backend=factory,
         )
 
         with pytest.raises((TypeError, JobError)) as exc_info:
@@ -628,7 +634,7 @@ class TestProgrammingErrorsPropagate:
                 job_fn = create_dynamic_redteam_job(
                     agent_key="test-agent",
                     agent_context=agent_context,
-                    target_factory=factory,
+                    backend=factory,
                 )
 
                 with pytest.raises((KeyError, JobError)) as exc_info:
@@ -676,7 +682,7 @@ class TestRuntimeErrorsProduceErrorOutput:
                 job_fn = create_dynamic_redteam_job(
                     agent_key="test-agent",
                     agent_context=agent_context,
-                    target_factory=factory,
+                    backend=factory,
                 )
                 output = await _call_dynamic_job(job_fn, datapoint)
 
@@ -714,7 +720,7 @@ class TestRuntimeErrorsProduceErrorOutput:
                 job_fn = create_dynamic_redteam_job(
                     agent_key="test-agent",
                     agent_context=agent_context,
-                    target_factory=factory,
+                    backend=factory,
                 )
                 output = await _call_dynamic_job(job_fn, datapoint)
 
@@ -751,7 +757,7 @@ class TestRuntimeErrorsProduceErrorOutput:
                 job_fn = create_dynamic_redteam_job(
                     agent_key="test-agent",
                     agent_context=agent_context,
-                    target_factory=factory,
+                    backend=factory,
                 )
                 output = await _call_dynamic_job(job_fn, datapoint)
 
@@ -784,7 +790,7 @@ class TestRuntimeErrorsProduceErrorOutput:
         job_fn = create_dynamic_redteam_job(
             agent_key="test-agent",
             agent_context=agent_context,
-            target_factory=factory,
+            backend=factory,
         )
 
         with patch(
@@ -823,7 +829,7 @@ class TestRuntimeErrorsProduceErrorOutput:
         job_fn = create_dynamic_redteam_job(
             agent_key="test-agent",
             agent_context=agent_context,
-            target_factory=factory,
+            backend=factory,
         )
 
         # Patch wait_for to raise immediately so we don't actually wait
@@ -871,7 +877,7 @@ class TestRuntimeErrorsProduceErrorOutput:
                 job_fn = create_dynamic_redteam_job(
                     agent_key="test-agent",
                     agent_context=agent_context,
-                    target_factory=factory,
+                    backend=factory,
                 )
                 output = await _call_dynamic_job(job_fn, datapoint)
 
@@ -916,7 +922,7 @@ class TestMemoryEntityIdGeneration:
                 job_fn = create_dynamic_redteam_job(
                     agent_key="test-agent",
                     agent_context=agent_context,
-                    target_factory=factory,
+                    backend=factory,
                     memory_entity_ids=tracking_ids,
                 )
                 await _call_dynamic_job(job_fn, datapoint)
@@ -955,7 +961,7 @@ class TestMemoryEntityIdGeneration:
                 job_fn = create_dynamic_redteam_job(
                     agent_key="test-agent",
                     agent_context=agent_context,
-                    target_factory=factory,
+                    backend=factory,
                     memory_entity_ids=tracking_ids,
                 )
                 datapoint = _make_datapoint(strategy=strategy)
@@ -991,7 +997,7 @@ class TestMemoryEntityIdGeneration:
                 job_fn = create_dynamic_redteam_job(
                     agent_key="test-agent",
                     agent_context=agent_context,
-                    target_factory=factory,
+                    backend=factory,
                     memory_entity_ids=tracking_ids,
                 )
                 await _call_dynamic_job(job_fn, datapoint)
@@ -1031,7 +1037,7 @@ class TestSingleTurnTokenUsagePropagation:
         job_fn = create_dynamic_redteam_job(
             agent_key="test-agent",
             agent_context=agent_context,
-            target_factory=factory,
+            backend=factory,
         )
 
         with patch(

--- a/packages/evaluatorq-py/tests/redteam/test_dynamic_job.py
+++ b/packages/evaluatorq-py/tests/redteam/test_dynamic_job.py
@@ -118,7 +118,7 @@ def _make_backend(target: MagicMock | None = None) -> MagicMock:
         target = _make_target()
     backend = MagicMock()
     backend.create_target = MagicMock(return_value=target)
-    backend.map_error = MagicMock(side_effect=lambda exc: ("target_error", f"{type(exc).__name__}: {exc}"))
+    backend.map_error = MagicMock(side_effect=lambda exc: ("target_error", f"{type(exc).__name__}: {exc}"))  # pyright: ignore[reportUnknownLambdaType]
     return backend
 
 

--- a/packages/evaluatorq-py/tests/redteam/test_hooks_lifecycle.py
+++ b/packages/evaluatorq-py/tests/redteam/test_hooks_lifecycle.py
@@ -459,12 +459,10 @@ class TestDynamicInternalStageOrdering:
     """
 
     def _build_backend_mock(self, agent_context: AgentContext) -> Any:
-        """Construct a mock BackendBundle that returns the given agent context."""
+        """Construct a mock Backend that returns the given agent context."""
         return MagicMock(
-            context_provider=MagicMock(
-                get_agent_context=AsyncMock(return_value=agent_context)
-            ),
-            memory_cleanup=MagicMock(),
+            get_agent_context=AsyncMock(return_value=agent_context),
+            cleanup_memory=AsyncMock(),
         )
 
     @pytest.mark.asyncio
@@ -709,10 +707,8 @@ class TestDynamicConfirmPayload:
         datapoints = [DataPoint(inputs={"id": "1", "category": "ASI01", "messages": []})]
         mock_report = _make_report()
         backend_mock = MagicMock(
-            context_provider=MagicMock(
-                get_agent_context=AsyncMock(return_value=agent_ctx)
-            ),
-            memory_cleanup=MagicMock(),
+            get_agent_context=AsyncMock(return_value=agent_ctx),
+            cleanup_memory=AsyncMock(),
         )
 
         with (
@@ -838,10 +834,8 @@ class TestDynamicConfirmPayload:
         spy = SpyHooks(confirm_result=False)
         agent_ctx = _make_agent_context()
         backend_mock = MagicMock(
-            context_provider=MagicMock(
-                get_agent_context=AsyncMock(return_value=agent_ctx)
-            ),
-            memory_cleanup=MagicMock(),
+            get_agent_context=AsyncMock(return_value=agent_ctx),
+            cleanup_memory=AsyncMock(),
         )
 
         gen_mock = AsyncMock(return_value=([], {}))
@@ -915,10 +909,8 @@ class TestDynamicConfirmPayload:
         datapoints = [DataPoint(inputs={"id": "1", "category": "ASI01", "messages": []})]
         mock_report = _make_report()
         backend_mock = MagicMock(
-            context_provider=MagicMock(
-                get_agent_context=AsyncMock(return_value=agent_ctx)
-            ),
-            memory_cleanup=MagicMock(),
+            get_agent_context=AsyncMock(return_value=agent_ctx),
+            cleanup_memory=AsyncMock(),
         )
 
         with (

--- a/packages/evaluatorq-py/tests/redteam/test_hooks_lifecycle.py
+++ b/packages/evaluatorq-py/tests/redteam/test_hooks_lifecycle.py
@@ -144,9 +144,7 @@ class TestStaticPipelineHooks:
             patch(
                 "evaluatorq.redteam.runner.resolve_backend",
                 return_value=MagicMock(
-                    context_provider=MagicMock(
-                        get_agent_context=AsyncMock(return_value=_make_agent_context())
-                    )
+                    resolve_context=AsyncMock(return_value=_make_agent_context())
                 ),
             ),
         ]
@@ -254,9 +252,7 @@ class TestStaticPipelineHooks:
             patch(
                 "evaluatorq.redteam.runner.resolve_backend",
                 return_value=MagicMock(
-                    context_provider=MagicMock(
-                        get_agent_context=AsyncMock(return_value=_make_agent_context())
-                    )
+                    resolve_context=AsyncMock(return_value=_make_agent_context())
                 ),
             ),
         ):
@@ -461,7 +457,7 @@ class TestDynamicInternalStageOrdering:
     def _build_backend_mock(self, agent_context: AgentContext) -> Any:
         """Construct a mock Backend that returns the given agent context."""
         return MagicMock(
-            get_agent_context=AsyncMock(return_value=agent_context),
+            resolve_context=AsyncMock(return_value=agent_context),
             cleanup_memory=AsyncMock(),
         )
 
@@ -707,7 +703,7 @@ class TestDynamicConfirmPayload:
         datapoints = [DataPoint(inputs={"id": "1", "category": "ASI01", "messages": []})]
         mock_report = _make_report()
         backend_mock = MagicMock(
-            get_agent_context=AsyncMock(return_value=agent_ctx),
+            resolve_context=AsyncMock(return_value=agent_ctx),
             cleanup_memory=AsyncMock(),
         )
 
@@ -834,7 +830,7 @@ class TestDynamicConfirmPayload:
         spy = SpyHooks(confirm_result=False)
         agent_ctx = _make_agent_context()
         backend_mock = MagicMock(
-            get_agent_context=AsyncMock(return_value=agent_ctx),
+            resolve_context=AsyncMock(return_value=agent_ctx),
             cleanup_memory=AsyncMock(),
         )
 
@@ -909,7 +905,7 @@ class TestDynamicConfirmPayload:
         datapoints = [DataPoint(inputs={"id": "1", "category": "ASI01", "messages": []})]
         mock_report = _make_report()
         backend_mock = MagicMock(
-            get_agent_context=AsyncMock(return_value=agent_ctx),
+            resolve_context=AsyncMock(return_value=agent_ctx),
             cleanup_memory=AsyncMock(),
         )
 

--- a/packages/evaluatorq-py/tests/redteam/test_llm_client_threading.py
+++ b/packages/evaluatorq-py/tests/redteam/test_llm_client_threading.py
@@ -98,18 +98,18 @@ class TestResolveBackendLlmClient:
         from evaluatorq.redteam.backends.registry import resolve_backend
 
         custom_client = MagicMock(spec=AsyncOpenAI)
-        bundle = resolve_backend('openai', llm_client=custom_client)
-        # The target factory should have been created with our custom client
-        assert bundle.target_factory._client is custom_client  # pyright: ignore[reportAttributeAccessIssue]
+        backend = resolve_backend('openai', llm_client=custom_client)
+        # The OpenAIBackend stores the client directly as _client
+        assert backend._client is custom_client  # pyright: ignore[reportAttributeAccessIssue]
 
-    @patch('evaluatorq.redteam.backends.registry.create_async_llm_client')
+    @patch('evaluatorq.redteam.backends.openai.create_async_llm_client')
     def test_openai_backend_falls_back_to_create(self, mock_create):
         from evaluatorq.redteam.backends.registry import resolve_backend
 
         mock_create.return_value = MagicMock(spec=AsyncOpenAI)
-        bundle = resolve_backend('openai', llm_client=None)
+        backend = resolve_backend('openai', llm_client=None)
         mock_create.assert_called_once()
-        assert bundle.target_factory._client is mock_create.return_value  # pyright: ignore[reportAttributeAccessIssue]
+        assert backend._client is mock_create.return_value  # pyright: ignore[reportAttributeAccessIssue]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/evaluatorq-py/tests/redteam/test_orchestrator_coverage.py
+++ b/packages/evaluatorq-py/tests/redteam/test_orchestrator_coverage.py
@@ -319,7 +319,6 @@ async def _noop_span_ctx(*args, **kwargs):
 def _make_orchestrator():
     """Create a MultiTurnOrchestrator with a mocked AsyncOpenAI client."""
     from evaluatorq.redteam.adaptive.orchestrator import MultiTurnOrchestrator
-    from evaluatorq.redteam.backends.base import DefaultErrorMapper
 
     mock_llm = MagicMock()
     mock_llm.chat = MagicMock()
@@ -329,7 +328,6 @@ def _make_orchestrator():
     orchestrator = MultiTurnOrchestrator(
         llm_client=mock_llm,
         model="test-model",
-        error_mapper=DefaultErrorMapper(),
     )
     return orchestrator, mock_llm
 

--- a/packages/evaluatorq-py/tests/redteam/test_orq_responses_target_as_agent_target.py
+++ b/packages/evaluatorq-py/tests/redteam/test_orq_responses_target_as_agent_target.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from evaluatorq.contracts import AgentResponse, LLMCallConfig
-from evaluatorq.redteam.backends.base import is_agent_target
+from evaluatorq.redteam.backends.base import AgentTarget
 from evaluatorq.simulation.target import OrqResponsesTarget
 from evaluatorq.simulation.types import ChatMessage
 
@@ -69,9 +69,9 @@ def _make_target() -> OrqResponsesTarget:
 
 class TestIsAgentTarget:
     def test_is_agent_target_returns_true(self):
-        """is_agent_target() must return True for OrqResponsesTarget."""
+        """isinstance(x, AgentTarget) must return True for OrqResponsesTarget."""
         target = _make_target()
-        assert is_agent_target(target) is True
+        assert isinstance(target, AgentTarget) is True
 
     def test_has_send_prompt_callable(self):
         """send_prompt attribute must exist and be callable."""
@@ -147,10 +147,10 @@ class TestNew:
         assert isinstance(fresh, OrqResponsesTarget)
 
     def test_new_result_is_also_agent_target(self):
-        """The instance returned by new() must also satisfy is_agent_target."""
+        """The instance returned by new() must also satisfy isinstance(x, AgentTarget)."""
         target = _make_target()
         fresh = target.new()
-        assert is_agent_target(fresh) is True
+        assert isinstance(fresh, AgentTarget) is True
 
     def test_new_fresh_instance_has_previous_response_id_none(self):
         """new() fresh instance must have _previous_response_id == None."""

--- a/packages/evaluatorq-py/tests/redteam/test_runner.py
+++ b/packages/evaluatorq-py/tests/redteam/test_runner.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 import pytest
 
 from evaluatorq.redteam import get_category_info, list_categories, red_team
+from evaluatorq.redteam.backends.base import AgentTarget
 from evaluatorq.redteam.contracts import AgentResponse, Pipeline, RedTeamReport, ReportSummary
 from evaluatorq.redteam.runner import _deduplicate_target_labels, _parse_target
 
@@ -391,9 +392,7 @@ class TestRedTeamWithAgentTarget:
         from unittest.mock import AsyncMock, patch
         from evaluatorq.redteam.contracts import SendResult
 
-        class MockTarget:
-            memory_entity_id: str | None = None
-
+        class MockTarget(AgentTarget):
             async def send_prompt(self, prompt: str) -> AgentResponse:
                 return AgentResponse(text='response')
 
@@ -415,9 +414,7 @@ class TestRedTeamWithAgentTarget:
         from unittest.mock import AsyncMock, patch
         from evaluatorq.redteam.contracts import SendResult
 
-        class MockTarget:
-            memory_entity_id: str | None = None
-
+        class MockTarget(AgentTarget):
             async def send_prompt(self, prompt: str) -> AgentResponse:
                 return AgentResponse(text='response')
 
@@ -444,9 +441,7 @@ class TestRedTeamWithAgentTarget:
         """Passing an invalid item inside a list raises TypeError."""
         from evaluatorq.redteam.contracts import SendResult
 
-        class MockTarget:
-            memory_entity_id: str | None = None
-
+        class MockTarget(AgentTarget):
             async def send_prompt(self, prompt: str) -> AgentResponse:
                 return AgentResponse(text='response')
 

--- a/packages/evaluatorq-py/tests/redteam/test_runner_error_mapping_regression.py
+++ b/packages/evaluatorq-py/tests/redteam/test_runner_error_mapping_regression.py
@@ -1,0 +1,28 @@
+"""Regression test for spec §8 / Risk 1 — pre-existing bug at runner.py:833.
+
+Before PR1, runner.py hardcoded ``DefaultErrorMapper()`` which masked the
+backend's specific mapping. After PR1, ORQ HTTP exceptions route through
+``ORQBackend.map_error`` and produce ``orq.http.<status>`` codes.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _OrqHTTPError(Exception):
+    def __init__(self, status_code: int):
+        super().__init__(f"orq returned {status_code}")
+        self.status_code = status_code
+
+
+@pytest.mark.asyncio
+async def test_orq_http_exception_maps_to_orq_http_status_code():
+    """End-to-end: ORQ rate-limit exception → ``orq.http.429``, not ``target_error``."""
+    from evaluatorq.redteam.backends.orq import ORQBackend
+
+    backend = ORQBackend(orq_client=MagicMock(), timeout_ms=1000)
+    code, msg = backend.map_error(_OrqHTTPError(429))
+    assert code == "orq.http.429", f"expected orq.http.429, got {code!r}"
+    assert "orq returned 429" in msg

--- a/packages/evaluatorq-py/tests/redteam/test_runner_error_mapping_regression.py
+++ b/packages/evaluatorq-py/tests/redteam/test_runner_error_mapping_regression.py
@@ -76,13 +76,34 @@ def _make_strategy():
 
 
 def test_orq_http_exception_maps_to_orq_http_status_code():
-    """Unit: ORQ rate-limit exception → ``orq.http.429``, not ``target_error``."""
+    """Unit: ORQ rate-limit exception → ``orq.http.429``, not ``target_error``.
+
+    ``_OrqHTTPError`` has a ``status_code`` attribute, so ``extract_status_code``
+    picks it up structurally → ``orq.http.429``.
+    """
     from evaluatorq.redteam.backends.orq import ORQBackend
 
     backend = ORQBackend(orq_client=MagicMock(), timeout_ms=1000)
     code, msg = backend.map_error(_OrqHTTPError(429))
     assert code == "orq.http.429", f"expected orq.http.429, got {code!r}"
     assert "orq returned 429" in msg
+
+
+def test_orq_text_only_rate_limit_maps_to_orq_rate_limit():
+    """Unit: rate-limit indicated only in text (no ``status_code`` attr) → ``orq.rate_limit``.
+
+    Documents the distinction vs. the structured-attribute path above: without a
+    ``status_code`` attribute, the mapper falls through to text heuristics and
+    emits the generic ``orq.rate_limit`` code.
+    """
+    from evaluatorq.redteam.backends.orq import ORQBackend
+
+    class _RateLimitedError(Exception):
+        pass
+
+    backend = ORQBackend(orq_client=MagicMock(), timeout_ms=1000)
+    code, _msg = backend.map_error(_RateLimitedError("upstream returned 429"))
+    assert code == "orq.rate_limit", f"expected orq.rate_limit, got {code!r}"
 
 
 @pytest.mark.asyncio

--- a/packages/evaluatorq-py/tests/redteam/test_runner_error_mapping_regression.py
+++ b/packages/evaluatorq-py/tests/redteam/test_runner_error_mapping_regression.py
@@ -1,14 +1,25 @@
 """Regression test for spec §8 / Risk 1 — pre-existing bug at runner.py:833.
 
-Before PR1, runner.py hardcoded ``DefaultErrorMapper()`` which masked the
-backend's specific mapping. After PR1, ORQ HTTP exceptions route through
-``ORQBackend.map_error`` and produce ``orq.http.<status>`` codes.
+Before PR1, the dynamic-job wiring hardcoded ``DefaultErrorMapper()`` which
+masked the backend's provider-specific mapping. After PR1 the orchestrator
+holds a ``Backend`` and routes target exceptions through ``backend.map_error``,
+so an ORQ HTTP error surfaces as ``orq.http.<status>`` instead of the generic
+``target_error``.
+
+The first test pins the unit-level mapping; the second pins the *wiring* — it
+drives a real ``MultiTurnOrchestrator.run_attack`` with a backend and asserts
+the mapped code reaches ``OrchestratorResult.error_code``. The second test is
+the one that actually guards the regression: it fails if the orchestrator ever
+goes back to a hardcoded default mapper.
 """
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from evaluatorq.redteam.backends.base import Backend
 
 
 class _OrqHTTPError(Exception):
@@ -17,12 +28,116 @@ class _OrqHTTPError(Exception):
         self.status_code = status_code
 
 
-@pytest.mark.asyncio
-async def test_orq_http_exception_maps_to_orq_http_status_code():
-    """End-to-end: ORQ rate-limit exception → ``orq.http.429``, not ``target_error``."""
+_PATCH_REDTEAM_SPAN = "evaluatorq.redteam.adaptive.orchestrator.with_redteam_span"
+_PATCH_LLM_SPAN = "evaluatorq.redteam.adaptive.orchestrator.with_llm_span"
+_PATCH_RECORD_LLM = "evaluatorq.redteam.adaptive.orchestrator.record_llm_response"
+
+
+@asynccontextmanager
+async def _noop_span_ctx(*args, **kwargs):
+    yield None
+
+
+def _make_completion(content: str):
+    choice = MagicMock()
+    choice.message.content = content
+    choice.finish_reason = "stop"
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage = None
+    response.model = "test-model"
+    response.id = "resp-123"
+    return response
+
+
+def _make_context():
+    from evaluatorq.redteam.contracts import AgentContext
+
+    return AgentContext(key="victim-agent", display_name="Victim", description="d")
+
+
+def _make_strategy():
+    from evaluatorq.redteam.contracts import (
+        AttackStrategy,
+        AttackTechnique,
+        DeliveryMethod,
+        TurnType,
+    )
+
+    return AttackStrategy(
+        category="ASI01",
+        name="test-strategy",
+        description="Test strategy description",
+        attack_technique=AttackTechnique.INDIRECT_INJECTION,
+        delivery_methods=[DeliveryMethod.CRESCENDO],
+        turn_type=TurnType.MULTI,
+        objective_template="Convince {agent_name} to follow instructions",
+    )
+
+
+def test_orq_http_exception_maps_to_orq_http_status_code():
+    """Unit: ORQ rate-limit exception → ``orq.http.429``, not ``target_error``."""
     from evaluatorq.redteam.backends.orq import ORQBackend
 
     backend = ORQBackend(orq_client=MagicMock(), timeout_ms=1000)
     code, msg = backend.map_error(_OrqHTTPError(429))
     assert code == "orq.http.429", f"expected orq.http.429, got {code!r}"
     assert "orq returned 429" in msg
+
+
+@pytest.mark.asyncio
+@patch(_PATCH_RECORD_LLM)
+@patch(_PATCH_LLM_SPAN, side_effect=_noop_span_ctx)
+@patch(_PATCH_REDTEAM_SPAN, side_effect=_noop_span_ctx)
+async def test_orchestrator_uses_backend_map_error_for_error_code(_rs, _ls, _rl):
+    """Wiring: orchestrator routes target exceptions through ``backend.map_error``.
+
+    This is the actual regression guard. If the orchestrator reverts to a
+    hardcoded ``DefaultErrorMapper``, ``error_code`` becomes ``target_error``
+    and this fails.
+    """
+    from evaluatorq.redteam.adaptive.orchestrator import MultiTurnOrchestrator
+
+    class _MapErrorBackend(Backend):
+        def __init__(self):
+            super().__init__(name="orq")
+
+        def create_target(self, agent_key):
+            raise NotImplementedError("not used in this test")
+
+        async def cleanup_memory(self, ctx, entity_ids):
+            return None
+
+        def map_error(self, exc):
+            return ("orq.http.429", f"{type(exc).__name__}: {exc}")
+
+    mock_llm = MagicMock()
+    mock_llm.chat = MagicMock()
+    mock_llm.chat.completions = MagicMock()
+    mock_llm.chat.completions.create = AsyncMock(
+        side_effect=[_make_completion("Attack turn 1"), _make_completion("Attack turn 2")]
+    )
+
+    orchestrator = MultiTurnOrchestrator(
+        llm_client=mock_llm,
+        model="test-model",
+        backend=_MapErrorBackend(),
+    )
+
+    target = MagicMock()
+    target.send_prompt = AsyncMock(side_effect=[_OrqHTTPError(429), _OrqHTTPError(429)])
+    target.new = MagicMock()
+
+    result = await orchestrator.run_attack(
+        target=target,
+        strategy=_make_strategy(),
+        objective="Test",
+        agent_context=_make_context(),
+        max_turns=5,
+    )
+
+    assert result.error_code == "orq.http.429", (
+        f"expected backend-mapped orq.http.429, got {result.error_code!r} — "
+        "orchestrator may be using a hardcoded default mapper"
+    )
+    assert result.error_type == "target_error"

--- a/packages/evaluatorq-py/tests/redteam/test_token_usage_pipeline.py
+++ b/packages/evaluatorq-py/tests/redteam/test_token_usage_pipeline.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from evaluatorq.redteam.adaptive.orchestrator import MultiTurnOrchestrator
+from evaluatorq.redteam.backends.base import AgentTarget
 from evaluatorq.redteam.contracts import (
     AgentContext,
     AgentInfo,
@@ -72,12 +73,11 @@ def _make_chat_completion(content: str = "next attack prompt") -> MagicMock:
     return response
 
 
-class _FakeTarget:
+class _FakeTarget(AgentTarget):
     """Minimal :class:`AgentTarget` returning fixed token usage each call."""
 
-    memory_entity_id: str | None = None
-
     def __init__(self, usage: TokenUsage | None) -> None:
+        super().__init__()
         self._usage = usage
         self.call_count = 0
 
@@ -255,10 +255,9 @@ class TestPipelineTokenUsageAggregation:
         max_turns = 4
         create_mock = AsyncMock(side_effect=[_make_chat_completion() for _ in range(max_turns)])
 
-        class _FailingTarget:
-            memory_entity_id: str | None = None
-
+        class _FailingTarget(AgentTarget):
             def __init__(self) -> None:
+                super().__init__()
                 self.attempts = 0
 
             async def send_prompt(self, prompt: str) -> AgentResponse:


### PR DESCRIPTION
## Summary

First of three stacked PRs for RES-808. Collapses 12 abstract types in `redteam/backends/base.py` to 2 ABCs: `Backend` + `AgentTarget`.

- New `Backend` ABC owns `create_target` / `cleanup_memory` / `map_error` + default cached `get_agent_context(agent_key)` probe.
- `AgentTarget` promoted from `Protocol` to ABC inside `base.py` (relocation to `evaluatorq.contracts` is PR2).
- New `BareTargetBackend` adapter replaces `DirectTargetFactory` + duck-typed BYO plumbing.
- Concrete `ORQBackend` + `OpenAIBackend` consolidate the old 4-collaborator setup.
- Concrete targets (`ORQAgentTarget`, `OpenAIModelTarget`, `OrqResponsesTarget`, 4 integrations) now explicitly inherit `AgentTarget` and call `super().__init__(memory_entity_id=...)`.
- `ORQAgentTarget.map_error` / `cleanup_memory` and `OpenAIModelTarget.map_error` kept as thin delegates to module-level helpers (`_orq_map_error`, `_orq_cleanup_memory`, `_openai_map_error`) so the BYO path via `BareTargetBackend(target)` retains provider-specific codes.
- Fixes pre-existing bug at `runner.py:833`: `DefaultErrorMapper()` previously masked the ORQ-specific mapper — ORQ HTTP exceptions now produce `orq.http.<status>` codes instead of generic `target_error`. Regression test added.
- Deletes 12 dead types: 7 `Supports*` Protocols, 4 collaborator Protocols, `BackendBundle`, `DefaultErrorMapper`, `DirectTargetFactory`, `NoopMemoryCleanup`, `is_agent_target`, 4 ORQ + 3 OpenAI shim classes.
- `runner.py`: `PreparedTarget.resolved_memory_cleanup` field renamed to `backend: Backend`. `is_agent_target()` duck-type checks replaced with `isinstance(target, AgentTarget)`.

12 commits, ~1300 unit tests green (1269 passed, 3 integration deselected, 0 failed).

## Spec

`docs/superpowers/specs/2026-05-26-res-808-collapse-relocate-unify-design.md` (open in stacked PR #140 docs branch)

## Test plan

- [ ] `uv run pytest -m 'not integration'` green (verified: 1269 passed)
- [ ] `uv run basedpyright src/evaluatorq/redteam` clean (verified)
- [ ] Manual: ORQ rate-limit exception maps to `orq.rate_limit`, not `target_error` — see new `tests/redteam/test_runner_error_mapping_regression.py`

## Stacked PR sequence

- PR1 (this) → collapse abstractions
- PR2 (next) → relocate `AgentTarget` to `evaluatorq.contracts`
- PR3 → unify `respond(messages)` across redteam + sim

🤖 Generated with [Claude Code](https://claude.com/claude-code)