### PR TITLE
feat(evaluatorq): add agent simulation examples (RES-904)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,6 @@ Thumbs.db
 **/*.tsbuildinfo
 *.env
 packages/evaluatorq-py/outputs/*
+packages/evaluatorq-py/examples/agent_simulation/data/
 outputs/
 .worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,6 @@ Thumbs.db
 **/*.tsbuildinfo
 *.env
 packages/evaluatorq-py/outputs/*
-packages/evaluatorq-py/examples/agent_simulation/data/
+packages/evaluatorq-py/data/
 outputs/
 .worktrees/

--- a/packages/evaluatorq-py/examples/agent_simulation/.env.example
+++ b/packages/evaluatorq-py/examples/agent_simulation/.env.example
@@ -1,0 +1,4 @@
+ORQ_API_KEY=your-orq-api-key-here
+
+# Optional: override the default orq.ai server URL
+# ORQ_BASE_URL=https://my.orq.ai

--- a/packages/evaluatorq-py/examples/agent_simulation/01_basic_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/01_basic_simulation.py
@@ -30,9 +30,9 @@ from loguru import logger
 # library init code that reads them (e.g. evaluatorq tracing setup).
 load_dotenv()
 
-from evaluatorq.contracts import Message  # noqa: E402
-from evaluatorq.simulation import simulate  # noqa: E402
-from evaluatorq.simulation.types import (  # noqa: E402
+from evaluatorq.contracts import Message
+from evaluatorq.simulation import simulate
+from evaluatorq.simulation.types import (
     CommunicationStyle,
     Criterion,
     EmotionalArc,
@@ -42,8 +42,12 @@ from evaluatorq.simulation.types import (  # noqa: E402
 )
 
 
-async def support_agent(messages: list[Message]) -> str:
-    """Simple mock customer support agent — replace with your own logic."""
+async def support_agent(messages: list[Message]) -> str:  # noqa: RUF029
+    """Simple mock customer support agent — replace with your own logic.
+
+    Declared `async` because target_callback must be awaitable per the simulation
+    runner protocol; a real agent here would `await` an LLM/HTTP call.
+    """
     last = (messages[-1].content or "").lower() if messages else ""
     if "refund" in last:
         return "I can help with that. Could you share your order number?"

--- a/packages/evaluatorq-py/examples/agent_simulation/01_basic_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/01_basic_simulation.py
@@ -13,10 +13,9 @@ Usage:
 Where outputs land:
 - OTel spans appear automatically in orq.ai under orq.simulation.pipeline
   (requires ORQ_API_KEY to be set)
-- Results are returned in memory as SimulationResult objects
-- An Experiment row is created in orq.ai when ORQ_API_KEY is set and
-  evaluatorq() framework handles the upload (bare simulate() returns results
-  in memory; wire into evaluatorq() or wrap_simulation_agent() for auto-upload)
+- An Experiment row is created in orq.ai by default when ORQ_API_KEY is set
+  (pass upload_results=False to simulate() to suppress this)
+- Results are also returned in memory as SimulationResult objects
 """
 
 from __future__ import annotations
@@ -31,6 +30,7 @@ from loguru import logger
 # library init code that reads them (e.g. evaluatorq tracing setup).
 load_dotenv()
 
+from evaluatorq.contracts import Message  # noqa: E402
 from evaluatorq.simulation import simulate  # noqa: E402
 from evaluatorq.simulation.types import (  # noqa: E402
     CommunicationStyle,
@@ -42,9 +42,9 @@ from evaluatorq.simulation.types import (  # noqa: E402
 )
 
 
-async def support_agent(messages: list[dict]) -> str:
+async def support_agent(messages: list[Message]) -> str:
     """Simple mock customer support agent — replace with your own logic."""
-    last = messages[-1]["content"].lower() if messages else ""
+    last = (messages[-1].content or "").lower() if messages else ""
     if "refund" in last:
         return "I can help with that. Could you share your order number?"
     if "order" in last or "status" in last:
@@ -86,7 +86,7 @@ async def main() -> None:
 
     # 3. Run simulation
     # target_callback=: pass any async function; use agent_key= for orq.ai deployments.
-    # model=: the LLM used for the UserSimulator and Judge (defaults to openai/gpt-4o-mini).
+    # sim_model=: the LLM used for the UserSimulator and Judge (defaults to openai/gpt-5.4-mini).
     # evaluator_names=: scorers applied to each result (default: goal_achieved, criteria_met).
     logger.info("Running simulation...")
     results = await simulate(

--- a/packages/evaluatorq-py/examples/agent_simulation/01_basic_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/01_basic_simulation.py
@@ -86,7 +86,7 @@ async def main() -> None:
 
     # 3. Run simulation
     # target_callback=: pass any async function; use agent_key= for orq.ai deployments.
-    # model=: the LLM used for the UserSimulator and Judge (defaults to azure/gpt-4o-mini).
+    # model=: the LLM used for the UserSimulator and Judge (defaults to openai/gpt-5.4-mini).
     # evaluator_names=: scorers applied to each result (default: goal_achieved, criteria_met).
     logger.info("Running simulation...")
     results = await simulate(

--- a/packages/evaluatorq-py/examples/agent_simulation/01_basic_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/01_basic_simulation.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Example: Basic agent simulation with a mock agent.
+
+Demonstrates the core simulation loop without needing an orq.ai account:
+- Define a persona and scenario manually
+- Run a simulation against a local callback function
+- Inspect the conversation and result
+
+Usage:
+    cd packages/evaluatorq-py
+    uv run python examples/agent_simulation/01_basic_simulation.py
+
+Where outputs land:
+- OTel spans appear automatically in orq.ai under orq.simulation.pipeline
+  (requires ORQ_API_KEY to be set)
+- Results are returned in memory as SimulationResult objects
+- An Experiment row is created in orq.ai when ORQ_API_KEY is set and
+  evaluatorq() framework handles the upload (bare simulate() returns results
+  in memory; wire into evaluatorq() or wrap_simulation_agent() for auto-upload)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+from loguru import logger
+
+# load_dotenv() runs before local imports so env vars are set before any
+# library init code that reads them (e.g. evaluatorq tracing setup).
+load_dotenv()
+
+from evaluatorq.simulation import simulate  # noqa: E402
+from evaluatorq.simulation.types import (  # noqa: E402
+    CommunicationStyle,
+    Criterion,
+    EmotionalArc,
+    Persona,
+    Scenario,
+    StartingEmotion,
+)
+
+
+async def support_agent(messages: list[dict]) -> str:
+    """Simple mock customer support agent — replace with your own logic."""
+    last = messages[-1]["content"].lower() if messages else ""
+    if "refund" in last:
+        return "I can help with that. Could you share your order number?"
+    if "order" in last or "status" in last:
+        return "Let me look that up. What email is on the account?"
+    if "thank" in last:
+        return "Happy to help! Anything else I can do for you?"
+    return "Thanks for reaching out. How can I assist you today?"
+
+
+async def main() -> None:
+    if not os.getenv("ORQ_API_KEY"):
+        raise SystemExit("ORQ_API_KEY is not set — needed for UserSimulator and Judge LLMs")
+
+    # 1. Define a persona — who the simulated user is
+    persona = Persona(
+        name="Impatient Customer",
+        patience=0.2,
+        assertiveness=0.8,
+        politeness=0.4,
+        technical_level=0.3,
+        communication_style=CommunicationStyle.terse,
+        background="Received the wrong item and wants a refund urgently",
+        emotional_arc=EmotionalArc.escalating,  # optional: tone escalates each turn
+    )
+
+    # 2. Define a scenario — what the user wants to achieve
+    scenario = Scenario(
+        name="Wrong Item Refund",
+        goal="Get a full refund for the wrong item received",
+        context="Customer ordered headphones but received a phone case instead",
+        starting_emotion=StartingEmotion.frustrated,
+        criteria=[
+            Criterion(description="Agent asks for order details", type="must_happen"),
+            Criterion(description="Agent acknowledges the mistake", type="must_happen"),
+            Criterion(description="Agent blames the customer", type="must_not_happen"),
+        ],
+        is_edge_case=False,  # set True to flag adversarial/edge-case scenarios for separate analysis
+    )
+
+    # 3. Run simulation
+    # target_callback=: pass any async function; use agent_key= for orq.ai deployments.
+    # model=: the LLM used for the UserSimulator and Judge (defaults to azure/gpt-4o-mini).
+    # evaluator_names=: scorers applied to each result (default: goal_achieved, criteria_met).
+    logger.info("Running simulation...")
+    results = await simulate(
+        evaluation_name="basic-simulation-example",
+        target_callback=support_agent,
+        personas=[persona],
+        scenarios=[scenario],
+        max_turns=6,
+        evaluator_names=["goal_achieved", "criteria_met"],
+    )
+
+    # 4. Inspect results
+    if not results:
+        logger.warning("No results returned — check ORQ_API_KEY and network connectivity")
+        return
+    result = results[0]
+    logger.info(f"Goal achieved: {result.goal_achieved}")
+    logger.info(f"Goal completion score: {result.goal_completion_score:.2f}")
+    logger.info(f"Turns: {result.turn_count}")
+    logger.info(f"Terminated by: {result.terminated_by}")
+    if result.rules_broken:
+        logger.warning(f"Rules broken: {result.rules_broken}")
+    if result.criteria_results:
+        logger.info(f"Criteria results: {result.criteria_results}")
+
+    logger.info("--- Conversation ---")
+    for msg in result.messages:
+        role = "User" if msg.role == "user" else "Agent"
+        logger.info(f"{role}: {msg.content}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/evaluatorq-py/examples/agent_simulation/01_basic_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/01_basic_simulation.py
@@ -43,7 +43,7 @@ from evaluatorq.simulation.types import (
 
 
 async def support_agent(messages: list[Message]) -> str:  # noqa: RUF029
-    """Simple mock customer support agent — replace with your own logic.
+    """Simple mock customer support agent - replace with your own logic.
 
     Declared `async` because target_callback must be awaitable per the simulation
     runner protocol; a real agent here would `await` an LLM/HTTP call.
@@ -60,9 +60,9 @@ async def support_agent(messages: list[Message]) -> str:  # noqa: RUF029
 
 async def main() -> None:
     if not os.getenv("ORQ_API_KEY"):
-        raise SystemExit("ORQ_API_KEY is not set — needed for UserSimulator and Judge LLMs")
+        raise SystemExit("ORQ_API_KEY is not set - needed for UserSimulator and Judge LLMs")
 
-    # 1. Define a persona — who the simulated user is
+    # 1. Define a persona - who the simulated user is
     persona = Persona(
         name="Impatient Customer",
         patience=0.2,
@@ -74,7 +74,7 @@ async def main() -> None:
         emotional_arc=EmotionalArc.escalating,  # optional: tone escalates each turn
     )
 
-    # 2. Define a scenario — what the user wants to achieve
+    # 2. Define a scenario - what the user wants to achieve
     scenario = Scenario(
         name="Wrong Item Refund",
         goal="Get a full refund for the wrong item received",
@@ -104,7 +104,7 @@ async def main() -> None:
 
     # 4. Inspect results
     if not results:
-        logger.warning("No results returned — check ORQ_API_KEY and network connectivity")
+        logger.warning("No results returned - check ORQ_API_KEY and network connectivity")
         return
     result = results[0]
     logger.info(f"Goal achieved: {result.goal_achieved}")

--- a/packages/evaluatorq-py/examples/agent_simulation/01_basic_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/01_basic_simulation.py
@@ -103,9 +103,13 @@ async def main() -> None:
     )
 
     # 4. Inspect results
+    # One persona x one scenario should yield exactly one result. An empty list
+    # means the simulation runner failed for every datapoint - treat it as an
+    # error, not a benign "nothing happened". Inspect the OTel spans under
+    # orq.simulation.pipeline to see where the run broke.
     if not results:
-        logger.warning("No results returned - check ORQ_API_KEY and network connectivity")
-        return
+        logger.error("Simulation produced no results - the run failed; check OTel spans under orq.simulation.pipeline")
+        raise SystemExit(1)
     result = results[0]
     logger.info(f"Goal achieved: {result.goal_achieved}")
     logger.info(f"Goal completion score: {result.goal_completion_score:.2f}")

--- a/packages/evaluatorq-py/examples/agent_simulation/01_basic_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/01_basic_simulation.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Example: Basic agent simulation with a mock agent.
 
-Demonstrates the core simulation loop without needing an orq.ai account:
+Demonstrates the core simulation loop with a local mock agent:
 - Define a persona and scenario manually
 - Run a simulation against a local callback function
 - Inspect the conversation and result
@@ -86,7 +86,7 @@ async def main() -> None:
 
     # 3. Run simulation
     # target_callback=: pass any async function; use agent_key= for orq.ai deployments.
-    # model=: the LLM used for the UserSimulator and Judge (defaults to openai/gpt-5.4-mini).
+    # model=: the LLM used for the UserSimulator and Judge (defaults to openai/gpt-4o-mini).
     # evaluator_names=: scorers applied to each result (default: goal_achieved, criteria_met).
     logger.info("Running simulation...")
     results = await simulate(

--- a/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
@@ -56,7 +56,7 @@ def make_a2a_callback(agent_key: str) -> Callable[[list[Message]], Coroutine[Any
     """Return a target_callback that calls an orq A2A agent via the Responses API.
 
     The Responses API (client.agents.responses.create) is the production path for
-    full A2A agents in orq.ai — agents with memory, tool use, and multi-step
+    full A2A agents in orq.ai - agents with memory, tool use, and multi-step
     reasoning, as opposed to stateless deployments (prompt + model config).
 
     Each call passes the full conversation history so the agent has context.
@@ -82,7 +82,7 @@ def make_a2a_callback(agent_key: str) -> Callable[[list[Message]], Coroutine[Any
         agent_resp = AgentResponse.from_openresponses(response)
         if not agent_resp.output:
             raise RuntimeError(
-                f"A2A agent '{agent_key}' returned no output — "
+                f"A2A agent '{agent_key}' returned no output - "
                 "check agent_key and API connectivity"
             )
         return agent_resp.text
@@ -95,8 +95,8 @@ async def main() -> None:
         description="Batch simulation against an orq.ai deployment or A2A agent"
     )
     target_group = parser.add_mutually_exclusive_group(required=True)
-    target_group.add_argument("--deployment", "-d", help="orq.ai deployment key (from AI Studio → Deployments)")
-    target_group.add_argument("--agent", "-a", help="orq.ai A2A agent key (from AI Studio → Agents)")
+    target_group.add_argument("--deployment", "-d", help="orq.ai deployment key (from AI Studio -> Deployments)")
+    target_group.add_argument("--agent", "-a", help="orq.ai A2A agent key (from AI Studio -> Agents)")
     parser.add_argument(
         "--description",
         default="",
@@ -113,7 +113,7 @@ async def main() -> None:
 
     if args.deployment:
         # Deployment path: agent_key= routes through from_orq_deployment() internally,
-        # which calls evaluatorq.deployment.invoke — stateless prompt + model config.
+        # which calls evaluatorq.deployment.invoke - stateless prompt + model config.
         target_key = args.deployment
         agent_description = args.description or f"orq.ai deployment '{args.deployment}'"
         target_kwargs: dict[str, Any] = {"agent_key": target_key}

--- a/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
@@ -43,10 +43,10 @@ from loguru import logger
 
 load_dotenv()
 
-# generate_and_simulate() synthesises Persona × Scenario pairs from a plain-text
+# generate_and_simulate() synthesises Persona x Scenario pairs from a plain-text
 # description, then runs the full simulation batch in one call.
-from evaluatorq.contracts import AgentResponse, Message  # noqa: E402
-from evaluatorq.simulation import (  # noqa: E402
+from evaluatorq.contracts import AgentResponse, Message
+from evaluatorq.simulation import (
     export_results_to_jsonl,
     generate_and_simulate,
 )
@@ -121,12 +121,12 @@ async def main() -> None:
     else:
         # A2A agent path: wrap client.agents.responses.create as a target_callback.
         # Use this for full agents with memory, tools, and multi-step reasoning.
-        assert args.agent is not None  # guaranteed by mutually exclusive group
+        assert args.agent is not None, "argparse mutually-exclusive group guarantees one of --deployment/--agent"  # noqa: S101
         agent_description = args.description or f"orq.ai A2A agent '{args.agent}'"
         target_kwargs = {"target_callback": make_a2a_callback(args.agent)}
         logger.info(f"Target: A2A agent '{args.agent}' via Responses API")
 
-    logger.info(f"Generating {args.num_personas} personas × {args.num_scenarios} scenarios...")
+    logger.info(f"Generating {args.num_personas} personas x {args.num_scenarios} scenarios...")
     results = await generate_and_simulate(
         evaluation_name="orq-deployment-simulation-example",
         agent_description=agent_description,

--- a/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
@@ -45,7 +45,7 @@ load_dotenv()
 
 # generate_and_simulate() synthesises Persona x Scenario pairs from a plain-text
 # description, then runs the full simulation batch in one call.
-from evaluatorq.contracts import AgentResponse, Message
+from evaluatorq.contracts import Message
 from evaluatorq.simulation import (
     export_results_to_jsonl,
     generate_and_simulate,
@@ -59,7 +59,8 @@ def make_a2a_callback(agent_key: str) -> Callable[[list[Message]], Coroutine[Any
     full A2A agents in orq.ai - agents with memory, tool use, and multi-step
     reasoning, as opposed to stateless deployments (prompt + model config).
 
-    Each call passes the full conversation history so the agent has context.
+    Each call sends only the latest user message; the A2A agent's server-side
+    memory provides conversation context across turns.
     """
     from orq_ai_sdk import Orq
     from orq_ai_sdk.models import A2AMessage, TextPart
@@ -77,15 +78,21 @@ def make_a2a_callback(agent_key: str) -> Callable[[list[Message]], Coroutine[Any
             agent_key=agent_key,
             message=message,
         )
-        # Parse the Responses API wire format via AgentResponse.from_openresponses,
-        # which handles type="message" items with content[].type="output_text".
-        agent_resp = AgentResponse.from_openresponses(response)
-        if not agent_resp.output:
+        # A2A response: output is List[AgentResponseMessage]; agent turns have
+        # role == "agent" and TextPart entries in .parts (kind="text").
+        texts = [
+            part.text
+            for msg in response.output
+            if msg.role == "agent"
+            for part in msg.parts
+            if isinstance(part, TextPart)
+        ]
+        if not texts:
             raise RuntimeError(
-                f"A2A agent '{agent_key}' returned no output - "
+                f"A2A agent '{agent_key}' returned no text output - "
                 "check agent_key and API connectivity"
             )
-        return agent_resp.text
+        return " ".join(texts)
 
     return callback
 

--- a/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
@@ -24,9 +24,8 @@ Usage:
 
 Where outputs land:
 - OTel spans appear automatically in orq.ai under orq.simulation.pipeline
-- An Experiment row is created in orq.ai (URL printed to stdout) when the
-  run is wired through evaluatorq() — see wrap_simulation_agent() for
-  production use with CI gating and auto-upload
+- An Experiment row is created in orq.ai by default (URL printed to stdout);
+  pass upload_results=False to generate_and_simulate() to suppress this
 - Results are exported to JSONL for offline analysis or dataset seeding
 """
 
@@ -46,13 +45,14 @@ load_dotenv()
 
 # generate_and_simulate() synthesises Persona × Scenario pairs from a plain-text
 # description, then runs the full simulation batch in one call.
+from evaluatorq.contracts import AgentResponse, Message  # noqa: E402
 from evaluatorq.simulation import (  # noqa: E402
     export_results_to_jsonl,
     generate_and_simulate,
 )
 
 
-def make_a2a_callback(agent_key: str) -> Callable[[list[dict]], Coroutine[Any, Any, str]]:
+def make_a2a_callback(agent_key: str) -> Callable[[list[Message]], Coroutine[Any, Any, str]]:
     """Return a target_callback that calls an orq A2A agent via the Responses API.
 
     The Responses API (client.agents.responses.create) is the production path for
@@ -60,34 +60,32 @@ def make_a2a_callback(agent_key: str) -> Callable[[list[dict]], Coroutine[Any, A
     reasoning, as opposed to stateless deployments (prompt + model config).
 
     Each call passes the full conversation history so the agent has context.
-    The response's output is a list of AgentResponseMessage objects; we extract
-    text parts from the last agent message.
     """
     from orq_ai_sdk import Orq
     from orq_ai_sdk.models import A2AMessage, TextPart
 
     client = Orq(api_key=os.getenv("ORQ_API_KEY", ""))
 
-    async def callback(messages: list[dict]) -> str:
+    async def callback(messages: list[Message]) -> str:
         last = messages[-1]
         message = A2AMessage(
             role="user",
-            parts=[TextPart(kind="text", text=last["content"])],
+            parts=[TextPart(kind="text", text=last.content or "")],
         )
         response = await asyncio.to_thread(
             client.agents.responses.create,
             agent_key=agent_key,
             message=message,
         )
-        # output is a list of AgentResponseMessage; extract text from agent turns
-        texts = [
-            part.text
-            for msg in response.output
-            if msg.role == "agent"
-            for part in msg.parts
-            if hasattr(part, "text")
-        ]
-        return " ".join(texts) if texts else ""
+        # Parse the Responses API wire format via AgentResponse.from_openresponses,
+        # which handles type="message" items with content[].type="output_text".
+        agent_resp = AgentResponse.from_openresponses(response)
+        if not agent_resp.output:
+            raise RuntimeError(
+                f"A2A agent '{agent_key}' returned no output — "
+                "check agent_key and API connectivity"
+            )
+        return agent_resp.text
 
     return callback
 

--- a/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
@@ -86,8 +86,18 @@ def make_a2a_callback(agent_key: str) -> Callable[[list[Message]], Coroutine[Any
             task_id=state.get("task_id"),
         )
         # Remember the task so the next turn continues this conversation.
+        # If the response carries no task_id, threading is broken: every turn
+        # sends task_id=None and the agent loses server-side state, silently
+        # degrading the multi-turn simulation into disconnected single turns.
+        # Surface that once so a degraded run is distinguishable from a healthy one.
         if getattr(response, "task_id", None):
             state["task_id"] = response.task_id
+        elif not state.get("warned_no_task_id"):
+            logger.warning(
+                f"A2A agent '{agent_key}' returned no task_id - multi-turn context "
+                "will not thread; the agent will see each turn in isolation"
+            )
+            state["warned_no_task_id"] = "1"
         # A2A response: output is List[AgentResponseMessage]; agent turns have
         # role == "agent" and TextPart entries in .parts (kind="text").
         texts = [

--- a/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
@@ -140,11 +140,11 @@ async def main() -> None:
     )
 
     # Summary
-    passed = sum(r.goal_achieved for r in results)
-    if results:
-        logger.info(f"Pass rate: {passed}/{len(results)} ({100 * passed / len(results):.0f}%)")
-    else:
+    if not results:
         logger.warning("No results to summarise")
+    else:
+        passed = sum(r.goal_achieved for r in results)
+        logger.info(f"Pass rate: {passed}/{len(results)} ({100 * passed / len(results):.0f}%)")
 
     for r in results:
         status = "PASS" if r.goal_achieved else "FAIL"
@@ -152,7 +152,7 @@ async def main() -> None:
         logger.info(f"         terminated_by={r.terminated_by} rules_broken={r.rules_broken or []}")
 
     # Export to JSONL for offline analysis or seeding an orq.ai Dataset
-    output_path = Path(__file__).parent.parent.parent / args.output
+    output_path = Path.cwd() / args.output
     output_path.parent.mkdir(parents=True, exist_ok=True)
     export_results_to_jsonl(results, str(output_path))
     logger.info(f"Results written to {output_path}")

--- a/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Example: Batch simulation against an orq.ai deployment or A2A agent.
+
+Demonstrates how to:
+- Auto-generate personas and scenarios from an agent description
+- Run a batch of simulations against a live orq.ai deployment (--deployment)
+  or a live A2A agent via the orq Responses API (--agent)
+- Export results to JSONL
+
+Usage:
+    cd packages/evaluatorq-py
+
+    # Against an orq.ai deployment (prompt + model config in AI Studio)
+    uv run python examples/agent_simulation/02_orq_deployment_simulation.py \
+        --deployment my-support-agent
+
+    # Against an A2A agent via the orq Responses API
+    uv run python examples/agent_simulation/02_orq_deployment_simulation.py \
+        --agent my-a2a-agent
+
+    # Faster test run
+    uv run python examples/agent_simulation/02_orq_deployment_simulation.py \
+        --deployment my-support-agent --num-personas 2 --num-scenarios 3
+
+Where outputs land:
+- OTel spans appear automatically in orq.ai under orq.simulation.pipeline
+- An Experiment row is created in orq.ai (URL printed to stdout) when the
+  run is wired through evaluatorq() — see wrap_simulation_agent() for
+  production use with CI gating and auto-upload
+- Results are exported to JSONL for offline analysis or dataset seeding
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+from collections.abc import Callable, Coroutine
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+from loguru import logger
+
+load_dotenv()
+
+# generate_and_simulate() synthesises Persona × Scenario pairs from a plain-text
+# description, then runs the full simulation batch in one call.
+from evaluatorq.simulation import (  # noqa: E402
+    export_results_to_jsonl,
+    generate_and_simulate,
+)
+
+
+def make_a2a_callback(agent_key: str) -> Callable[[list[dict]], Coroutine[Any, Any, str]]:
+    """Return a target_callback that calls an orq A2A agent via the Responses API.
+
+    The Responses API (client.agents.responses.create) is the production path for
+    full A2A agents in orq.ai — agents with memory, tool use, and multi-step
+    reasoning, as opposed to stateless deployments (prompt + model config).
+
+    Each call passes the full conversation history so the agent has context.
+    The response's output is a list of AgentResponseMessage objects; we extract
+    text parts from the last agent message.
+    """
+    from orq_ai_sdk import Orq
+    from orq_ai_sdk.models import A2AMessage, TextPart
+
+    client = Orq(api_key=os.environ["ORQ_API_KEY"])
+
+    async def callback(messages: list[dict]) -> str:
+        last = messages[-1]
+        message = A2AMessage(
+            role="user",
+            parts=[TextPart(kind="text", text=last["content"])],
+        )
+        response = await asyncio.to_thread(
+            client.agents.responses.create,
+            agent_key=agent_key,
+            message=message,
+        )
+        # output is a list of AgentResponseMessage; extract text from agent turns
+        texts = [
+            part.text
+            for msg in response.output
+            if msg.role == "agent"
+            for part in msg.parts
+            if hasattr(part, "text")
+        ]
+        return " ".join(texts) if texts else ""
+
+    return callback
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Batch simulation against an orq.ai deployment or A2A agent"
+    )
+    target_group = parser.add_mutually_exclusive_group(required=True)
+    target_group.add_argument("--deployment", "-d", help="orq.ai deployment key (from AI Studio → Deployments)")
+    target_group.add_argument("--agent", "-a", help="orq.ai A2A agent key (from AI Studio → Agents)")
+    parser.add_argument(
+        "--description",
+        default="",
+        help="Plain-text description of what the agent does (improves persona/scenario generation)",
+    )
+    parser.add_argument("--num-personas", type=int, default=3)
+    parser.add_argument("--num-scenarios", type=int, default=4)
+    parser.add_argument("--max-turns", type=int, default=8)
+    parser.add_argument("--output", default="data/results.jsonl", help="Output path for JSONL results (relative to project root)")
+    args = parser.parse_args()
+
+    if not os.getenv("ORQ_API_KEY"):
+        raise SystemExit("ORQ_API_KEY is not set")
+
+    if args.deployment:
+        # Deployment path: agent_key= routes through from_orq_deployment() internally,
+        # which calls evaluatorq.deployment.invoke — stateless prompt + model config.
+        target_key = args.deployment
+        agent_description = args.description or f"orq.ai deployment '{args.deployment}'"
+        target_kwargs: dict[str, Any] = {"agent_key": target_key}
+        logger.info(f"Target: deployment '{target_key}'")
+    else:
+        # A2A agent path: wrap client.agents.responses.create as a target_callback.
+        # Use this for full agents with memory, tools, and multi-step reasoning.
+        agent_description = args.description or f"orq.ai A2A agent '{args.agent}'"
+        target_kwargs = {"target_callback": make_a2a_callback(args.agent)}
+        logger.info(f"Target: A2A agent '{args.agent}' via Responses API")
+
+    logger.info(f"Generating {args.num_personas} personas × {args.num_scenarios} scenarios...")
+    results = await generate_and_simulate(
+        evaluation_name="orq-deployment-simulation-example",
+        agent_description=agent_description,
+        num_personas=args.num_personas,
+        num_scenarios=args.num_scenarios,
+        max_turns=args.max_turns,
+        evaluator_names=["goal_achieved", "criteria_met"],
+        parallelism=5,
+        **target_kwargs,
+    )
+
+    # Summary
+    passed = sum(r.goal_achieved for r in results)
+    if results:
+        logger.info(f"Pass rate: {passed}/{len(results)} ({100 * passed / len(results):.0f}%)")
+    else:
+        logger.warning("No results to summarise")
+
+    for r in results:
+        status = "PASS" if r.goal_achieved else "FAIL"
+        logger.info(f"  [{status}] score={r.goal_completion_score:.2f} turns={r.turn_count}")
+        logger.info(f"         terminated_by={r.terminated_by} rules_broken={r.rules_broken or []}")
+
+    # Export to JSONL for offline analysis or seeding an orq.ai Dataset
+    output_path = Path(__file__).parent.parent.parent / args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    export_results_to_jsonl(results, str(output_path))
+    logger.info(f"Results written to {output_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
@@ -59,13 +59,19 @@ def make_a2a_callback(agent_key: str) -> Callable[[list[Message]], Coroutine[Any
     full A2A agents in orq.ai - agents with memory, tool use, and multi-step
     reasoning, as opposed to stateless deployments (prompt + model config).
 
-    Each call sends only the latest user message; the A2A agent's server-side
-    memory provides conversation context across turns.
+    Each call sends only the latest user message. Conversation context is
+    preserved by threading the task_id returned from the first response into
+    subsequent calls (task_id= continues the existing agent execution), so the
+    agent's server-side state carries across turns.
     """
     from orq_ai_sdk import Orq
     from orq_ai_sdk.models import A2AMessage, TextPart
 
     client = Orq(api_key=os.getenv("ORQ_API_KEY", ""))
+
+    # Persists across turns within this callback's lifetime: the first call
+    # returns a task_id; later calls pass it back to continue the same execution.
+    state: dict[str, str] = {}
 
     async def callback(messages: list[Message]) -> str:
         last = messages[-1]
@@ -77,7 +83,11 @@ def make_a2a_callback(agent_key: str) -> Callable[[list[Message]], Coroutine[Any
             client.agents.responses.create,
             agent_key=agent_key,
             message=message,
+            task_id=state.get("task_id"),
         )
+        # Remember the task so the next turn continues this conversation.
+        if getattr(response, "task_id", None):
+            state["task_id"] = response.task_id
         # A2A response: output is List[AgentResponseMessage]; agent turns have
         # role == "agent" and TextPart entries in .parts (kind="text").
         texts = [

--- a/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
@@ -66,7 +66,7 @@ def make_a2a_callback(agent_key: str) -> Callable[[list[dict]], Coroutine[Any, A
     from orq_ai_sdk import Orq
     from orq_ai_sdk.models import A2AMessage, TextPart
 
-    client = Orq(api_key=os.environ["ORQ_API_KEY"])
+    client = Orq(api_key=os.getenv("ORQ_API_KEY", ""))
 
     async def callback(messages: list[dict]) -> str:
         last = messages[-1]
@@ -107,7 +107,7 @@ async def main() -> None:
     parser.add_argument("--num-personas", type=int, default=3)
     parser.add_argument("--num-scenarios", type=int, default=4)
     parser.add_argument("--max-turns", type=int, default=8)
-    parser.add_argument("--output", default="data/results.jsonl", help="Output path for JSONL results (relative to project root)")
+    parser.add_argument("--output", default="data/results.jsonl", help="Output path for JSONL results (relative to packages/evaluatorq-py/)")
     args = parser.parse_args()
 
     if not os.getenv("ORQ_API_KEY"):

--- a/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/02_orq_deployment_simulation.py
@@ -123,6 +123,7 @@ async def main() -> None:
     else:
         # A2A agent path: wrap client.agents.responses.create as a target_callback.
         # Use this for full agents with memory, tools, and multi-step reasoning.
+        assert args.agent is not None  # guaranteed by mutually exclusive group
         agent_description = args.description or f"orq.ai A2A agent '{args.agent}'"
         target_kwargs = {"target_callback": make_a2a_callback(args.agent)}
         logger.info(f"Target: A2A agent '{args.agent}' via Responses API")
@@ -152,7 +153,7 @@ async def main() -> None:
         logger.info(f"         terminated_by={r.terminated_by} rules_broken={r.rules_broken or []}")
 
     # Export to JSONL for offline analysis or seeding an orq.ai Dataset
-    output_path = Path.cwd() / args.output
+    output_path = Path(__file__).parent.parent.parent / args.output
     output_path.parent.mkdir(parents=True, exist_ok=True)
     export_results_to_jsonl(results, str(output_path))
     logger.info(f"Results written to {output_path}")

--- a/packages/evaluatorq-py/examples/agent_simulation/03_tool_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/03_tool_simulation.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Example: Simulating an agent that uses tools.
+
+Demonstrates how to test agents that make tool calls (e.g. look up orders,
+process refunds) without connecting to real external services. MockToolRegistry
+intercepts tool calls and returns configurable mock responses.
+
+Usage:
+    cd packages/evaluatorq-py
+    uv run python examples/agent_simulation/03_tool_simulation.py
+
+Where outputs land:
+- OTel spans appear automatically in orq.ai under orq.simulation.pipeline
+- SimulationResult objects are returned in memory (transcript, scores, etc.)
+- Tool call history is accessible via ToolSimulator.get_tool_call_history()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+from dotenv import load_dotenv
+from loguru import logger
+
+load_dotenv()
+
+# MockToolRegistry and ToolSimulator are part of the agent_simulation research
+# package. The production evaluatorq SDK does not ship these yet — they are
+# available when you install agent-simulation from this repository.
+from agent_simulation.tools import MockToolRegistry, ToolSimulator  # noqa: E402
+from evaluatorq.simulation import simulate  # noqa: E402
+from evaluatorq.simulation.types import (  # noqa: E402
+    CommunicationStyle,
+    Criterion,
+    Persona,
+    Scenario,
+    StartingEmotion,
+)
+
+
+async def tool_using_agent(messages: list[dict], tool_simulator: ToolSimulator) -> str:
+    """Mock agent that uses tools to answer questions.
+
+    In a real scenario this would be your LLM agent; here we fake tool calls
+    so the example runs without an API key for the target agent itself.
+    """
+    last = messages[-1]["content"].lower() if messages else ""
+
+    # Mimics the OpenAI function-call response format so ToolSimulator can intercept it
+    if "order" in last or "status" in last or "where" in last:
+        tool_call_response = {
+            "tool_calls": [{
+                "id": "call_001",
+                "type": "function",
+                "function": {
+                    "name": "get_order_status",
+                    "arguments": json.dumps({"order_id": "ORD-12345"}),
+                },
+            }]
+        }
+        tool_results = tool_simulator.execute_tools(tool_call_response)
+        if not tool_results:
+            return "I was unable to look up your order. Could you provide the order number?"
+        # content is a JSON string (json.dumps'd by ToolSimulator.execute_tools)
+        order_data = json.loads(tool_results[0].get("content", "{}"))
+        return (
+            f"I checked your order. Status: {order_data.get('status', 'unknown')}. "
+            f"Estimated delivery: {order_data.get('estimated_delivery', 'unknown')}."
+        )
+
+    if "refund" in last:
+        tool_call_response = {
+            "tool_calls": [{
+                "id": "call_002",
+                "type": "function",
+                "function": {
+                    "name": "process_refund",
+                    "arguments": json.dumps({"order_id": "ORD-12345", "amount": 49.99}),
+                },
+            }]
+        }
+        tool_results = tool_simulator.execute_tools(tool_call_response)
+        if not tool_results:
+            return "I was unable to process the refund. Please try again or contact support."
+        refund_data = json.loads(tool_results[0].get("content", "{}"))
+        return (
+            f"I've initiated your refund. Confirmation: {refund_data.get('refund_id', 'N/A')}. "
+            f"It should appear in 3-5 business days."
+        )
+
+    return "I'm here to help with your order. What can I assist you with?"
+
+
+async def main() -> None:
+    if not os.getenv("ORQ_API_KEY"):
+        raise SystemExit("ORQ_API_KEY is not set — needed for UserSimulator and Judge LLMs")
+
+    # 1. Set up mock tool registry with custom responses
+    registry = MockToolRegistry()
+
+    registry.register_tool(
+        name="get_order_status",
+        description="Look up the current status of an order by order ID",
+        parameters={
+            "type": "object",
+            "properties": {"order_id": {"type": "string", "description": "Order ID"}},
+            "required": ["order_id"],
+        },
+        mock_responses=[
+            {"status": "shipped", "estimated_delivery": "in 2 days", "carrier": "FedEx"},
+            {"status": "processing", "estimated_delivery": "in 4 days", "carrier": "UPS"},
+        ],
+    )
+
+    registry.register_tool(
+        name="process_refund",
+        description="Process a refund for an order",
+        parameters={
+            "type": "object",
+            "properties": {
+                "order_id": {"type": "string"},
+                "amount": {"type": "number"},
+            },
+            "required": ["order_id", "amount"],
+        },
+        mock_responses=[
+            {"refund_id": "REF-99001", "status": "initiated", "amount": 49.99},
+        ],
+    )
+
+    simulator = ToolSimulator(tool_registry=registry)
+
+    # 2. Wrap the agent so it has access to the tool simulator
+    async def agent_with_tools(messages: list[dict]) -> str:
+        return await tool_using_agent(messages, simulator)
+
+    # 3. Define a scenario that will trigger tool use
+    persona = Persona(
+        name="Curious Shopper",
+        patience=0.7,
+        assertiveness=0.5,
+        politeness=0.8,
+        technical_level=0.4,
+        communication_style=CommunicationStyle.casual,
+        background="Waiting on a package and wants an update",
+    )
+
+    scenario = Scenario(
+        name="Order Status Check",
+        goal="Find out where my order is and get a refund if it's delayed",
+        context="Customer placed an order a week ago and hasn't received it yet",
+        starting_emotion=StartingEmotion.neutral,
+        criteria=[
+            Criterion(description="Agent looks up the order status", type="must_happen"),
+            Criterion(description="Agent provides a specific delivery estimate", type="must_happen"),
+            Criterion(
+                description="Agent makes up tracking information without checking",
+                type="must_not_happen",
+            ),
+        ],
+    )
+
+    # 4. Run simulation
+    # target_callback= accepts any async function; use agent_key= for orq.ai deployments.
+    results = await simulate(
+        evaluation_name="tool-simulation-example",
+        target_callback=agent_with_tools,
+        personas=[persona],
+        scenarios=[scenario],
+        max_turns=6,
+        evaluator_names=["goal_achieved", "criteria_met"],
+    )
+
+    # 5. Inspect tool call history and results
+    if not results:
+        logger.warning("No results returned — check ORQ_API_KEY and network connectivity")
+        return
+
+    tool_history = simulator.get_tool_call_history()
+    logger.info(f"Tool calls made: {len(tool_history)}")
+    for call in tool_history:
+        logger.info(f"  → {call['tool']}: {call['args']}")
+
+    result = results[0]
+    logger.info(f"Goal achieved: {result.goal_achieved}")
+    logger.info(f"Goal completion score: {result.goal_completion_score:.2f}")
+    logger.info(f"Turns: {result.turn_count}")
+
+    logger.info("--- Conversation ---")
+    for msg in result.messages:
+        role = "User" if msg.role == "user" else "Agent"
+        logger.info(f"{role}: {msg.content}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/evaluatorq-py/examples/agent_simulation/03_tool_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/03_tool_simulation.py
@@ -5,6 +5,11 @@ Demonstrates how to test agents that make tool calls (e.g. look up orders,
 process refunds) without connecting to real external services. MockToolRegistry
 intercepts tool calls and returns configurable mock responses.
 
+Prerequisites:
+    Install the agent-simulation research package (not on PyPI — install from source):
+
+        pip install "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
+
 Usage:
     cd packages/evaluatorq-py
     uv run python examples/agent_simulation/03_tool_simulation.py

--- a/packages/evaluatorq-py/examples/agent_simulation/03_tool_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/03_tool_simulation.py
@@ -186,9 +186,12 @@ async def main() -> None:
     )
 
     # 5. Inspect tool call history and results
+    # One persona x one scenario should yield exactly one result. An empty list
+    # means the run failed for every datapoint - treat it as an error and inspect
+    # the OTel spans under orq.simulation.pipeline rather than exiting cleanly.
     if not results:
-        logger.warning("No results returned - check ORQ_API_KEY and network connectivity")
-        return
+        logger.error("Simulation produced no results - the run failed; check OTel spans under orq.simulation.pipeline")
+        raise SystemExit(1)
 
     tool_history = simulator.get_tool_call_history()
     logger.info(f"Tool calls made: {len(tool_history)}")

--- a/packages/evaluatorq-py/examples/agent_simulation/03_tool_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/03_tool_simulation.py
@@ -31,10 +31,14 @@ from loguru import logger
 
 load_dotenv()
 
-# MockToolRegistry and ToolSimulator are part of the agent_simulation research
-# package. The production evaluatorq SDK does not ship these yet — they are
-# available when you install agent-simulation from this repository.
-from agent_simulation.tools import MockToolRegistry, ToolSimulator  # noqa: E402
+try:
+    from agent_simulation.tools import MockToolRegistry, ToolSimulator  # noqa: E402
+except ImportError as e:
+    raise ImportError(
+        'agent-simulation package not found. Install from source:\n'
+        '  uv pip install "agent-simulation @ git+https://github.com/orq-ai/research.git'
+        '#subdirectory=projects/agent-simulation"'
+    ) from e
 from evaluatorq.simulation import simulate  # noqa: E402
 from evaluatorq.simulation.types import (  # noqa: E402
     CommunicationStyle,

--- a/packages/evaluatorq-py/examples/agent_simulation/03_tool_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/03_tool_simulation.py
@@ -16,7 +16,9 @@ Usage:
 
 Where outputs land:
 - OTel spans appear automatically in orq.ai under orq.simulation.pipeline
-- SimulationResult objects are returned in memory (transcript, scores, etc.)
+- An Experiment row is created in orq.ai by default when ORQ_API_KEY is set
+  (pass upload_results=False to simulate() to suppress this)
+- SimulationResult objects are also returned in memory (transcript, scores, etc.)
 - Tool call history is accessible via ToolSimulator.get_tool_call_history()
 """
 
@@ -39,6 +41,7 @@ except ImportError as e:
         '  uv pip install "agent-simulation @ git+https://github.com/orq-ai/research.git'
         '#subdirectory=projects/agent-simulation"'
     ) from e
+from evaluatorq.contracts import Message  # noqa: E402
 from evaluatorq.simulation import simulate  # noqa: E402
 from evaluatorq.simulation.types import (  # noqa: E402
     CommunicationStyle,
@@ -49,13 +52,13 @@ from evaluatorq.simulation.types import (  # noqa: E402
 )
 
 
-async def tool_using_agent(messages: list[dict], tool_simulator: ToolSimulator) -> str:
+async def tool_using_agent(messages: list[Message], tool_simulator: ToolSimulator) -> str:
     """Mock agent that uses tools to answer questions.
 
     In a real scenario this would be your LLM agent; here we fake tool calls
     so the example runs without an API key for the target agent itself.
     """
-    last = messages[-1]["content"].lower() if messages else ""
+    last = (messages[-1].content or "").lower() if messages else ""
 
     # Mimics the OpenAI function-call response format so ToolSimulator can intercept it
     if "order" in last or "status" in last or "where" in last:
@@ -142,7 +145,7 @@ async def main() -> None:
     simulator = ToolSimulator(tool_registry=registry)
 
     # 2. Wrap the agent so it has access to the tool simulator
-    async def agent_with_tools(messages: list[dict]) -> str:
+    async def agent_with_tools(messages: list[Message]) -> str:
         return await tool_using_agent(messages, simulator)
 
     # 3. Define a scenario that will trigger tool use

--- a/packages/evaluatorq-py/examples/agent_simulation/03_tool_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/03_tool_simulation.py
@@ -34,16 +34,16 @@ from loguru import logger
 load_dotenv()
 
 try:
-    from agent_simulation.tools import MockToolRegistry, ToolSimulator  # noqa: E402
+    from agent_simulation.tools import MockToolRegistry, ToolSimulator
 except ImportError as e:
     raise ImportError(
         'agent-simulation package not found. Install from source:\n'
         '  uv pip install "agent-simulation @ git+https://github.com/orq-ai/research.git'
         '#subdirectory=projects/agent-simulation"'
     ) from e
-from evaluatorq.contracts import Message  # noqa: E402
-from evaluatorq.simulation import simulate  # noqa: E402
-from evaluatorq.simulation.types import (  # noqa: E402
+from evaluatorq.contracts import Message
+from evaluatorq.simulation import simulate
+from evaluatorq.simulation.types import (
     CommunicationStyle,
     Criterion,
     Persona,
@@ -52,7 +52,7 @@ from evaluatorq.simulation.types import (  # noqa: E402
 )
 
 
-async def tool_using_agent(messages: list[Message], tool_simulator: ToolSimulator) -> str:
+async def tool_using_agent(messages: list[Message], tool_simulator: ToolSimulator) -> str:  # noqa: RUF029
     """Mock agent that uses tools to answer questions.
 
     In a real scenario this would be your LLM agent; here we fake tool calls

--- a/packages/evaluatorq-py/examples/agent_simulation/03_tool_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/03_tool_simulation.py
@@ -6,7 +6,7 @@ process refunds) without connecting to real external services. MockToolRegistry
 intercepts tool calls and returns configurable mock responses.
 
 Prerequisites:
-    Install the agent-simulation research package (not on PyPI — install from source):
+    Install the agent-simulation research package (not on PyPI - install from source):
 
         uv pip install "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
 
@@ -107,7 +107,7 @@ async def tool_using_agent(messages: list[Message], tool_simulator: ToolSimulato
 
 async def main() -> None:
     if not os.getenv("ORQ_API_KEY"):
-        raise SystemExit("ORQ_API_KEY is not set — needed for UserSimulator and Judge LLMs")
+        raise SystemExit("ORQ_API_KEY is not set - needed for UserSimulator and Judge LLMs")
 
     # 1. Set up mock tool registry with custom responses
     registry = MockToolRegistry()
@@ -187,13 +187,13 @@ async def main() -> None:
 
     # 5. Inspect tool call history and results
     if not results:
-        logger.warning("No results returned — check ORQ_API_KEY and network connectivity")
+        logger.warning("No results returned - check ORQ_API_KEY and network connectivity")
         return
 
     tool_history = simulator.get_tool_call_history()
     logger.info(f"Tool calls made: {len(tool_history)}")
     for call in tool_history:
-        logger.info(f"  → {call['tool']}: {call['args']}")
+        logger.info(f"  -> {call['tool']}: {call['args']}")
 
     result = results[0]
     logger.info(f"Goal achieved: {result.goal_achieved}")

--- a/packages/evaluatorq-py/examples/agent_simulation/03_tool_simulation.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/03_tool_simulation.py
@@ -8,7 +8,7 @@ intercepts tool calls and returns configurable mock responses.
 Prerequisites:
     Install the agent-simulation research package (not on PyPI — install from source):
 
-        pip install "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
+        uv pip install "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
 
 Usage:
     cd packages/evaluatorq-py

--- a/packages/evaluatorq-py/examples/agent_simulation/04_hardening_loop.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/04_hardening_loop.py
@@ -2,8 +2,8 @@
 """Example: Iterative agent instruction improvement with the hardening loop.
 
 NOTE: This example uses two packages:
-- evaluatorq.simulation.types — production SDK types (Persona, Scenario, Criterion, enums)
-- agent_simulation — research package for HardeningLoop (not in production evaluatorq yet)
+- evaluatorq.simulation.types - production SDK types (Persona, Scenario, Criterion, enums)
+- agent_simulation - research package for HardeningLoop (not in production evaluatorq yet)
 
 String literals (e.g. communication_style="casual") are used instead of enum values
 because agent_simulation.models.persona.Persona uses Pydantic Literal types, not enums.
@@ -19,7 +19,7 @@ This is especially useful when you have a set of test scenarios and want the
 agent's instructions to pass them reliably.
 
 Prerequisites:
-    Install the agent-simulation research package (not on PyPI — install from source):
+    Install the agent-simulation research package (not on PyPI - install from source):
 
         uv pip install "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
 
@@ -54,7 +54,7 @@ except ImportError as e:
 
 from evaluatorq.contracts import Message
 
-# A deliberately weak set of instructions — the loop will improve these
+# A deliberately weak set of instructions - the loop will improve these
 INITIAL_INSTRUCTIONS = """
 You are a customer support agent. Help customers with their questions.
 Be helpful and polite.
@@ -79,7 +79,7 @@ def make_agent(instructions: str) -> Callable[[list[Message]], Awaitable[str]]:
             return "I'll process that refund. What's your order number?"
         if "cancel" in last:
             if can_cancel:
-                return "Of course — I can cancel that order for you. What's the order number?"
+                return "Of course - I can cancel that order for you. What's the order number?"
             # Deliberately bad until the hardening loop improves the instructions
             return "I'm sorry, I cannot help with cancellations."
         if "speak" in last and "manager" in last:
@@ -91,7 +91,7 @@ def make_agent(instructions: str) -> Callable[[list[Message]], Awaitable[str]]:
 
 async def main() -> None:
     if not os.getenv("ORQ_API_KEY"):
-        raise SystemExit("ORQ_API_KEY is not set — needed for DiagnosisAgent and FixGeneratorAgent")
+        raise SystemExit("ORQ_API_KEY is not set - needed for DiagnosisAgent and FixGeneratorAgent")
 
     datapoints = [
         Datapoint.generate(
@@ -164,7 +164,7 @@ async def main() -> None:
     ) as loop:
         report = await loop.harden(datapoints, max_iterations=3)
 
-    logger.info(f"Pass rate: {report.original_pass_rate:.0%} → {report.final_pass_rate:.0%}")
+    logger.info(f"Pass rate: {report.original_pass_rate:.0%} -> {report.final_pass_rate:.0%}")
     logger.info(f"Iterations: {report.total_iterations}")
 
     logger.info("--- Improved Instructions ---")
@@ -172,7 +172,7 @@ async def main() -> None:
 
     logger.info("--- Iteration Summary ---")
     for i, iteration in enumerate(report.iterations, 1):
-        logger.info(f"Iteration {i}: {iteration.pass_rate_before:.0%} → {iteration.pass_rate_after:.0%}")
+        logger.info(f"Iteration {i}: {iteration.pass_rate_before:.0%} -> {iteration.pass_rate_after:.0%}")
 
 
 if __name__ == "__main__":

--- a/packages/evaluatorq-py/examples/agent_simulation/04_hardening_loop.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/04_hardening_loop.py
@@ -39,11 +39,18 @@ from loguru import logger
 
 load_dotenv()
 
-from agent_simulation import SimulationRunner  # noqa: E402
-from agent_simulation.hardening import HardeningLoop  # noqa: E402
-from agent_simulation.models.datapoint import Datapoint  # noqa: E402
-from agent_simulation.models.persona import Persona  # noqa: E402
-from agent_simulation.models.scenario import Criterion, Scenario  # noqa: E402
+try:
+    from agent_simulation import SimulationRunner  # noqa: E402
+    from agent_simulation.hardening import HardeningLoop  # noqa: E402
+    from agent_simulation.models.datapoint import Datapoint  # noqa: E402
+    from agent_simulation.models.persona import Persona  # noqa: E402
+    from agent_simulation.models.scenario import Criterion, Scenario  # noqa: E402
+except ImportError as e:
+    raise ImportError(
+        'agent-simulation package not found. Install from source:\n'
+        '  uv pip install "agent-simulation @ git+https://github.com/orq-ai/research.git'
+        '#subdirectory=projects/agent-simulation"'
+    ) from e
 
 
 # A deliberately weak set of instructions — the loop will improve these

--- a/packages/evaluatorq-py/examples/agent_simulation/04_hardening_loop.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/04_hardening_loop.py
@@ -40,11 +40,11 @@ from loguru import logger
 load_dotenv()
 
 try:
-    from agent_simulation import SimulationRunner  # noqa: E402
-    from agent_simulation.hardening import HardeningLoop  # noqa: E402
-    from agent_simulation.models.datapoint import Datapoint  # noqa: E402
-    from agent_simulation.models.persona import Persona  # noqa: E402
-    from agent_simulation.models.scenario import Criterion, Scenario  # noqa: E402
+    from agent_simulation import SimulationRunner
+    from agent_simulation.hardening import HardeningLoop
+    from agent_simulation.models.datapoint import Datapoint
+    from agent_simulation.models.persona import Persona
+    from agent_simulation.models.scenario import Criterion, Scenario
 except ImportError as e:
     raise ImportError(
         'agent-simulation package not found. Install from source:\n'
@@ -52,8 +52,7 @@ except ImportError as e:
         '#subdirectory=projects/agent-simulation"'
     ) from e
 
-from evaluatorq.contracts import Message  # noqa: E402
-
+from evaluatorq.contracts import Message
 
 # A deliberately weak set of instructions — the loop will improve these
 INITIAL_INSTRUCTIONS = """
@@ -74,7 +73,7 @@ def make_agent(instructions: str) -> Callable[[list[Message]], Awaitable[str]]:
     """
     can_cancel = "cancellation" in instructions.lower() or "cancel" in instructions.lower()
 
-    async def agent(messages: list[Message]) -> str:
+    async def agent(messages: list[Message]) -> str:  # noqa: RUF029
         last = (messages[-1].content or "").lower() if messages else ""
         if "refund" in last:
             return "I'll process that refund. What's your order number?"

--- a/packages/evaluatorq-py/examples/agent_simulation/04_hardening_loop.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/04_hardening_loop.py
@@ -18,6 +18,11 @@ Demonstrates how to automatically improve an agent's system prompt by:
 This is especially useful when you have a set of test scenarios and want the
 agent's instructions to pass them reliably.
 
+Prerequisites:
+    Install the agent-simulation research package (not on PyPI — install from source):
+
+        pip install "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
+
 Usage:
     cd packages/evaluatorq-py
     uv run python examples/agent_simulation/04_hardening_loop.py

--- a/packages/evaluatorq-py/examples/agent_simulation/04_hardening_loop.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/04_hardening_loop.py
@@ -52,6 +52,8 @@ except ImportError as e:
         '#subdirectory=projects/agent-simulation"'
     ) from e
 
+from evaluatorq.contracts import Message  # noqa: E402
+
 
 # A deliberately weak set of instructions — the loop will improve these
 INITIAL_INSTRUCTIONS = """
@@ -60,7 +62,7 @@ Be helpful and polite.
 """
 
 
-def make_agent(instructions: str) -> Callable[[list[dict]], Awaitable[str]]:
+def make_agent(instructions: str) -> Callable[[list[Message]], Awaitable[str]]:
     """Return an agent callback whose behaviour reflects the given instructions.
 
     The mock checks whether key phrases have been added to the instructions by
@@ -72,8 +74,8 @@ def make_agent(instructions: str) -> Callable[[list[dict]], Awaitable[str]]:
     """
     can_cancel = "cancellation" in instructions.lower() or "cancel" in instructions.lower()
 
-    async def agent(messages: list[dict]) -> str:
-        last = messages[-1]["content"].lower() if messages else ""
+    async def agent(messages: list[Message]) -> str:
+        last = (messages[-1].content or "").lower() if messages else ""
         if "refund" in last:
             return "I'll process that refund. What's your order number?"
         if "cancel" in last:

--- a/packages/evaluatorq-py/examples/agent_simulation/04_hardening_loop.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/04_hardening_loop.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Example: Iterative agent instruction improvement with the hardening loop.
+
+NOTE: This example uses two packages:
+- evaluatorq.simulation.types — production SDK types (Persona, Scenario, Criterion, enums)
+- agent_simulation — research package for HardeningLoop (not in production evaluatorq yet)
+
+String literals (e.g. communication_style="casual") are used instead of enum values
+because agent_simulation.models.persona.Persona uses Pydantic Literal types, not enums.
+Pydantic coerces them correctly at runtime.
+
+Demonstrates how to automatically improve an agent's system prompt by:
+1. Running simulations to find failures
+2. Diagnosing why the agent failed
+3. Generating targeted instruction fixes
+4. Re-running to verify improvement
+
+This is especially useful when you have a set of test scenarios and want the
+agent's instructions to pass them reliably.
+
+Usage:
+    cd packages/evaluatorq-py
+    uv run python examples/agent_simulation/04_hardening_loop.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Awaitable, Callable
+
+from dotenv import load_dotenv
+from loguru import logger
+
+load_dotenv()
+
+from agent_simulation import SimulationRunner  # noqa: E402
+from agent_simulation.hardening import HardeningLoop  # noqa: E402
+from agent_simulation.models.datapoint import Datapoint  # noqa: E402
+from agent_simulation.models.persona import Persona  # noqa: E402
+from agent_simulation.models.scenario import Criterion, Scenario  # noqa: E402
+
+
+# A deliberately weak set of instructions — the loop will improve these
+INITIAL_INSTRUCTIONS = """
+You are a customer support agent. Help customers with their questions.
+Be helpful and polite.
+"""
+
+
+def make_agent(instructions: str) -> Callable[[list[dict]], Awaitable[str]]:
+    """Return an agent callback whose behaviour reflects the given instructions.
+
+    The mock checks whether key phrases have been added to the instructions by
+    the hardening loop, and unlocks better responses accordingly. This lets the
+    example show a real pass-rate improvement across iterations without needing
+    a live LLM for the target agent.
+
+    In production, pass `instructions` as the system prompt to your LLM agent.
+    """
+    can_cancel = "cancellation" in instructions.lower() or "cancel" in instructions.lower()
+
+    async def agent(messages: list[dict]) -> str:
+        last = messages[-1]["content"].lower() if messages else ""
+        if "refund" in last:
+            return "I'll process that refund. What's your order number?"
+        if "cancel" in last:
+            if can_cancel:
+                return "Of course — I can cancel that order for you. What's the order number?"
+            # Deliberately bad until the hardening loop improves the instructions
+            return "I'm sorry, I cannot help with cancellations."
+        if "speak" in last and "manager" in last:
+            return "Of course, let me connect you with a manager right away."
+        return "How can I help you today?"
+
+    return agent
+
+
+async def main() -> None:
+    if not os.getenv("ORQ_API_KEY"):
+        raise SystemExit("ORQ_API_KEY is not set — needed for DiagnosisAgent and FixGeneratorAgent")
+
+    datapoints = [
+        Datapoint.generate(
+            persona=Persona(
+                name="Cancellation Customer",
+                patience=0.4,
+                assertiveness=0.7,
+                politeness=0.6,
+                technical_level=0.3,
+                communication_style="casual",
+                background="Wants to cancel an order placed by mistake",
+                emotional_arc="escalating",
+            ),
+            scenario=Scenario(
+                name="Order Cancellation",
+                goal="Cancel my order",
+                context="Customer placed an order 10 minutes ago and wants to cancel",
+                starting_emotion="urgent",
+                criteria=[
+                    Criterion(description="Agent helps with the cancellation", type="must_happen"),
+                    Criterion(description="Agent refuses or deflects the request", type="must_not_happen"),
+                ],
+            ),
+        ),
+        Datapoint.generate(
+            persona=Persona(
+                name="Refund Seeker",
+                patience=0.3,
+                assertiveness=0.8,
+                politeness=0.5,
+                technical_level=0.2,
+                communication_style="terse",
+                background="Received a damaged product",
+                emotional_arc="escalating",
+            ),
+            scenario=Scenario(
+                name="Damaged Product Refund",
+                goal="Get a full refund for the damaged item",
+                context="Customer received a broken laptop charger",
+                starting_emotion="frustrated",
+                criteria=[
+                    Criterion(description="Agent initiates the refund process", type="must_happen"),
+                    Criterion(description="Agent asks for proof of damage", type="must_happen"),
+                ],
+            ),
+        ),
+    ]
+
+    # Run the hardening loop.
+    # Use a mutable container so on_instructions_updated can swap the active agent
+    # without a nonlocal rebind across the closure boundary. In production, use this
+    # hook to push new_instructions as a system prompt to your LLM instead.
+    logger.info("Starting hardening loop...")
+    logger.info(f"Initial instructions:\n{INITIAL_INSTRUCTIONS.strip()}")
+
+    current_agent: list[Callable[[list[dict]], Awaitable[str]]] = [make_agent(INITIAL_INSTRUCTIONS)]
+
+    async def agent_proxy(messages: list[dict]) -> str:
+        return await current_agent[0](messages)
+
+    runner = SimulationRunner(target_callback=agent_proxy, max_turns=6)
+
+    def on_instructions_updated(new_instructions: str) -> None:
+        current_agent[0] = make_agent(new_instructions)
+
+    async with HardeningLoop(
+        runner,
+        INITIAL_INSTRUCTIONS,
+        on_instructions_updated=on_instructions_updated,
+    ) as loop:
+        report = await loop.harden(datapoints, max_iterations=3)
+
+    logger.info(f"Pass rate: {report.original_pass_rate:.0%} → {report.final_pass_rate:.0%}")
+    logger.info(f"Iterations: {report.total_iterations}")
+
+    logger.info("--- Improved Instructions ---")
+    logger.info(report.improved_instructions)
+
+    logger.info("--- Iteration Summary ---")
+    for i, iteration in enumerate(report.iterations, 1):
+        logger.info(f"Iteration {i}: {iteration.pass_rate_before:.0%} → {iteration.pass_rate_after:.0%}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/evaluatorq-py/examples/agent_simulation/04_hardening_loop.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/04_hardening_loop.py
@@ -21,7 +21,7 @@ agent's instructions to pass them reliably.
 Prerequisites:
     Install the agent-simulation research package (not on PyPI — install from source):
 
-        pip install "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
+        uv pip install "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
 
 Usage:
     cd packages/evaluatorq-py

--- a/packages/evaluatorq-py/examples/agent_simulation/04_hardening_loop.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/04_hardening_loop.py
@@ -148,9 +148,9 @@ async def main() -> None:
     logger.info("Starting hardening loop...")
     logger.info(f"Initial instructions:\n{INITIAL_INSTRUCTIONS.strip()}")
 
-    current_agent: list[Callable[[list[dict]], Awaitable[str]]] = [make_agent(INITIAL_INSTRUCTIONS)]
+    current_agent: list[Callable[[list[Message]], Awaitable[str]]] = [make_agent(INITIAL_INSTRUCTIONS)]
 
-    async def agent_proxy(messages: list[dict]) -> str:
+    async def agent_proxy(messages: list[Message]) -> str:
         return await current_agent[0](messages)
 
     runner = SimulationRunner(target_callback=agent_proxy, max_turns=6)

--- a/packages/evaluatorq-py/examples/agent_simulation/05_wrap_and_experiment.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/05_wrap_and_experiment.py
@@ -7,7 +7,7 @@ simulate() call in two important ways:
 1. wrap_simulation_agent() creates a job function that evaluatorq() calls once per
    DataPoint, reusing the resolved agent callback across the batch.
 2. evaluatorq() handles CI gating, result display, and auto-upload to orq.ai
-   Experiments — so results land in the Experiments table and are linked to the
+   Experiments - so results land in the Experiments table and are linked to the
    deployment, not just returned in memory.
 
 Use this pattern when:
@@ -25,7 +25,7 @@ Usage:
         --deployment my-support-agent
 
 Where outputs land:
-- Experiment row created in orq.ai — URL printed to stdout on completion
+- Experiment row created in orq.ai - URL printed to stdout on completion
 - OTel spans under orq.job / orq.simulation.run / orq.simulation.turn
 - SimulationResult objects converted to OpenResponses format and returned
   as DataPointResult.output by evaluatorq()
@@ -57,7 +57,7 @@ from evaluatorq.simulation.types import (
 
 
 async def main() -> None:
-    parser = argparse.ArgumentParser(description="Simulation wired into evaluatorq() — the production pattern")
+    parser = argparse.ArgumentParser(description="Simulation wired into evaluatorq() - the production pattern")
     parser.add_argument("--deployment", "-d", required=True, help="orq.ai deployment key (from AI Studio)")
     parser.add_argument("--max-turns", type=int, default=6)
     args = parser.parse_args()
@@ -127,7 +127,7 @@ async def main() -> None:
     logger.info(f"Running {len(data)} simulations ({len(personas)} personas x {len(scenarios)} scenarios)")
 
     # 3. Create the simulation job.
-    #    agent_key= is the orq.ai deployment key — routes through from_orq_deployment() internally.
+    #    agent_key= is the orq.ai deployment key - routes through from_orq_deployment() internally.
     #    Use target_callback= for local functions or third-party agents.
     job = wrap_simulation_agent(
         name="support-simulation",
@@ -148,7 +148,7 @@ async def main() -> None:
     finally:
         await job.aclose()
 
-    logger.info("Simulation complete — check orq.ai Experiments for results")
+    logger.info("Simulation complete - check orq.ai Experiments for results")
 
 
 if __name__ == "__main__":

--- a/packages/evaluatorq-py/examples/agent_simulation/05_wrap_and_experiment.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/05_wrap_and_experiment.py
@@ -15,8 +15,9 @@ Use this pattern when:
 - You are running simulations as part of a CI/CD pipeline
 - You need to compose simulation scoring with other evaluatorq evaluators
 
-Use simulate() (see basic_simulation or orq_deployment_simulation) when you
-just want results back in memory for a one-off exploratory run.
+Use simulate() or generate_and_simulate() (see examples 01–02) when you want
+a simpler call without composing alongside other evaluatorq evaluators, or
+when you want to pass upload_results=False to suppress the Experiment upload.
 
 Usage:
     cd packages/evaluatorq-py

--- a/packages/evaluatorq-py/examples/agent_simulation/05_wrap_and_experiment.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/05_wrap_and_experiment.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Example: Production simulation with wrap_simulation_agent() + evaluatorq().
+
+This is the recommended pattern for production use. It differs from the bare
+simulate() call in two important ways:
+
+1. wrap_simulation_agent() creates a job function that evaluatorq() calls once per
+   DataPoint, reusing the resolved agent callback across the batch.
+2. evaluatorq() handles CI gating, result display, and auto-upload to orq.ai
+   Experiments — so results land in the Experiments table and are linked to the
+   deployment, not just returned in memory.
+
+Use this pattern when:
+- You want Experiment rows in orq.ai with a URL you can share with stakeholders
+- You are running simulations as part of a CI/CD pipeline
+- You need to compose simulation scoring with other evaluatorq evaluators
+
+Use simulate() (see basic_simulation or orq_deployment_simulation) when you
+just want results back in memory for a one-off exploratory run.
+
+Usage:
+    cd packages/evaluatorq-py
+    uv run python examples/agent_simulation/05_wrap_and_experiment.py \
+        --deployment my-support-agent
+
+Where outputs land:
+- Experiment row created in orq.ai — URL printed to stdout on completion
+- OTel spans under orq.job / orq.simulation.run / orq.simulation.turn
+- SimulationResult objects converted to OpenResponses format and returned
+  as DataPointResult.output by evaluatorq()
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+
+from dotenv import load_dotenv
+from loguru import logger
+
+# load_dotenv() runs before local imports so env vars are set before any
+# library init code that reads them (e.g. evaluatorq tracing setup).
+load_dotenv()
+
+from evaluatorq import DataPoint, evaluatorq  # noqa: E402
+from evaluatorq.simulation import wrap_simulation_agent  # noqa: E402
+from evaluatorq.simulation.types import (  # noqa: E402
+    CommunicationStyle,
+    Criterion,
+    EmotionalArc,
+    Persona,
+    Scenario,
+    StartingEmotion,
+)
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Simulation wired into evaluatorq() — the production pattern")
+    parser.add_argument("--deployment", "-d", required=True, help="orq.ai deployment key (from AI Studio)")
+    parser.add_argument("--max-turns", type=int, default=6)
+    args = parser.parse_args()
+
+    if not os.getenv("ORQ_API_KEY"):
+        raise SystemExit("ORQ_API_KEY is not set")
+
+    # 1. Define personas and scenarios.
+    #    The DataPoint wraps each (persona, scenario) pair for the evaluatorq() framework.
+    personas = [
+        Persona(
+            name="Impatient Customer",
+            patience=0.2,
+            assertiveness=0.8,
+            politeness=0.4,
+            technical_level=0.3,
+            communication_style=CommunicationStyle.terse,
+            background="Received the wrong item and wants a refund urgently",
+            emotional_arc=EmotionalArc.escalating,
+        ),
+        Persona(
+            name="Polite First-Timer",
+            patience=0.8,
+            assertiveness=0.3,
+            politeness=0.9,
+            technical_level=0.2,
+            communication_style=CommunicationStyle.formal,
+            background="First time contacting support, unfamiliar with the process",
+        ),
+    ]
+
+    scenarios = [
+        Scenario(
+            name="Wrong Item Refund",
+            goal="Get a full refund for the wrong item received",
+            context="Customer ordered headphones but received a phone case instead",
+            starting_emotion=StartingEmotion.frustrated,
+            criteria=[
+                Criterion(description="Agent asks for order details", type="must_happen"),
+                Criterion(description="Agent acknowledges the mistake", type="must_happen"),
+                Criterion(description="Agent blames the customer", type="must_not_happen"),
+            ],
+        ),
+        Scenario(
+            name="Delivery Status",
+            goal="Find out when the order will arrive",
+            context="Customer placed an order 5 days ago and hasn't received it",
+            starting_emotion=StartingEmotion.neutral,
+            criteria=[
+                Criterion(description="Agent provides a specific timeline or tracking info", type="must_happen"),
+                Criterion(description="Agent makes up a delivery date without checking", type="must_not_happen"),
+            ],
+            is_edge_case=False,  # explicitly False here to contrast with edge-case scenarios
+        ),
+    ]
+
+    # 2. Build a DataPoint for each (persona, scenario) pair.
+    #    wrap_simulation_agent() reads inputs["persona"] and inputs["scenario"].
+    data = [
+        DataPoint(inputs={
+            "persona": persona.model_dump(),
+            "scenario": scenario.model_dump(),
+        })
+        for persona in personas
+        for scenario in scenarios
+    ]
+    logger.info(f"Running {len(data)} simulations ({len(personas)} personas × {len(scenarios)} scenarios)")
+
+    # 3. Create the simulation job.
+    #    agent_key= is the orq.ai deployment key — routes through from_orq_deployment() internally.
+    #    Use target_callback= for local functions or third-party agents.
+    job = wrap_simulation_agent(
+        name="support-simulation",
+        agent_key=args.deployment,
+        max_turns=args.max_turns,
+    )
+
+    # 4. Run via evaluatorq() for Experiment upload, CI gating, and result display.
+    #    The Experiment URL is printed to stdout when the run finishes.
+    #    job.aclose() releases the wrapper's long-lived simulation runner and HTTP client.
+    try:
+        await evaluatorq(
+            "support-agent-simulation",
+            data=data,
+            jobs=[job],
+            evaluators=[],  # add evaluatorq scorers here if needed
+        )
+    finally:
+        await job.aclose()
+
+    logger.info("Simulation complete — check orq.ai Experiments for results")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/evaluatorq-py/examples/agent_simulation/05_wrap_and_experiment.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/05_wrap_and_experiment.py
@@ -15,7 +15,7 @@ Use this pattern when:
 - You are running simulations as part of a CI/CD pipeline
 - You need to compose simulation scoring with other evaluatorq evaluators
 
-Use simulate() or generate_and_simulate() (see examples 01–02) when you want
+Use simulate() or generate_and_simulate() (see examples 01-02) when you want
 a simpler call without composing alongside other evaluatorq evaluators, or
 when you want to pass upload_results=False to suppress the Experiment upload.
 
@@ -44,9 +44,9 @@ from loguru import logger
 # library init code that reads them (e.g. evaluatorq tracing setup).
 load_dotenv()
 
-from evaluatorq import DataPoint, evaluatorq  # noqa: E402
-from evaluatorq.simulation import wrap_simulation_agent  # noqa: E402
-from evaluatorq.simulation.types import (  # noqa: E402
+from evaluatorq import DataPoint, evaluatorq
+from evaluatorq.simulation import wrap_simulation_agent
+from evaluatorq.simulation.types import (
     CommunicationStyle,
     Criterion,
     EmotionalArc,
@@ -124,7 +124,7 @@ async def main() -> None:
         for persona in personas
         for scenario in scenarios
     ]
-    logger.info(f"Running {len(data)} simulations ({len(personas)} personas × {len(scenarios)} scenarios)")
+    logger.info(f"Running {len(data)} simulations ({len(personas)} personas x {len(scenarios)} scenarios)")
 
     # 3. Create the simulation job.
     #    agent_key= is the orq.ai deployment key — routes through from_orq_deployment() internally.

--- a/packages/evaluatorq-py/examples/agent_simulation/README.md
+++ b/packages/evaluatorq-py/examples/agent_simulation/README.md
@@ -8,12 +8,21 @@ Python examples for simulating user interactions against AI agents - testing goa
 uv pip install evaluatorq
 ```
 
-> **Examples 03 and 04** (`03_tool_simulation.py`, `04_hardening_loop.py`) also require the
-> `agent-simulation` research package (not on PyPI - install from source):
+> **Examples 03 and 04** (`03_tool_simulation.py`, `04_hardening_loop.py`) are **preview**: they depend on the
+> `agent-simulation` research package, which is not on PyPI and not yet part of the production SDK. Install from source:
 >
 > ```bash
 > uv pip install "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
 > ```
+>
+> Examples 01, 02, and 05 only need `evaluatorq` and are the recommended starting points.
+
+## Where to start
+
+- **No agent yet?** Run `01_basic_simulation.py` — exercises the loop against a local mock callback.
+- **Have an orq.ai deployment or A2A agent?** Run `02_orq_deployment_simulation.py --deployment <key>`.
+- **Wiring simulations into a CI/CD pipeline?** See `05_wrap_and_experiment.py` for the production pattern.
+- **Tool-using agents / instruction hardening?** See `03` and `04` (preview, see note above).
 
 ## Quick Start
 
@@ -27,14 +36,28 @@ uv run python examples/agent_simulation/01_basic_simulation.py
 uv run python examples/agent_simulation/02_orq_deployment_simulation.py --deployment my-support-agent
 ```
 
+### Expected output
+
+A successful run prints per-simulation pass/fail lines and a final pass rate:
+
+```
+INFO | Pass rate: 8/12 (67%)
+INFO |   [PASS] score=0.85 turns=4
+INFO |          terminated_by=goal_reached rules_broken=[]
+INFO |   [FAIL] score=0.30 turns=8
+INFO |          terminated_by=max_turns rules_broken=['no-pii-disclosure']
+```
+
+When `ORQ_API_KEY` is set, the run also prints an Experiment URL on `my.orq.ai`. If you see no URL, the upload was skipped (e.g. `upload_results=False` or missing key) — the run itself still succeeded.
+
 ## Examples
 
 | File | What it shows |
 |------|--------------|
 | `01_basic_simulation.py` | Core simulation loop with a mock agent - no deployment needed |
 | `02_orq_deployment_simulation.py` | Batch simulation against a live orq.ai deployment or A2A agent |
-| `03_tool_simulation.py` | Testing tool-calling agents with `MockToolRegistry` |
-| `04_hardening_loop.py` | Iterative instruction improvement with `HardeningLoop` |
+| `03_tool_simulation.py` (preview) | Testing tool-calling agents with `MockToolRegistry` — needs `agent-simulation` |
+| `04_hardening_loop.py` (preview) | Iterative instruction improvement with `HardeningLoop` — needs `agent-simulation` |
 | `05_wrap_and_experiment.py` | Production pattern: `wrap_simulation_agent()` + `evaluatorq()` for Experiment upload and CI gating |
 
 ## Environment

--- a/packages/evaluatorq-py/examples/agent_simulation/README.md
+++ b/packages/evaluatorq-py/examples/agent_simulation/README.md
@@ -9,8 +9,11 @@ pip install evaluatorq
 ```
 
 > **Examples 03 and 04** (`03_tool_simulation.py`, `04_hardening_loop.py`) also require the
-> `agent-simulation` research package from
-> [orq-ai/research](https://github.com/orq-ai/research/tree/main/projects/agent-simulation).
+> `agent-simulation` research package (not on PyPI — install from source):
+>
+> ```bash
+> pip install "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
+> ```
 
 ## Quick Start
 

--- a/packages/evaluatorq-py/examples/agent_simulation/README.md
+++ b/packages/evaluatorq-py/examples/agent_simulation/README.md
@@ -43,7 +43,7 @@ A successful run prints per-simulation pass/fail lines and a final pass rate:
 ```
 INFO | Pass rate: 8/12 (67%)
 INFO |   [PASS] score=0.85 turns=4
-INFO |          terminated_by=goal_reached rules_broken=[]
+INFO |          terminated_by=judge rules_broken=[]
 INFO |   [FAIL] score=0.30 turns=8
 INFO |          terminated_by=max_turns rules_broken=['no-pii-disclosure']
 ```

--- a/packages/evaluatorq-py/examples/agent_simulation/README.md
+++ b/packages/evaluatorq-py/examples/agent_simulation/README.md
@@ -1,0 +1,44 @@
+# Agent Simulation Examples
+
+Python examples for simulating user interactions against AI agents — testing goal completion, criteria adherence, and iterative instruction improvement.
+
+## Prerequisites
+
+```bash
+pip install evaluatorq
+```
+
+> **Examples 03 and 04** (`03_tool_simulation.py`, `04_hardening_loop.py`) also require the
+> `agent-simulation` research package from
+> [orq-ai/research](https://github.com/orq-ai/research/tree/main/projects/agent-simulation).
+
+## Quick Start
+
+```bash
+export ORQ_API_KEY="orq-..."
+
+# Simplest example — runs against a local mock agent, no deployment needed
+python 01_basic_simulation.py
+
+# Against a live orq.ai deployment
+python 02_orq_deployment_simulation.py --deployment my-support-agent
+```
+
+## Examples
+
+| File | What it shows |
+|------|--------------|
+| `01_basic_simulation.py` | Core simulation loop with a mock agent — no deployment needed |
+| `02_orq_deployment_simulation.py` | Batch simulation against a live orq.ai deployment or A2A agent |
+| `03_tool_simulation.py` | Testing tool-calling agents with `MockToolRegistry` |
+| `04_hardening_loop.py` | Iterative instruction improvement with `HardeningLoop` |
+| `05_wrap_and_experiment.py` | Production pattern: `wrap_simulation_agent()` + `evaluatorq()` for Experiment upload and CI gating |
+
+## Environment
+
+Copy `.env.example` and fill in your key:
+
+```bash
+cp .env.example .env
+# add ORQ_API_KEY=orq-...
+```

--- a/packages/evaluatorq-py/examples/agent_simulation/README.md
+++ b/packages/evaluatorq-py/examples/agent_simulation/README.md
@@ -5,14 +5,14 @@ Python examples for simulating user interactions against AI agents — testing g
 ## Prerequisites
 
 ```bash
-pip install evaluatorq
+uv pip install evaluatorq
 ```
 
 > **Examples 03 and 04** (`03_tool_simulation.py`, `04_hardening_loop.py`) also require the
 > `agent-simulation` research package (not on PyPI — install from source):
 >
 > ```bash
-> pip install "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
+> uv pip install "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
 > ```
 
 ## Quick Start
@@ -21,10 +21,10 @@ pip install evaluatorq
 export ORQ_API_KEY="orq-..."
 
 # Simplest example — runs against a local mock agent, no deployment needed
-python 01_basic_simulation.py
+uv run python examples/agent_simulation/01_basic_simulation.py
 
 # Against a live orq.ai deployment
-python 02_orq_deployment_simulation.py --deployment my-support-agent
+uv run python examples/agent_simulation/02_orq_deployment_simulation.py --deployment my-support-agent
 ```
 
 ## Examples

--- a/packages/evaluatorq-py/examples/agent_simulation/README.md
+++ b/packages/evaluatorq-py/examples/agent_simulation/README.md
@@ -1,6 +1,6 @@
 # Agent Simulation Examples
 
-Python examples for simulating user interactions against AI agents — testing goal completion, criteria adherence, and iterative instruction improvement.
+Python examples for simulating user interactions against AI agents - testing goal completion, criteria adherence, and iterative instruction improvement.
 
 ## Prerequisites
 
@@ -9,7 +9,7 @@ uv pip install evaluatorq
 ```
 
 > **Examples 03 and 04** (`03_tool_simulation.py`, `04_hardening_loop.py`) also require the
-> `agent-simulation` research package (not on PyPI — install from source):
+> `agent-simulation` research package (not on PyPI - install from source):
 >
 > ```bash
 > uv pip install "agent-simulation @ git+https://github.com/orq-ai/research.git#subdirectory=projects/agent-simulation"
@@ -20,7 +20,7 @@ uv pip install evaluatorq
 ```bash
 export ORQ_API_KEY="orq-..."
 
-# Simplest example — runs against a local mock agent, no deployment needed
+# Simplest example - runs against a local mock agent, no deployment needed
 uv run python examples/agent_simulation/01_basic_simulation.py
 
 # Against a live orq.ai deployment
@@ -31,7 +31,7 @@ uv run python examples/agent_simulation/02_orq_deployment_simulation.py --deploy
 
 | File | What it shows |
 |------|--------------|
-| `01_basic_simulation.py` | Core simulation loop with a mock agent — no deployment needed |
+| `01_basic_simulation.py` | Core simulation loop with a mock agent - no deployment needed |
 | `02_orq_deployment_simulation.py` | Batch simulation against a live orq.ai deployment or A2A agent |
 | `03_tool_simulation.py` | Testing tool-calling agents with `MockToolRegistry` |
 | `04_hardening_loop.py` | Iterative instruction improvement with `HardeningLoop` |

--- a/packages/evaluatorq-py/tests/simulation/test_examples_smoke.py
+++ b/packages/evaluatorq-py/tests/simulation/test_examples_smoke.py
@@ -1,0 +1,45 @@
+"""Import-only smoke tests for examples/agent_simulation/*.
+
+Catches drift between evaluatorq.simulation internals and the public examples
+(API renames, removed imports, etc.) without running any live API calls.
+
+Examples 03/04 depend on the `agent-simulation` research package which is not
+installed by default — those are skipped when the package is missing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+EXAMPLES_DIR = Path(__file__).resolve().parents[2] / "examples" / "agent_simulation"
+
+RESEARCH_PACKAGE_REQUIRED = {"03_tool_simulation", "04_hardening_loop"}
+
+
+def _load(name: str) -> None:
+    path = EXAMPLES_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"_example_{name}", path)
+    assert spec is not None  # noqa: S101
+    assert spec.loader is not None  # noqa: S101
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+
+@pytest.mark.parametrize(
+    "example",
+    [
+        "01_basic_simulation",
+        "02_orq_deployment_simulation",
+        "03_tool_simulation",
+        "04_hardening_loop",
+        "05_wrap_and_experiment",
+    ],
+)
+def test_example_imports(example: str) -> None:
+    if example in RESEARCH_PACKAGE_REQUIRED:
+        if importlib.util.find_spec("agent_simulation") is None:
+            pytest.skip(f"{example} requires the agent-simulation research package")
+    _load(example)


### PR DESCRIPTION
## Summary

- Moves the 5 agent simulation examples from the research repo into `evaluatorq-py/examples/agent_simulation/` so users can run them directly from the published package
- Follows the same folder structure and numbering convention as the existing `redteam` examples
- Examples: `01_basic_simulation`, `02_orq_deployment_simulation`, `03_tool_simulation`, `04_hardening_loop`, `05_wrap_and_experiment`
- Notes in README and file docstrings that examples 03/04 require the `agent-simulation` research package (those depend on `MockToolRegistry`, `HardeningLoop` — not yet in the production SDK)

Related: orq-ai/research#174

## Test plan

- [ ] `cd packages/evaluatorq-py && ORQ_API_KEY=... uv run python examples/agent_simulation/01_basic_simulation.py`
- [ ] `uv run python examples/agent_simulation/02_orq_deployment_simulation.py --deployment <key>`
- [ ] `uv run python examples/agent_simulation/05_wrap_and_experiment.py --deployment <key>`