### PR TITLE
refactor(evaluatorq): migrate Orq router endpoint v2/router → v3/router

### DIFF
--- a/packages/evaluatorq-py/examples/redteam/05_custom_llm_client.py
+++ b/packages/evaluatorq-py/examples/redteam/05_custom_llm_client.py
@@ -33,14 +33,14 @@ async def main() -> None:
     #   - A local proxy:          base_url="http://localhost:8080/v1"
     #   - A self-hosted model:    base_url="http://my-model:8000/v1"
     #   - Azure OpenAI:           base_url="https://<resource>.openai.azure.com/..."
-    #   - The ORQ router:         base_url="https://my.orq.ai/v2/router"
+    #   - The ORQ router:         base_url="https://my.orq.ai/v3/router"
     # Use OPENAI_API_KEY if available, otherwise fall back to ORQ_API_KEY with the ORQ router.
     api_key = os.environ.get("OPENAI_API_KEY") or os.environ.get("ORQ_API_KEY")
     if not api_key:
         raise RuntimeError("Set OPENAI_API_KEY or ORQ_API_KEY in your environment")
     using_openai = bool(os.environ.get("OPENAI_API_KEY"))
     base_url = os.environ.get("OPENAI_BASE_URL") or (
-        "https://api.openai.com/v1" if using_openai else os.environ.get("ORQ_BASE_URL", "https://my.orq.ai/v2/router")
+        "https://api.openai.com/v1" if using_openai else os.environ.get("ORQ_BASE_URL", "https://my.orq.ai/v3/router")
     )
     client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 

--- a/packages/evaluatorq-py/examples/redteam/README.md
+++ b/packages/evaluatorq-py/examples/redteam/README.md
@@ -37,7 +37,7 @@ The pipeline auto-detects which API to use based on your environment:
 | Environment | LLM calls route through | Models |
 |---|---|---|
 | `OPENAI_API_KEY` only | OpenAI directly | `gpt-5-mini`, `gpt-4.1-mini`, etc. |
-| `ORQ_API_KEY` only | ORQ router (`my.orq.ai/v2/router`) | Auto-prefixed: `openai/gpt-5-mini` |
+| `ORQ_API_KEY` only | ORQ router (`my.orq.ai/v3/router`) | Auto-prefixed: `openai/gpt-5-mini` |
 | Both set | OpenAI directly (takes precedence) | `gpt-5-mini` |
 
 When using the ORQ router, model IDs are automatically prefixed with their provider (e.g. `gpt-5-mini` → `openai/gpt-5-mini`). You never need to add the prefix manually.

--- a/packages/evaluatorq-py/examples/redteam/crypto_stealing_demo/agents/base.py
+++ b/packages/evaluatorq-py/examples/redteam/crypto_stealing_demo/agents/base.py
@@ -92,7 +92,7 @@ class DemoAgent(AgentTarget):
     model: str = "openai/gpt-5.4-mini"
 
     def __init__(self) -> None:
-        base_url = os.environ.get("ORQ_BASE_URL", "https://my.orq.ai").rstrip("/") + "/v2/router"
+        base_url = os.environ.get("ORQ_BASE_URL", "https://my.orq.ai").rstrip("/") + "/v3/router"
         self.client = AsyncOpenAI(base_url=base_url, api_key=os.environ["ORQ_API_KEY"])
         self.memory_entity_id: str | None = None
         self._conversation: list[dict[str, Any]] = []

--- a/packages/evaluatorq-py/examples/redteam/refund_agent_demo/agent_build/run_redteam.py
+++ b/packages/evaluatorq-py/examples/redteam/refund_agent_demo/agent_build/run_redteam.py
@@ -27,7 +27,7 @@ from openai import AsyncOpenAI
 from agent_build.build_agent import AGENTS
 from agent_build.refund_target import RefundAgentTarget
 
-ORQ_ROUTER_BASE_URL = os.environ.get('ROUTER_BASE_URL', 'https://api.orq.ai/v2/router')
+ORQ_ROUTER_BASE_URL = os.environ.get('ROUTER_BASE_URL', 'https://api.orq.ai/v3/router')
 
 # Models used by the pipeline. Override via CLI flags below.
 DEFAULT_ATTACKER_MODEL = 'google/gemini-3-flash-preview'

--- a/packages/evaluatorq-py/scripts/manual_tests/simulation_report_demo.py
+++ b/packages/evaluatorq-py/scripts/manual_tests/simulation_report_demo.py
@@ -36,7 +36,7 @@ async def main() -> None:
     from evaluatorq.contracts import Message
 
     api_key = os.environ["ORQ_API_KEY"]
