### PR TITLE
RES-808 (PR2/3): relocate AgentTarget ABC to evaluatorq.contracts

### DIFF
--- a/packages/evaluatorq-py/CHANGELOG.md
+++ b/packages/evaluatorq-py/CHANGELOG.md
@@ -34,7 +34,7 @@ red_team(
 )
 ```
 
-- **`AgentTarget` relocated**: moved from `evaluatorq.redteam.backends.base` to `evaluatorq.contracts`. Importing it from the old path now raises `ImportError`. The `Backend` ABC stays in `evaluatorq.redteam.backends.base`. `AgentContext`, `ToolInfo`, `MemoryStoreInfo`, and `KnowledgeBaseInfo` also moved to `evaluatorq.contracts` (re-exported from `evaluatorq.redteam.contracts` for back-compat).
+- **`AgentTarget` relocated**: moved from `evaluatorq.redteam.backends.base` to `evaluatorq.contracts`. Importing it from the old path now raises `ImportError`. The `Backend` ABC stays in `evaluatorq.redteam.backends.base`. `AgentContext`, `ToolInfo`, `MemoryStoreInfo`, and `KnowledgeBaseInfo` also moved to `evaluatorq.contracts`, but — unlike `AgentTarget` — their old import path `evaluatorq.redteam.contracts` still works (re-exported, same class objects, `isinstance` unaffected). Only `AgentTarget`'s old path is a hard break.
 
 **Migration:**
 

--- a/packages/evaluatorq-py/CHANGELOG.md
+++ b/packages/evaluatorq-py/CHANGELOG.md
@@ -34,6 +34,18 @@ red_team(
 )
 ```
 
+- **`AgentTarget` relocated**: moved from `evaluatorq.redteam.backends.base` to `evaluatorq.contracts`. Importing it from the old path now raises `ImportError`. The `Backend` ABC stays in `evaluatorq.redteam.backends.base`. `AgentContext`, `ToolInfo`, `MemoryStoreInfo`, and `KnowledgeBaseInfo` also moved to `evaluatorq.contracts` (re-exported from `evaluatorq.redteam.contracts` for back-compat).
+
+**Migration:**
+
+```python
+# Before
+from evaluatorq.redteam.backends.base import AgentTarget
+
+# After
+from evaluatorq.contracts import AgentTarget
+```
+
 ### New Features
 
 - **`LLMCallConfig`** — per-role LLM configuration with `model`, `temperature`, `max_tokens`, `timeout_ms`, `extra_kwargs`, and `client` fields

--- a/packages/evaluatorq-py/CLAUDE.md
+++ b/packages/evaluatorq-py/CLAUDE.md
@@ -108,7 +108,7 @@ src/evaluatorq/
 - New vulnerabilities: see `docs/custom-evaluators-and-frameworks.md`
 - New evaluators: create a function returning `LlmEvaluatorEntity`, register in `VULNERABILITY_EVALUATOR_REGISTRY`
 - New strategies: create `AttackStrategy` objects, register in `strategy_registry.py`
-- New backends: implement the `AgentTarget` protocol from `backends/base.py`
+- New backends: implement the `AgentTarget` ABC from `evaluatorq.contracts` (subclass `Backend` from `backends/base.py` for full target lifecycle)
 
 ### Testing Conventions
 

--- a/packages/evaluatorq-py/src/evaluatorq/contracts.py
+++ b/packages/evaluatorq-py/src/evaluatorq/contracts.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeAlias, Union
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -18,7 +19,7 @@ else:
 if TYPE_CHECKING:
     from openai import AsyncOpenAI
 
-    _ClientT: TypeAlias = "AsyncOpenAI | None"
+    _ClientT: TypeAlias = AsyncOpenAI | None
 else:
     _ClientT = Any
 
@@ -87,7 +88,7 @@ class ReasoningOutputItem(BaseModel):
 
 
 OutputMessage = Annotated[
-    Union[TextOutputItem, ToolCallOutputItem, ReasoningOutputItem],
+    TextOutputItem | ToolCallOutputItem | ReasoningOutputItem,
     Field(discriminator="type"),
 ]
 
@@ -160,7 +161,7 @@ class TokenUsage(BaseModel):
     calls: int = Field(default=0, ge=0, description="Number of LLM API calls")
 
     @classmethod
-    def from_completion(cls, response: Any) -> "TokenUsage | None":
+    def from_completion(cls, response: Any) -> TokenUsage | None:
         """Extract token usage from an OpenAI-compatible completion response."""
         usage = getattr(response, "usage", None)
         if usage is None:
