### PR TITLE
fix(vercel-provider): pass through custom fetch

### DIFF
--- a/packages/vercel-provider/README.md
+++ b/packages/vercel-provider/README.md
@@ -185,6 +185,7 @@ const orq = createOrqAiProvider({
   headers: {                                 // Optional: Additional headers
     "X-Custom-Header": "value",
   },
+  fetch: customFetch,                        // Optional: Custom fetch implementation
 });
 ```
 
@@ -199,6 +200,7 @@ Creates an Orq AI provider instance.
 - `options`: Configuration object with:
   - `apiKey`: String (required) - Your Orq API key
   - `baseURL`: String (optional) - Custom API base URL
+  - `fetch`: Function (optional) - Custom fetch implementation
   - `headers`: Object (optional) - Additional HTTP headers
 
 #### Returns:
@@ -219,6 +221,7 @@ Provider instance with model access methods.
 interface OrqAiProviderOptions {
   apiKey: string;
   baseURL?: string;
+  fetch?: typeof fetch;
   headers?: Record<string, string>;
 }
 ```

--- a/packages/vercel-provider/orq-ai-provider-docs.mdx
+++ b/packages/vercel-provider/orq-ai-provider-docs.mdx
@@ -198,8 +198,24 @@ The Orq AI provider accepts the following configuration options:
 ```ts
 interface OrqAiProviderOptions {
   apiKey: string;                           // Required: Your Orq API key
+  baseURL?: string;                         // Optional: Custom API endpoint
+  fetch?: typeof fetch;                     // Optional: Custom fetch implementation
   headers?: Record<string, string>;         // Optional: Additional HTTP headers
 }
+```
+
+Use `fetch` when you need to route requests through a custom runtime,
+proxy, or test transport:
+
+```ts
+const orq = createOrqAiProvider({
+    apiKey: 'YOUR_ORQ_API',
+    fetch: (input, init) => {
+        const headers = new Headers(init?.headers);
+        headers.set('X-Debug-Transport', 'local');
+        return fetch(input, { ...init, headers });
+    },
+});
 ```
 
 ## Additional Resources

--- a/packages/vercel-provider/src/lib/orq-ai-sdk-provider.ts
+++ b/packages/vercel-provider/src/lib/orq-ai-sdk-provider.ts
@@ -21,6 +21,7 @@ const DEFAULT_BASE_URL = "https://api.orq.ai/v2/proxy";
 export interface OrqAiProviderSettings {
   apiKey: string;
   baseURL?: string;
+  fetch?: FetchFunction;
   headers?: Record<string, string>;
 }
 
@@ -58,6 +59,7 @@ export function createOrqAiProvider(
     provider: `orq.ai.${modelType}`,
     url: ({ path }) => `${baseURL}${path}`,
     headers: getHeaders,
+    fetch: options.fetch,
   });
 
   const createChatModel = (modelId: string) => {


### PR DESCRIPTION
## Summary

- expose a `fetch` override on `OrqAiProviderSettings`
- pass the custom fetch implementation into the shared model config used by chat, completion, embedding, and image models
- document the option in the provider README and docs page

## Why

The provider's internal model config already supports `fetch`, and the custom image model already reads `this.config.fetch`, but `createOrqAiProvider` did not expose or pass a custom fetch implementation through. This makes it harder to use the provider in custom runtimes, proxies, or tests that need to control transport behavior.

## Validation

- `bun install --frozen-lockfile`
- `bunx nx build vercel-provider`
- `bunx biome check packages/vercel-provider/src/lib/orq-ai-sdk-provider.ts packages/vercel-provider/README.md packages/vercel-provider/orq-ai-provider-docs.mdx`
- `bun -e "import { createOrqAiProvider } from './packages/vercel-provider/dist/index.js'; const customFetch = async () => new Response('{}'); const orq = createOrqAiProvider({ apiKey: 'test-key', fetch: customFetch }); const image = orq.imageModel('openai/dall-e-3'); if (image.config?.fetch !== customFetch) throw new Error('custom fetch was not passed to image model'); console.log('custom fetch passthrough smoke: ok');"`