-    base_url = f"{os.environ.get('ORQ_BASE_URL', 'https://api.orq.ai')}/v2/router"
+    base_url = f"{os.environ.get('ORQ_BASE_URL', 'https://api.orq.ai')}/v3/router"
     client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
     system = (

--- a/packages/evaluatorq-py/scripts/manual_tests/test_langgraph.py
+++ b/packages/evaluatorq-py/scripts/manual_tests/test_langgraph.py
@@ -26,7 +26,7 @@ load_dotenv()
 
 # Route OpenAI calls through the orq router
 os.environ.setdefault("OPENAI_API_KEY", os.environ.get("ORQ_API_KEY", ""))
-os.environ.setdefault("OPENAI_BASE_URL", "https://api.orq.ai/v2/router")
+os.environ.setdefault("OPENAI_BASE_URL", "https://api.orq.ai/v3/router")
 
 passed = 0
 failed = 0
@@ -46,7 +46,7 @@ def make_graph() -> CompiledStateGraph:  # pyright: ignore[reportMissingTypeArgu
     api_key = os.environ["ORQ_API_KEY"]
     model = ChatOpenAI(
         model="openai/gpt-4o-mini",
-        base_url="https://api.orq.ai/v2/router",
+        base_url="https://api.orq.ai/v3/router",
         api_key=api_key,  # pyright: ignore[reportArgumentType]
     )
     return create_react_agent(model, tools=[], checkpointer=MemorySaver())

--- a/packages/evaluatorq-py/scripts/manual_tests/test_openai_agents.py
+++ b/packages/evaluatorq-py/scripts/manual_tests/test_openai_agents.py
@@ -21,7 +21,7 @@ load_dotenv()
 
 # Route OpenAI calls through the orq router
 os.environ.setdefault("OPENAI_API_KEY", os.environ.get("ORQ_API_KEY", ""))
-os.environ.setdefault("OPENAI_BASE_URL", "https://api.orq.ai/v2/router")
+os.environ.setdefault("OPENAI_BASE_URL", "https://api.orq.ai/v3/router")
 
 # Disable OpenAI Agents SDK tracing (orq key is not valid for OpenAI's trace endpoint)
 os.environ["OPENAI_AGENTS_DISABLE_TRACING"] = "1"
@@ -44,7 +44,7 @@ def make_agent() -> Agent:
     api_key = os.environ["ORQ_API_KEY"]
     client = AsyncOpenAI(
         api_key=api_key,
-        base_url="https://api.orq.ai/v2/router",
+        base_url="https://api.orq.ai/v3/router",
     )
     return Agent(
         name="test-agent",

--- a/packages/evaluatorq-py/src/evaluatorq/openresponses/client.py
+++ b/packages/evaluatorq-py/src/evaluatorq/openresponses/client.py
@@ -23,7 +23,7 @@ def build_simulation_client(
     2. ``extra_api_key`` argument, treated as an ORQ key and routed through
        the Orq router.
     3. ``ORQ_API_KEY`` env var — routes through
-       ``ORQ_BASE_URL/v2/router`` (default: ``https://api.orq.ai/v2/router``).
+       ``ORQ_BASE_URL/v3/router`` (default: ``https://api.orq.ai/v3/router``).
     4. ``OPENAI_API_KEY`` env var — uses the OpenAI SDK default base URL so
        traffic goes to OpenAI directly, not to the Orq router.
     """
@@ -42,7 +42,7 @@ def build_simulation_client(
         )
 
     base_url: str | None = (
-        f"{os.environ.get('ORQ_BASE_URL', 'https://api.orq.ai')}/v2/router"
+        f"{os.environ.get('ORQ_BASE_URL', 'https://api.orq.ai')}/v3/router"
         if orq_key
         else None
     )

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/orq.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/orq.py
@@ -38,9 +38,9 @@ def _get_orq_api_key() -> str:
 
 
 def _get_orq_server_url() -> str:
-    """Read ORQ_BASE_URL from environment and strip /v2/router for SDK use."""
+    """Read ORQ_BASE_URL from environment and strip /v3/router for SDK use."""
     url = os.environ.get('ORQ_BASE_URL', ORQ_DEFAULT_BASE_URL)
-    return url.rstrip('/').removesuffix('/v2/router')
+    return url.rstrip('/').removesuffix('/v3/router')
 
 
 from evaluatorq.contracts import AgentTarget, Message

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/backends/registry.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/backends/registry.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 ORQ_DEFAULT_BASE_URL = "https://my.orq.ai"
-_ROUTER_SUFFIX = "/v2/router"
+_ROUTER_SUFFIX = "/v3/router"
 
 
 def create_async_llm_client(role_config: LLMCallConfig | None = None) -> AsyncOpenAI:
@@ -34,7 +34,7 @@ def create_async_llm_client(role_config: LLMCallConfig | None = None) -> AsyncOp
     2. Standard OpenAI env (``OPENAI_API_KEY`` + optional ``OPENAI_BASE_URL``)
     3. ORQ env (``ORQ_API_KEY`` + optional ``ORQ_BASE_URL``, defaults to https://my.orq.ai)
 
-    When using ORQ, the router suffix ``/v2/router`` is appended automatically
+    When using ORQ, the router suffix ``/v3/router`` is appended automatically
     to produce the OpenAI-compatible completions endpoint.
     """
     if role_config is not None and role_config.client is not None:

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/agents/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/agents/base.py
@@ -154,7 +154,7 @@ class BaseAgent(ABC):
         2. ``api_key`` argument (extracted from legacy ``AgentConfig.api_key``),
            treated as an ORQ key and routed through the Orq router.
         3. ``ORQ_API_KEY`` env var — routes through
-           ``ORQ_BASE_URL/v2/router`` (default: ``https://api.orq.ai/v2/router``).
+           ``ORQ_BASE_URL/v3/router`` (default: ``https://api.orq.ai/v3/router``).
         4. ``OPENAI_API_KEY`` env var — uses the OpenAI SDK default base URL so
            traffic goes to OpenAI directly, not to the Orq router.
         """

--- a/packages/evaluatorq-py/tests/redteam/test_backends.py
+++ b/packages/evaluatorq-py/tests/redteam/test_backends.py
@@ -414,7 +414,7 @@ class TestORQErrorMapper:
 class TestGetOrqServerUrl:
     """Tests for _get_orq_server_url()."""
 
-    def test_strips_v2_router_suffix(self, monkeypatch):
+    def test_strips_router_suffix(self, monkeypatch):
         from evaluatorq.redteam.backends.orq import _get_orq_server_url
 
         monkeypatch.setenv("ORQ_BASE_URL", "https://my.orq.ai/v3/router")

--- a/packages/evaluatorq-py/tests/redteam/test_backends.py
+++ b/packages/evaluatorq-py/tests/redteam/test_backends.py
@@ -417,13 +417,13 @@ class TestGetOrqServerUrl:
     def test_strips_v2_router_suffix(self, monkeypatch):
         from evaluatorq.redteam.backends.orq import _get_orq_server_url
 
-        monkeypatch.setenv("ORQ_BASE_URL", "https://my.orq.ai/v2/router")
+        monkeypatch.setenv("ORQ_BASE_URL", "https://my.orq.ai/v3/router")
         assert _get_orq_server_url() == "https://my.orq.ai"
 
     def test_strips_trailing_slash_and_suffix(self, monkeypatch):
         from evaluatorq.redteam.backends.orq import _get_orq_server_url
 
-        monkeypatch.setenv("ORQ_BASE_URL", "https://my.orq.ai/v2/router/")
+        monkeypatch.setenv("ORQ_BASE_URL", "https://my.orq.ai/v3/router/")
         assert _get_orq_server_url() == "https://my.orq.ai"
 
     def test_returns_url_unchanged_when_no_suffix(self, monkeypatch):

--- a/packages/evaluatorq-py/tests/redteam/test_llm_client_threading.py
+++ b/packages/evaluatorq-py/tests/redteam/test_llm_client_threading.py
@@ -74,7 +74,7 @@ class TestCreateAsyncLlmClientPriority:
         create_async_llm_client()
         mock_cls.assert_called_once_with(
             api_key='orq-key',
-            base_url='https://my.orq.ai/v2/router',
+            base_url='https://my.orq.ai/v3/router',
         )
 
     @patch.dict('os.environ', {}, clear=True)

--- a/packages/evaluatorq-py/tests/simulation/test_client_builder.py
+++ b/packages/evaluatorq-py/tests/simulation/test_client_builder.py
@@ -2,8 +2,8 @@
 
 Covers all resolution branches:
 1. config_client passed → returns (client, owned=False), no env reads
-2. extra_api_key arg → routes via ORQ_BASE_URL/v2/router, owned=True
-3. ORQ_API_KEY env only → routes via ORQ_BASE_URL/v2/router, owned=True
+2. extra_api_key arg → routes via ORQ_BASE_URL/v3/router, owned=True
+3. ORQ_API_KEY env only → routes via ORQ_BASE_URL/v3/router, owned=True
 4. OPENAI_API_KEY env only (no ORQ_API_KEY) → base_url=None (OpenAI default), owned=True
 5. Both ORQ and OPENAI env vars → ORQ wins (precedence)
 6. Neither env var nor client → raises ValueError with helpful message
@@ -105,7 +105,7 @@ class TestExtraApiKey:
             _, owned = build_simulation_client(extra_api_key="sk-extra-key")
 
         assert owned is True
-        assert captured.get("base_url") == "https://api.orq.ai/v2/router"
+        assert captured.get("base_url") == "https://api.orq.ai/v3/router"
         assert captured.get("api_key") == "sk-extra-key"
 
     def test_extra_api_key_uses_custom_orq_base_url(self, monkeypatch):
@@ -125,7 +125,7 @@ class TestExtraApiKey:
 
             build_simulation_client(extra_api_key="sk-extra-key")
 
-        assert captured.get("base_url") == "https://custom.example.com/v2/router"
+        assert captured.get("base_url") == "https://custom.example.com/v3/router"
 
 
 # ---------------------------------------------------------------------------
@@ -152,7 +152,7 @@ class TestOrqApiKeyEnv:
             _, owned = build_simulation_client()
 
         assert owned is True
-        assert captured.get("base_url") == "https://api.orq.ai/v2/router"
+        assert captured.get("base_url") == "https://api.orq.ai/v3/router"
         assert captured.get("api_key") == "orq-env-key"
 
 
@@ -209,7 +209,7 @@ class TestOrqTakesPrecedenceOverOpenAI:
 
         assert owned is True
         # Must route via ORQ, not OpenAI default
-        assert captured.get("base_url") == "https://api.orq.ai/v2/router"
+        assert captured.get("base_url") == "https://api.orq.ai/v3/router"
         assert captured.get("api_key") == "orq-wins"
 
 
@@ -263,7 +263,7 @@ class TestCustomOrqBaseUrl:
 
             build_simulation_client()
 
-        assert captured.get("base_url") == "https://staging.orq.ai/v2/router"
+        assert captured.get("base_url") == "https://staging.orq.ai/v3/router"
 
     def test_custom_base_url_not_used_when_openai_key_only(self, monkeypatch):
         """ORQ_BASE_URL must NOT affect routing when only OPENAI_API_KEY is set."""

--- a/packages/evaluatorq-py/tests/simulation/test_generator_client_resolution.py
+++ b/packages/evaluatorq-py/tests/simulation/test_generator_client_resolution.py
@@ -14,7 +14,7 @@ def test_openai_key_only_uses_openai_base_url(gen_cls, monkeypatch):
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
     gen = gen_cls()
     assert "api.openai.com" in str(gen._client.base_url)
-    assert "/v2/router" not in str(gen._client.base_url)
+    assert "/v3/router" not in str(gen._client.base_url)
 
 
 @pytest.mark.parametrize("gen_cls", GEN_CLASSES)
@@ -22,7 +22,7 @@ def test_orq_key_wins_when_both_set(gen_cls, monkeypatch):
     monkeypatch.setenv("ORQ_API_KEY", "orq-test")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     gen = gen_cls()
-    assert str(gen._client.base_url).rstrip("/").endswith("/v2/router")
+    assert str(gen._client.base_url).rstrip("/").endswith("/v3/router")
 
 
 @pytest.mark.parametrize("gen_cls", GEN_CLASSES)

--- a/packages/evaluatorq/src/lib/integrations/simulation/agents/base.ts
+++ b/packages/evaluatorq/src/lib/integrations/simulation/agents/base.ts
@@ -79,7 +79,7 @@ export abstract class BaseAgent {
         );
       }
       this.client = new OpenAI({
-        baseURL: process.env.ROUTER_BASE_URL ?? "https://api.orq.ai/v2/router",
+        baseURL: process.env.ROUTER_BASE_URL ?? "https://api.orq.ai/v3/router",
         apiKey: resolvedApiKey,
       });
       this.clientOwned = true;

--- a/packages/evaluatorq/src/lib/integrations/simulation/generators/first-message-generator.ts
+++ b/packages/evaluatorq/src/lib/integrations/simulation/generators/first-message-generator.ts
@@ -99,7 +99,7 @@ export class FirstMessageGenerator {
         );
       }
       this.client = new OpenAI({
-        baseURL: process.env.ROUTER_BASE_URL || "https://api.orq.ai/v2/router",
+        baseURL: process.env.ROUTER_BASE_URL || "https://api.orq.ai/v3/router",
         apiKey,
       });
     }

--- a/packages/evaluatorq/src/lib/integrations/simulation/generators/persona-generator.ts
+++ b/packages/evaluatorq/src/lib/integrations/simulation/generators/persona-generator.ts
@@ -109,7 +109,7 @@ export class PersonaGenerator {
         );
       }
       this.client = new OpenAI({
-        baseURL: process.env.ROUTER_BASE_URL || "https://api.orq.ai/v2/router",
+        baseURL: process.env.ROUTER_BASE_URL || "https://api.orq.ai/v3/router",
         apiKey,
       });
     }

--- a/packages/evaluatorq/src/lib/integrations/simulation/generators/scenario-generator.ts
+++ b/packages/evaluatorq/src/lib/integrations/simulation/generators/scenario-generator.ts
@@ -253,7 +253,7 @@ export class ScenarioGenerator {
         );
       }
       this.client = new OpenAI({
-        baseURL: process.env.ROUTER_BASE_URL || "https://api.orq.ai/v2/router",
+        baseURL: process.env.ROUTER_BASE_URL || "https://api.orq.ai/v3/router",
         apiKey,
       });
     }

--- a/packages/evaluatorq/src/lib/integrations/simulation/runner/simulation.ts
+++ b/packages/evaluatorq/src/lib/integrations/simulation/runner/simulation.ts
@@ -166,7 +166,7 @@ export class SimulationRunner {
       }
       this.sharedClient = new OpenAI({
         apiKey,
-        baseURL: process.env.ROUTER_BASE_URL ?? "https://api.orq.ai/v2/router",
+        baseURL: process.env.ROUTER_BASE_URL ?? "https://api.orq.ai/v3/router",
       });
     }
     return this.sharedClient;

--- a/packages/evaluatorq/src/lib/integrations/simulation/simulation/index.ts
+++ b/packages/evaluatorq/src/lib/integrations/simulation/simulation/index.ts
@@ -126,7 +126,7 @@ async function _simulateCore(
     // Create a shared HTTP client so the generator doesn't leak its own pool
     const sharedClient = new OpenAI({
       apiKey,
-      baseURL: process.env.ROUTER_BASE_URL ?? "https://api.orq.ai/v2/router",
+      baseURL: process.env.ROUTER_BASE_URL ?? "https://api.orq.ai/v3/router",
     });
     // Generate first messages for each combination (with bounded concurrency)
     const firstMsgGen = new FirstMessageGenerator({


### PR DESCRIPTION
## What

Swap the Orq OpenAI-compatible gateway path from `/v2/router` → `/v3/router` across **both** packages (`evaluatorq` TS + `evaluatorq-py`).

Per Orq's own design doc (`docs/superpowers/specs/2026-05-26-res-808...md`): *"both `/v2/router/responses` and `/v3/router/responses` reach the same handler."* So this is a forward-looking endpoint bump with **no behavioral change** — same handler server-side.

## Scope — 21 files

**Python src (4)**
- `openresponses/client.py` — simulation client base_url fallback
- `redteam/backends/orq.py` — `_get_orq_server_url` suffix strip
- `redteam/backends/registry.py` — `_ROUTER_SUFFIX`
- `simulation/agents/base.py` — docstring

**TS src (6)** — all `ROUTER_BASE_URL` defaults
- `agents/base.ts`, `generators/{first-message,persona,scenario}.ts`, `runner/simulation.ts`, `simulation/index.ts`

**Tests (4), examples (4), manual-test scripts (3)**

**Intentionally skipped:** the 3 dated `docs/superpowers/` specs/plans — historical point-in-time records; one literally reads `_ROUTER_SUFFIX = "/v2/router" → "/v3/router"` and mechanical replace would corrupt it to `v3 → v3`.

## Validation

| Check | Result |
|---|---|
| Full `evaluatorq-py` suite | ✅ 1666 pass, 1 skip |
| Affected py tests (backends, client builder, generator resolution) | ✅ 94 pass |
| TS typecheck | ✅ pass |
| Biome (6 changed TS) | ✅ clean |
| Residual `v2/router` in source | ✅ zero |
| TS suite | 153 pass / 2 fail |

The **2 TS failures are pre-existing and environmental** — reproduce 153/2 on clean `main`. They're live integration tests in `include-messages-conflict.test.ts` hitting `POST /v2/datasets` and getting HTTP 404 *"Workspace not found … verify your API key"*. Unrelated to this change (different endpoint, no router path involved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)