@@ -175,7 +176,7 @@ class TokenUsage(BaseModel):
         total = int(raw_total) if raw_total is not None and int(raw_total) > 0 else prompt + completion
         return cls(prompt_tokens=prompt, completion_tokens=completion, total_tokens=total, calls=1)
 
-    def __add__(self, other: "TokenUsage | None") -> "TokenUsage":
+    def __add__(self, other: TokenUsage | None) -> TokenUsage:
         if other is None:
             return self.model_copy()
         return TokenUsage(
@@ -185,7 +186,7 @@ class TokenUsage(BaseModel):
             calls=self.calls + other.calls,
         )
 
-    def __radd__(self, other: object) -> "TokenUsage":
+    def __radd__(self, other: object) -> TokenUsage:
         """Support sum() which starts with integer 0, and reflected addition."""
         if isinstance(other, int) and other == 0:
             return self.model_copy()
@@ -228,7 +229,7 @@ class AgentResponse(BaseModel):
             *,
             output: list[OutputMessage] | None = None,
             text: str | None = None,
-            usage: "TokenUsage | None" = None,
+            usage: TokenUsage | None = None,
             model: str | None = None,
             response_id: str | None = None,
             finish_reason: str | None = None,
@@ -260,13 +261,129 @@ class AgentResponse(BaseModel):
         return [item for item in self.output if isinstance(item, ToolCallOutputItem)]
 
 
+# ---------------------------------------------------------------------------
+# Agent context models
+# ---------------------------------------------------------------------------
+
+
+class ToolInfo(BaseModel):
+    """Information about an agent's tool."""
+
+    name: str = Field(description='Tool name/identifier')
+    description: str | None = Field(default=None, description='Tool description')
+    parameters: dict[str, Any] | None = Field(default=None, description='Tool parameter schema')
+
+
+class MemoryStoreInfo(BaseModel):
+    """Information about an agent's memory store."""
+
+    id: str = Field(description='Memory store ID')
+    key: str | None = Field(default=None, description='Memory store key/slug')
+    description: str | None = Field(default=None, description='Memory store description')
+
+
+class KnowledgeBaseInfo(BaseModel):
+    """Information about an agent's knowledge base."""
+
+    id: str = Field(description='Knowledge base ID')
+    key: str | None = Field(default=None, description='Knowledge base key/slug')
+    name: str | None = Field(default=None, description='Knowledge base name')
+    description: str | None = Field(default=None, description='Knowledge base description')
+
+
+class AgentContext(BaseModel):
+    """Extended agent information for context-aware attacks.
+
+    Describes the target agent's configuration and capabilities.
+    """
+
+    key: str = Field(description='Agent identifier key')
+    display_name: str | None = Field(default=None, description='Agent display name')
+    description: str | None = Field(default=None, description='Agent description')
+    system_prompt: str | None = Field(default=None, description='Agent system prompt (used by deployments)')
+    instructions: str | None = Field(default=None, description='Agent behavioral instructions')
+    tools: list[ToolInfo] = Field(default_factory=list, description='Available tools')
+    memory_stores: list[MemoryStoreInfo] = Field(default_factory=list, description='Memory stores')
+    knowledge_bases: list[KnowledgeBaseInfo] = Field(default_factory=list, description='Knowledge bases')
+    model: str | None = Field(default=None, description='Primary model')
+
+    @property
+    def has_tools(self) -> bool:
+        """Check if agent has any tools configured."""
+        return len(self.tools) > 0
+
+    @property
+    def has_memory(self) -> bool:
+        """Check if agent has any memory stores configured."""
+        return len(self.memory_stores) > 0
+
+    @property
+    def has_knowledge(self) -> bool:
+        """Check if agent has any knowledge bases configured."""
+        return len(self.knowledge_bases) > 0
+
+    def get_tool_names(self) -> list[str]:
+        """Get list of tool names."""
+        return [t.name for t in self.tools]
+
+
+# ---------------------------------------------------------------------------
+# AgentTarget ABC
+# ---------------------------------------------------------------------------
+
+
+class AgentTarget(ABC):
+    """Abstract base class for agent targets that can receive prompts.
+
+    Subclasses must implement ``send_prompt`` and ``new``. Targets that back a
+    server-side memory store override ``get_agent_context`` (self-describing),
+    ``cleanup_memory`` (release created entities), and ``map_error``
+    (provider-specific error codes); stateless targets inherit the safe
+    defaults. ``memory_entity_id`` is an instance attribute (set in
+    ``__init__``) so subclasses can mutate it without shadowing a class default.
+    """
+
+    def __init__(self, memory_entity_id: str | None = None) -> None:
+        self.memory_entity_id = memory_entity_id
+
+    @abstractmethod
+    async def send_prompt(self, prompt: str) -> AgentResponse:
+        """Send a prompt; return the response."""
+        ...
+
+    @abstractmethod
+    def new(self) -> AgentTarget:
+        """Return a fresh independent instance for a new attack."""
+        ...
+
+    async def get_agent_context(self) -> AgentContext:
+        """Default: minimal context. Override for platform-backed targets."""
+        return AgentContext(key=getattr(self, "agent_key", "unknown"))
+
+    async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
+        """Release any memory entities this target created. Default: no-op (stateless)."""
+        return
+
+    def map_error(self, exc: Exception) -> tuple[str, str] | None:
+        """Map an exception to a provider-specific ``(code, message)``.
+
+        Return ``None`` to defer to the backend's default mapping. Stateless
+        targets inherit this no-opinion default.
+        """
+        return None
+
+
 __all__ = [
     "DEFAULT_PIPELINE_MODEL",
     "DEFAULT_TARGET_MAX_TOKENS",
     "DEFAULT_TARGET_TIMEOUT_MS",
+    "AgentContext",
     "AgentResponse",
+    "AgentTarget",
     "FunctionCall",
+    "KnowledgeBaseInfo",
     "LLMCallConfig",
+    "MemoryStoreInfo",
     "Message",
     "OutputMessage",
     "ReasoningOutputItem",
@@ -274,4 +391,5 @@ __all__ = [
     "TextOutputItem",
     "TokenUsage",
     "ToolCallOutputItem",
+    "ToolInfo",
 ]

--- a/packages/evaluatorq-py/src/evaluatorq/integrations/callable_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/callable_integration/target.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from loguru import logger
 
-from evaluatorq.redteam.backends.base import AgentTarget
+from evaluatorq.contracts import AgentTarget
 from evaluatorq.redteam.contracts import AgentContext, AgentResponse, OutputMessage, TextOutputItem, TokenUsage
 
 # Accepted callable signatures — may return str (backward-compat) or AgentResponse

--- a/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/langgraph_integration/target.py
@@ -13,7 +13,7 @@ from langchain_core.messages import AIMessage
 from langchain_core.outputs import LLMResult
 from langchain_core.runnables import RunnableConfig
 
-from evaluatorq.redteam.backends.base import AgentTarget
+from evaluatorq.contracts import AgentTarget
 from evaluatorq.redteam.contracts import (
     AgentContext,
     AgentResponse,

--- a/packages/evaluatorq-py/src/evaluatorq/integrations/openai_agents_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/openai_agents_integration/target.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from agents import Agent, Runner
 
-from evaluatorq.redteam.backends.base import AgentTarget
+from evaluatorq.contracts import AgentTarget
 from evaluatorq.redteam.contracts import (
     AgentContext,
     AgentResponse,

--- a/packages/evaluatorq-py/src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/integrations/vercel_ai_sdk_integration/target.py
@@ -19,7 +19,7 @@ from urllib.parse import urlparse
 
 import httpx
 
-from evaluatorq.redteam.backends.base import AgentTarget
+from evaluatorq.contracts import AgentTarget
 from evaluatorq.redteam.contracts import AgentContext, AgentResponse, OutputMessage, TextOutputItem, TokenUsage
 
 

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/__init__.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/__init__.py
@@ -31,14 +31,17 @@ def _check_redteam_deps() -> None:  # noqa: RUF067
 _check_redteam_deps()  # noqa: RUF067
 
 
+from evaluatorq.contracts import AgentTarget
+from evaluatorq.redteam.adaptive.orchestrator import (
+    ADVERSARIAL_ANALYSIS_PROMPT,
+    ADVERSARIAL_INITIAL_USER_PROMPT,
+    ADVERSARIAL_SYSTEM_PROMPT,
+)
 from evaluatorq.redteam.adaptive.strategy_registry import (
     get_category_info,
 )
 from evaluatorq.redteam.adaptive.strategy_registry import (
     list_available_categories as list_categories,
-)
-from evaluatorq.redteam.backends.base import (
-    AgentTarget,
 )
 from evaluatorq.redteam.backends.openai import OpenAIModelTarget
 from evaluatorq.redteam.backends.registry import register_backend
@@ -47,6 +50,7 @@ from evaluatorq.redteam.contracts import (
     AgentCapability,
     AgentContext,
     AgentInfo,
+    AgentResponse,
     AttackEvaluationResult,
     AttackInfo,
     AttackSource,
@@ -64,11 +68,6 @@ from evaluatorq.redteam.contracts import (
     Framework,
     FrameworkSummary,
     FunctionCall,
-    AgentResponse,
-    OutputMessage,
-    ReasoningOutputItem,
-    TextOutputItem,
-    ToolCallOutputItem,
     JobOutputPayload,
     KnowledgeBaseInfo,
     LLMCallConfig,
@@ -76,8 +75,10 @@ from evaluatorq.redteam.contracts import (
     MemoryStoreInfo,
     Message,
     OrchestratorResult,
+    OutputMessage,
     Pipeline,
     PipelineStage,
+    ReasoningOutputItem,
     RedTeamInput,
     RedTeamReport,
     RedTeamResult,
@@ -85,10 +86,12 @@ from evaluatorq.redteam.contracts import (
     ReportSummary,
     Severity,
     SeveritySummary,
+    StrategyToolCall,
     TargetConfig,
     TechniqueSummary,
+    TextOutputItem,
     TokenUsage,
-    StrategyToolCall,
+    ToolCallOutputItem,
     ToolInfo,
     TurnType,
     TurnTypeSummary,
@@ -99,11 +102,6 @@ from evaluatorq.redteam.contracts import (
     VulnerabilitySummary,
     normalize_category,
     normalize_framework,
-)
-from evaluatorq.redteam.adaptive.orchestrator import (
-    ADVERSARIAL_ANALYSIS_PROMPT,
-    ADVERSARIAL_INITIAL_USER_PROMPT,
-    ADVERSARIAL_SYSTEM_PROMPT,
 )
 from evaluatorq.redteam.exceptions import BackendError, CancelledError, CredentialError, RedTeamError
 from evaluatorq.redteam.hooks import (

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/orchestrator.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/orchestrator.py
@@ -19,8 +19,8 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TaskID, TextColumn
 from typing_extensions import Self
 
 from evaluatorq.common.sanitize import xml_escape
-from evaluatorq.contracts import AgentResponse, TextOutputItem
-from evaluatorq.redteam.backends.base import AgentTarget, Backend, _coerce_to_agent_response
+from evaluatorq.contracts import AgentResponse, AgentTarget, TextOutputItem
+from evaluatorq.redteam.backends.base import Backend, _coerce_to_agent_response
 from evaluatorq.redteam.contracts import (
     DEFAULT_PIPELINE_MODEL,
     PIPELINE_CONFIG,

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
@@ -12,52 +12,10 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
-from evaluatorq.redteam.contracts import AgentResponse
+from evaluatorq.contracts import AgentResponse
 
 if TYPE_CHECKING:
-    from evaluatorq.redteam.contracts import AgentContext
-
-
-class AgentTarget(ABC):
-    """Abstract base class for agent targets that can receive prompts.
-
-    Subclasses must implement ``send_prompt`` and ``new``. Targets that back a
-    server-side memory store override ``get_agent_context`` (self-describing),
-    ``cleanup_memory`` (release created entities), and ``map_error``
-    (provider-specific error codes); stateless targets inherit the safe
-    defaults. ``memory_entity_id`` is an instance attribute (set in
-    ``__init__``) so subclasses can mutate it without shadowing a class default.
-    """
-
-    def __init__(self, memory_entity_id: str | None = None) -> None:
-        self.memory_entity_id = memory_entity_id
-
-    @abstractmethod
-    async def send_prompt(self, prompt: str) -> AgentResponse:
-        """Send a prompt; return the response."""
-        ...
-
-    @abstractmethod
-    def new(self) -> AgentTarget:
-        """Return a fresh independent instance for a new attack."""
-        ...
-
-    async def get_agent_context(self) -> AgentContext:
-        """Default: minimal context. Override for platform-backed targets."""
-        from evaluatorq.redteam.contracts import AgentContext
-        return AgentContext(key=getattr(self, "agent_key", "unknown"))
-
-    async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
-        """Release any memory entities this target created. Default: no-op (stateless)."""
-        return
-
-    def map_error(self, exc: Exception) -> tuple[str, str] | None:
-        """Map an exception to a provider-specific ``(code, message)``.
-
-        Return ``None`` to defer to the backend's default mapping. Stateless
-        targets inherit this no-opinion default.
-        """
-        return None
+    from evaluatorq.contracts import AgentContext, AgentTarget
 
 
 def _coerce_to_agent_response(raw: Any) -> AgentResponse:
@@ -148,6 +106,8 @@ class BareTargetBackend(Backend):
         return self._target.new()
 
     async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
+        from evaluatorq.contracts import AgentTarget
+
         if entity_ids and type(self._target).cleanup_memory is AgentTarget.cleanup_memory:
             # Target created memory entities but inherits the no-op cleanup default;
             # adversarial data may persist. Surface loudly (matches ORQ path).

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
@@ -108,6 +108,8 @@ class BareTargetBackend(Backend):
         return self._target.new()
 
     async def cleanup_memory(self, ctx: AgentContext, entity_ids: list[str]) -> None:
+        # Local import: module-level would re-expose AgentTarget as backends.base.AgentTarget,
+        # violating the clean-break invariant pinned by test_agent_target_not_re_exported_from_base.
         from evaluatorq.contracts import AgentTarget
 
         if entity_ids and type(self._target).cleanup_memory is AgentTarget.cleanup_memory:

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/base.py
@@ -1,8 +1,10 @@
-"""Backend abstract base classes for dynamic red teaming agent targets.
+"""Backend abstract base class for dynamic red teaming agent targets.
 
-Defines the ABCs (``AgentTarget``, ``Backend``) that any agent backend must
-subclass. The ORQ implementation lives in ``backends.orq``; other backends
-(HTTP, LangChain, custom callables) subclass these independently.
+Defines the ``Backend`` ABC plus the ``BareTargetBackend`` adapter. The
+``AgentTarget`` ABC that backends construct lives in ``evaluatorq.contracts``
+(relocated in RES-808 PR2). The ORQ implementation lives in ``backends.orq``;
+other backends (HTTP, LangChain, custom callables) subclass ``Backend``
+independently.
 """
 
 from __future__ import annotations

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/openai.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/openai.py
@@ -7,8 +7,9 @@ from typing import TYPE_CHECKING, Any, cast
 
 from loguru import logger
 
+from evaluatorq.contracts import AgentTarget
 from evaluatorq.redteam.backends._errors import extract_provider_error_code, extract_status_code
-from evaluatorq.redteam.backends.base import AgentTarget, Backend
+from evaluatorq.redteam.backends.base import Backend
 from evaluatorq.redteam.contracts import (
     DEFAULT_TARGET_MAX_TOKENS,
     DEFAULT_TARGET_TIMEOUT_MS,

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/orq.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/orq.py
@@ -43,8 +43,9 @@ def _get_orq_server_url() -> str:
     return url.rstrip('/').removesuffix('/v2/router')
 
 
+from evaluatorq.contracts import AgentTarget
 from evaluatorq.redteam.backends._errors import extract_provider_error_code, extract_status_code
-from evaluatorq.redteam.backends.base import AgentTarget, Backend
+from evaluatorq.redteam.backends.base import Backend
 from evaluatorq.redteam.contracts import (
     PIPELINE_CONFIG,
     AgentContext,

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/contracts.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/contracts.py
@@ -11,7 +11,7 @@ Semantic convention:
 
 import os
 from datetime import datetime
-from typing import Any, Literal, TypedDict
+from typing import Any, TypedDict
 
 from pydantic import (
     BaseModel,
@@ -342,7 +342,7 @@ def infer_framework(category: str) -> str:
 # existing ``from evaluatorq.redteam.contracts import ...`` call sites continue
 # to work unchanged. (RES-596 consolidated the duplicated definitions.)
 
-from evaluatorq.contracts import (  # noqa: F401, E402
+from evaluatorq.contracts import (  # noqa: F401
     AgentResponse,
     FunctionCall,
     Message,
@@ -352,7 +352,6 @@ from evaluatorq.contracts import (  # noqa: F401, E402
     TextOutputItem,
     ToolCallOutputItem,
 )
-
 
 # ---------------------------------------------------------------------------
 # Input models
@@ -455,33 +454,16 @@ class StaticDataset(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Agent context models
+# Agent context models — relocated to evaluatorq.contracts (RES-808 PR2).
+# Re-exported here so existing ``evaluatorq.redteam.contracts`` imports keep working.
 # ---------------------------------------------------------------------------
 
-
-class ToolInfo(BaseModel):
-    """Information about an agent's tool."""
-
-    name: str = Field(description='Tool name/identifier')
-    description: str | None = Field(default=None, description='Tool description')
-    parameters: dict[str, Any] | None = Field(default=None, description='Tool parameter schema')
-
-
-class MemoryStoreInfo(BaseModel):
-    """Information about an agent's memory store."""
-
-    id: str = Field(description='Memory store ID')
-    key: str | None = Field(default=None, description='Memory store key/slug')
-    description: str | None = Field(default=None, description='Memory store description')
-
-
-class KnowledgeBaseInfo(BaseModel):
-    """Information about an agent's knowledge base."""
-
-    id: str = Field(description='Knowledge base ID')
-    key: str | None = Field(default=None, description='Knowledge base key/slug')
-    name: str | None = Field(default=None, description='Knowledge base name')
-    description: str | None = Field(default=None, description='Knowledge base description')
+from evaluatorq.contracts import (  # noqa: F401
+    AgentContext,
+    KnowledgeBaseInfo,
+    MemoryStoreInfo,
+    ToolInfo,
+)
 
 
 class TargetConfig(BaseModel):
@@ -494,42 +476,6 @@ class TargetConfig(BaseModel):
         default=None,
         description="System prompt for the target model/agent",
     )
-
-
-class AgentContext(BaseModel):
-    """Extended agent information for context-aware attacks.
-
-    Describes the target agent's configuration and capabilities.
-    """
-
-    key: str = Field(description='Agent identifier key')
-    display_name: str | None = Field(default=None, description='Agent display name')
-    description: str | None = Field(default=None, description='Agent description')
-    system_prompt: str | None = Field(default=None, description='Agent system prompt (used by deployments)')
-    instructions: str | None = Field(default=None, description='Agent behavioral instructions')
-    tools: list[ToolInfo] = Field(default_factory=list, description='Available tools')
-    memory_stores: list[MemoryStoreInfo] = Field(default_factory=list, description='Memory stores')
-    knowledge_bases: list[KnowledgeBaseInfo] = Field(default_factory=list, description='Knowledge bases')
-    model: str | None = Field(default=None, description='Primary model')
-
-    @property
-    def has_tools(self) -> bool:
-        """Check if agent has any tools configured."""
-        return len(self.tools) > 0
-
-    @property
-    def has_memory(self) -> bool:
-        """Check if agent has any memory stores configured."""
-        return len(self.memory_stores) > 0
-
-    @property
-    def has_knowledge(self) -> bool:
-        """Check if agent has any knowledge bases configured."""
-        return len(self.knowledge_bases) > 0
-
-    def get_tool_names(self) -> list[str]:
-        """Get list of tool names."""
-        return [t.name for t in self.tools]
 
 
 # ---------------------------------------------------------------------------
@@ -705,8 +651,7 @@ class AttackStrategy(BaseModel):
 # Token usage — re-exported from evaluatorq.contracts (RES-596)
 # ---------------------------------------------------------------------------
 
-from evaluatorq.contracts import TokenUsage  # noqa: F401, E402
-
+from evaluatorq.contracts import TokenUsage
 
 SendResult = AgentResponse  # deprecated alias; use AgentResponse directly
 

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, cast
 from loguru import logger
 
 from evaluatorq import DataPoint, EvaluationResult, job
+from evaluatorq.contracts import AgentTarget
 from evaluatorq.redteam.adaptive.orchestrator import ProgressDisplay, _get_active_progress
 from evaluatorq.redteam.adaptive.pipeline import (
     cleanup_memory_entities,
@@ -34,7 +35,6 @@ from evaluatorq.redteam.adaptive.strategy_registry import (
     select_applicable_strategies_for_vulnerability,
 )
 from evaluatorq.redteam.backends.base import (
-    AgentTarget,
     Backend,
     BareTargetBackend,
     _coerce_to_agent_response,

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/target.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/target.py
@@ -9,8 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
-from evaluatorq.contracts import AgentResponse, LLMCallConfig
-from evaluatorq.redteam.backends.base import AgentTarget
+from evaluatorq.contracts import AgentResponse, AgentTarget, LLMCallConfig
 from evaluatorq.simulation._client import build_simulation_client, extract_responses_output
 from evaluatorq.simulation.types import ChatMessage, TokenUsage
 from evaluatorq.simulation.utils.retry import with_retry
@@ -131,7 +130,7 @@ class OrqResponsesTarget(AgentTarget):
             await self._client.close()
             self._client_owned = False
 
-    async def __aenter__(self) -> "OrqResponsesTarget":
+    async def __aenter__(self) -> OrqResponsesTarget:
         return self
 
     async def __aexit__(self, *_exc_info: object) -> None:

--- a/packages/evaluatorq-py/tests/redteam/e2e/conftest.py
+++ b/packages/evaluatorq-py/tests/redteam/e2e/conftest.py
@@ -14,7 +14,8 @@ from typing import Any
 
 import pytest
 
-from evaluatorq.redteam.backends.base import AgentTarget, Backend
+from evaluatorq.contracts import AgentTarget
+from evaluatorq.redteam.backends.base import Backend
 from evaluatorq.redteam.contracts import (
     AgentContext,
     AgentResponse,

--- a/packages/evaluatorq-py/tests/redteam/test_bare_target_backend.py
+++ b/packages/evaluatorq-py/tests/redteam/test_bare_target_backend.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 import pytest
 
-from evaluatorq.redteam.backends.base import AgentTarget, BareTargetBackend
+from evaluatorq.contracts import AgentTarget
+from evaluatorq.redteam.backends.base import BareTargetBackend
 from evaluatorq.redteam.contracts import AgentContext, AgentResponse
 
 
@@ -14,7 +15,7 @@ class _StubTarget(AgentTarget):
     async def send_prompt(self, prompt: str) -> AgentResponse:
         return AgentResponse(text="ok")
 
-    def new(self) -> "_StubTarget":
+    def new(self) -> _StubTarget:
         return _StubTarget()
 
 

--- a/packages/evaluatorq-py/tests/redteam/test_contracts_relocation.py
+++ b/packages/evaluatorq-py/tests/redteam/test_contracts_relocation.py
@@ -1,0 +1,55 @@
+"""Guards for the RES-808 PR2 relocation invariants.
+
+Two things must stay true after `AgentTarget` and the agent-context models
+moved into `evaluatorq.contracts`:
+
+1. The context models re-exported from `evaluatorq.redteam.contracts` are the
+   *same class objects* as the canonical ones in `evaluatorq.contracts`. If a
+   future edit redefines a model locally in the redteam module instead of
+   re-importing, the two become distinct classes and `isinstance` silently
+   breaks across the path boundary — while the rest of the suite stays green
+   (each module imports one path consistently). These tests pin the identity.
+
+2. `AgentTarget` is a deliberate clean break: it is NOT re-exported from
+   `evaluatorq.redteam.backends.base`. Re-adding that export would reintroduce
+   the circular-import direction PR2 removed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import evaluatorq.contracts as canonical
+import evaluatorq.redteam.contracts as redteam_contracts
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["AgentContext", "ToolInfo", "MemoryStoreInfo", "KnowledgeBaseInfo"],
+)
+def test_context_models_are_identical_across_paths(name: str) -> None:
+    """The redteam.contracts re-export must be the same object as the canonical class."""
+    assert getattr(redteam_contracts, name) is getattr(canonical, name), (
+        f"{name} diverged between evaluatorq.contracts and evaluatorq.redteam.contracts; "
+        "the redteam module must re-import, not redefine, the relocated model"
+    )
+
+
+def test_agent_target_identical_via_redteam_package() -> None:
+    """`evaluatorq.redteam.AgentTarget` must be the canonical contracts class."""
+    import evaluatorq.redteam as redteam_pkg
+
+    assert redteam_pkg.AgentTarget is canonical.AgentTarget
+
+
+def test_agent_target_not_re_exported_from_base() -> None:
+    """Clean break: AgentTarget must not be importable from redteam.backends.base."""
+    import evaluatorq.redteam.backends.base as base_mod
+
+    assert not hasattr(base_mod, "AgentTarget"), (
+        "AgentTarget must NOT be re-exported from redteam.backends.base "
+        "(RES-808 PR2 clean break); import it from evaluatorq.contracts"
+    )
+
+    with pytest.raises(ImportError):
+        from evaluatorq.redteam.backends.base import AgentTarget  # noqa: F401

--- a/packages/evaluatorq-py/tests/redteam/test_orq_responses_target_as_agent_target.py
+++ b/packages/evaluatorq-py/tests/redteam/test_orq_responses_target_as_agent_target.py
@@ -15,11 +15,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from evaluatorq.contracts import AgentResponse, LLMCallConfig
-from evaluatorq.redteam.backends.base import AgentTarget
+from evaluatorq.contracts import AgentResponse, AgentTarget, LLMCallConfig
 from evaluatorq.simulation.target import OrqResponsesTarget
 from evaluatorq.simulation.types import ChatMessage
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/packages/evaluatorq-py/tests/redteam/test_runner.py
+++ b/packages/evaluatorq-py/tests/redteam/test_runner.py
@@ -6,8 +6,8 @@ from datetime import datetime, timezone
 
 import pytest
 
+from evaluatorq.contracts import AgentTarget
 from evaluatorq.redteam import get_category_info, list_categories, red_team
-from evaluatorq.redteam.backends.base import AgentTarget
 from evaluatorq.redteam.contracts import AgentResponse, Pipeline, RedTeamReport, ReportSummary
 from evaluatorq.redteam.runner import _deduplicate_target_labels, _parse_target
 
@@ -292,7 +292,7 @@ class TestConfirmCallback:
     @pytest.mark.asyncio
     async def test_hooks_on_confirm_false_aborts(self):
         """Hooks returning False from on_confirm should abort execution."""
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import patch
 
         from evaluatorq.redteam.hooks import DefaultHooks
 
@@ -390,7 +390,6 @@ class TestRedTeamWithAgentTarget:
     @pytest.mark.asyncio
     async def test_agent_target_dispatches_to_dynamic(self):
         from unittest.mock import AsyncMock, patch
-        from evaluatorq.redteam.contracts import SendResult
 
         class MockTarget(AgentTarget):
             async def send_prompt(self, prompt: str) -> AgentResponse:
@@ -412,7 +411,6 @@ class TestRedTeamWithAgentTarget:
     @pytest.mark.asyncio
     async def test_agent_target_list_dispatches(self):
         from unittest.mock import AsyncMock, patch
-        from evaluatorq.redteam.contracts import SendResult
 
         class MockTarget(AgentTarget):
             async def send_prompt(self, prompt: str) -> AgentResponse:
@@ -439,7 +437,6 @@ class TestRedTeamWithAgentTarget:
     @pytest.mark.asyncio
     async def test_invalid_item_in_list_raises(self):
         """Passing an invalid item inside a list raises TypeError."""
-        from evaluatorq.redteam.contracts import SendResult
 
         class MockTarget(AgentTarget):
             async def send_prompt(self, prompt: str) -> AgentResponse:

--- a/packages/evaluatorq-py/tests/redteam/test_token_usage_pipeline.py
+++ b/packages/evaluatorq-py/tests/redteam/test_token_usage_pipeline.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from evaluatorq.redteam.adaptive.orchestrator import MultiTurnOrchestrator
-from evaluatorq.redteam.backends.base import AgentTarget
+from evaluatorq.contracts import AgentTarget
 from evaluatorq.redteam.contracts import (
     AgentContext,
     AgentInfo,


### PR DESCRIPTION
## Summary
- Move `AgentTarget` ABC to `evaluatorq.contracts` so simulation can depend on the target shape without importing from the redteam package.
- Move `AgentContext` + `ToolInfo` + `MemoryStoreInfo` + `KnowledgeBaseInfo` to `evaluatorq.contracts` as well (avoids a `contracts → redteam` import inversion in `AgentTarget.get_agent_context`'s default body). `redteam/contracts.py` keeps re-export shims so existing imports keep working.
- `Backend`, `BareTargetBackend`, and `validate_agent_target` **stay** in `redteam/backends/base.py` — `Backend` is redteam-specific (run lifecycle + registry), only `AgentTarget` is the shape sim reuses.
- **Breaking:** no back-compat re-export of `AgentTarget` from `redteam.backends.base` (clean break per spec). Migrated all 13 importers; CHANGELOG entry added.

## Stacked on
PR1 #141 (`bauke/res-808-pr1-collapse`). Sim conformance (`OrqResponsesTarget` inheriting, `TargetAgent` removal, round-trip smoke test) lands in **PR3** (unify on `respond`).

## Test plan
- [x] `uv run pytest -m 'not integration'` → 1272 passed, 3 deselected
- [x] `uv run basedpyright src/evaluatorq` → 0 errors, 0 warnings, 0 notes
- [x] ruff clean on changed files (only pre-existing repo-wide S101/RUF052 remain)
- [x] import smoke: `AgentContext` identical object across both modules; `AgentTarget` no longer importable from `base` (clean break verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)