### PR TITLE
feat(redteam): allow selection of attack strategy and delivery method (RES-295)

### DIFF
--- a/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/pipeline.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/pipeline.py
@@ -41,6 +41,7 @@ from evaluatorq.redteam.contracts import (
     AttackerResponse,
     AttackOutput,
     AttackStrategy,
+    DeliveryMethod,
     EvaluatorConfig,
     EvaluatorqEvaluatorConfig,
     JuryResult,
@@ -106,6 +107,8 @@ async def generate_dynamic_datapoints_for_vulnerabilities(
     llm_kwargs: dict[str, Any] | None = None,
     pipeline_config: LLMConfig | None = None,
     agent_capabilities: AgentCapabilities | None = None,
+    strategy_names: set[str] | None = None,
+    delivery_methods: set[DeliveryMethod] | None = None,
 ) -> tuple[list[DataPoint], dict[str, Any]]:
     """Generate evaluatorq DataPoints for dynamic red teaming, keyed by Vulnerability enum.
 
@@ -140,6 +143,8 @@ async def generate_dynamic_datapoints_for_vulnerabilities(
         llm_kwargs=llm_kwargs,
         pipeline_config=cfg,
         agent_capabilities=agent_capabilities,
+        strategy_names=strategy_names,
+        delivery_methods=delivery_methods,
     )
 
     # Convert Vulnerability-keyed metadata to string keys for external consumption
@@ -181,6 +186,8 @@ async def generate_dynamic_datapoints(
     llm_kwargs: dict[str, Any] | None = None,
     pipeline_config: LLMConfig | None = None,
     agent_capabilities: AgentCapabilities | None = None,
+    strategy_names: set[str] | None = None,
+    delivery_methods: set[DeliveryMethod] | None = None,
 ) -> tuple[list[DataPoint], dict[str, Any]]:
     """Generate evaluatorq DataPoints for dynamic red teaming.
 
@@ -229,6 +236,8 @@ async def generate_dynamic_datapoints(
             llm_kwargs=llm_kwargs,
             pipeline_config=cfg,
             agent_capabilities=agent_capabilities,
+            strategy_names=strategy_names,
+            delivery_methods=delivery_methods,
         )
         # Remap metadata keys from vulnerability IDs back to original category strings
         # so callers that expect category-keyed metadata continue to work.
@@ -256,6 +265,8 @@ async def generate_dynamic_datapoints(
         llm_kwargs=llm_kwargs,
         pipeline_config=cfg,
         agent_capabilities=agent_capabilities,
+        strategy_names=strategy_names,
+        delivery_methods=delivery_methods,
     )
 
     datapoints = []

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/pipeline.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/pipeline.py
@@ -108,7 +108,7 @@ async def generate_dynamic_datapoints_for_vulnerabilities(
     pipeline_config: LLMConfig | None = None,
     agent_capabilities: AgentCapabilities | None = None,
     strategy_names: set[str] | None = None,
-    delivery_methods: set[DeliveryMethod] | None = None,
+    delivery_methods: set[DeliveryMethod | str] | None = None,
 ) -> tuple[list[DataPoint], dict[str, Any]]:
     """Generate evaluatorq DataPoints for dynamic red teaming, keyed by Vulnerability enum.
 
@@ -187,7 +187,7 @@ async def generate_dynamic_datapoints(
     pipeline_config: LLMConfig | None = None,
     agent_capabilities: AgentCapabilities | None = None,
     strategy_names: set[str] | None = None,
-    delivery_methods: set[DeliveryMethod] | None = None,
+    delivery_methods: set[DeliveryMethod | str] | None = None,
 ) -> tuple[list[DataPoint], dict[str, Any]]:
     """Generate evaluatorq DataPoints for dynamic red teaming.
 

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/strategy_planner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/strategy_planner.py
@@ -51,7 +51,7 @@ async def plan_strategies_for_vulnerabilities(
     pipeline_config: LLMConfig | None = None,
     agent_capabilities: AgentCapabilities | None = None,
     strategy_names: set[str] | None = None,
-    delivery_methods: set[DeliveryMethod] | None = None,
+    delivery_methods: set[DeliveryMethod | str] | None = None,
 ) -> tuple[dict[Vulnerability, list[AttackStrategy]], dict[Vulnerability, dict[str, Any]], AgentCapabilities]:
     """Build per-vulnerability strategy plans for dynamic red teaming.
 
@@ -246,7 +246,7 @@ async def plan_strategies_for_categories(
     pipeline_config: LLMConfig | None = None,
     agent_capabilities: AgentCapabilities | None = None,
     strategy_names: set[str] | None = None,
-    delivery_methods: set[DeliveryMethod] | None = None,
+    delivery_methods: set[DeliveryMethod | str] | None = None,
 ) -> tuple[dict[str, list[AttackStrategy]], dict[str, dict[str, Any]], AgentCapabilities]:
     """Build per-category strategy plans for dynamic red teaming.
 

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/strategy_planner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/strategy_planner.py
@@ -11,15 +11,16 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
+from evaluatorq.common.tracing import set_span_attrs
 from evaluatorq.redteam.adaptive.capability_classifier import AgentCapabilities, classify_agent_capabilities
 from evaluatorq.redteam.adaptive.objective_generator import generate_strategies_for_vulnerability
 from evaluatorq.redteam.adaptive.strategy_registry import (
+    _filter_by_method,
     get_strategies_for_vulnerability,
     select_applicable_strategies,
     select_applicable_strategies_for_vulnerability,
 )
-from evaluatorq.redteam.contracts import PIPELINE_CONFIG, LLMConfig, TurnType, Vulnerability
-from evaluatorq.common.tracing import set_span_attrs
+from evaluatorq.redteam.contracts import PIPELINE_CONFIG, DeliveryMethod, LLMConfig, TurnType, Vulnerability
 from evaluatorq.redteam.tracing import with_redteam_span
 from evaluatorq.redteam.vulnerability_registry import resolve_category
 
@@ -49,6 +50,8 @@ async def plan_strategies_for_vulnerabilities(
     llm_kwargs: dict[str, Any] | None = None,
     pipeline_config: LLMConfig | None = None,
     agent_capabilities: AgentCapabilities | None = None,
+    strategy_names: set[str] | None = None,
+    delivery_methods: set[DeliveryMethod] | None = None,
 ) -> tuple[dict[Vulnerability, list[AttackStrategy]], dict[Vulnerability, dict[str, Any]], AgentCapabilities]:
     """Build per-vulnerability strategy plans for dynamic red teaming.
 
@@ -125,7 +128,14 @@ async def plan_strategies_for_vulnerabilities(
             agent_capabilities=caps_for_filter,
         )
         all_hardcoded_by_vuln[vuln] = all_hardcoded
-        applicable_hardcoded_by_vuln[vuln] = applicable_hardcoded
+        # Apply user-supplied strategy-name / delivery-method filter BEFORE the
+        # max_per_category cap (applied later) so explicit selections survive
+        # the per-category limit.
+        applicable_hardcoded_by_vuln[vuln] = _filter_by_method(
+            applicable_hardcoded,
+            names=strategy_names,
+            delivery_methods=delivery_methods,
+        )
 
     generated_by_vuln: dict[Vulnerability, list[AttackStrategy]] = {vuln: [] for vuln in vulnerabilities}
     generated_single_by_vuln: dict[Vulnerability, list[AttackStrategy]] = {vuln: [] for vuln in vulnerabilities}
@@ -168,6 +178,14 @@ async def plan_strategies_for_vulnerabilities(
 
             generation_results = await asyncio.gather(*(_generate_for_vulnerability(vuln) for vuln in vulnerabilities))
             for vuln, generated, generation_error in generation_results:
+                # Apply the same strategy-name / delivery-method filter to
+                # generated strategies, otherwise the LLM-side could silently
+                # bypass the caller's explicit selection.
+                generated = _filter_by_method(
+                    generated,
+                    names=strategy_names,
+                    delivery_methods=delivery_methods,
+                )
                 generated_by_vuln[vuln] = generated
                 generation_errors[vuln] = generation_error
                 generated_single = [s for s in generated if s.turn_type == TurnType.SINGLE]
@@ -227,6 +245,8 @@ async def plan_strategies_for_categories(
     llm_kwargs: dict[str, Any] | None = None,
     pipeline_config: LLMConfig | None = None,
     agent_capabilities: AgentCapabilities | None = None,
+    strategy_names: set[str] | None = None,
+    delivery_methods: set[DeliveryMethod] | None = None,
 ) -> tuple[dict[str, list[AttackStrategy]], dict[str, dict[str, Any]], AgentCapabilities]:
     """Build per-category strategy plans for dynamic red teaming.
 
@@ -271,6 +291,8 @@ async def plan_strategies_for_categories(
         llm_kwargs=llm_kwargs,
         pipeline_config=pipeline_config,
         agent_capabilities=agent_capabilities,
+        strategy_names=strategy_names,
+        delivery_methods=delivery_methods,
     )
 
     # Remap results back to original category strings
@@ -284,10 +306,15 @@ async def plan_strategies_for_categories(
             strategy_selection[category] = vuln_selection.get(vuln, {})
         else:
             # Fallback for unresolved categories: use filtered category lookup
-            all_category_strategies[category] = select_applicable_strategies(
+            fallback_strategies = select_applicable_strategies(
                 category=category,
                 agent_context=agent_context,
                 agent_capabilities=agent_capabilities,
+            )
+            all_category_strategies[category] = _filter_by_method(
+                fallback_strategies,
+                names=strategy_names,
+                delivery_methods=delivery_methods,
             )
             strategy_selection[category] = {
                 'all_hardcoded': [s.model_dump(mode='json') for s in all_category_strategies[category]],

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/strategy_registry.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/strategy_registry.py
@@ -18,6 +18,7 @@ from evaluatorq.redteam.contracts import (
     AgentCapability,
     AgentContext,
     AttackStrategy,
+    DeliveryMethod,
     TurnType,
     Vulnerability,
 )
@@ -195,6 +196,42 @@ def select_applicable_strategies_for_vulnerability(
         return []
 
     return _filter_applicable_strategies(all_strategies, vuln.value, agent_context, agent_capabilities)
+
+
+def _filter_by_method(
+    strategies: list[AttackStrategy],
+    names: set[str] | None,
+    delivery_methods: set[DeliveryMethod] | None,
+) -> list[AttackStrategy]:
+    """Filter strategies by name and/or delivery method.
+
+    Pure predicate — no logging, no I/O. Reusable from both the planner (for
+    hardcoded and generated strategies) and from future config-file loaders.
+    Selection semantics are AND when both filters are supplied.
+
+    Args:
+        strategies: Candidate strategies to filter.
+        names: Set of accepted `AttackStrategy.name` values. ``None`` disables
+            the name filter. Empty set filters out everything.
+        delivery_methods: Set of accepted :class:`DeliveryMethod` values. ``None``
+            disables the delivery-method filter. A strategy passes if any of
+            its `delivery_methods` overlaps the selection. Empty set filters
+            out everything.
+
+    Returns:
+        Strategies that pass both filters (AND semantics when both supplied).
+    """
+    if names is None and delivery_methods is None:
+        return list(strategies)
+
+    kept: list[AttackStrategy] = []
+    for strategy in strategies:
+        if names is not None and strategy.name not in names:
+            continue
+        if delivery_methods is not None and not (set(strategy.delivery_methods) & delivery_methods):
+            continue
+        kept.append(strategy)
+    return kept
 
 
 def _fallback_capability_check(required: list[AgentCapability], agent_context: AgentContext) -> bool:

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/strategy_registry.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/strategy_registry.py
@@ -234,6 +234,16 @@ def _filter_by_method(
     return kept
 
 
+def known_strategy_names() -> set[str]:
+    """Return all strategy names registered in the hardcoded registry.
+
+    Used to validate user-supplied `--strategy` filters. Excludes runtime
+    LLM-generated strategy names, which carry a ``generated_`` prefix and
+    cannot be enumerated ahead of a run.
+    """
+    return {strategy.name for strategies in VULNERABILITY_STRATEGY_REGISTRY.values() for strategy in strategies}
+
+
 def _fallback_capability_check(required: list[AgentCapability], agent_context: AgentContext) -> bool:
     """Check capabilities without LLM classification using agent config heuristics.
 

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/strategy_registry.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/adaptive/strategy_registry.py
@@ -201,7 +201,7 @@ def select_applicable_strategies_for_vulnerability(
 def _filter_by_method(
     strategies: list[AttackStrategy],
     names: set[str] | None,
-    delivery_methods: set[DeliveryMethod] | None,
+    delivery_methods: set[DeliveryMethod | str] | None,
 ) -> list[AttackStrategy]:
     """Filter strategies by name and/or delivery method.
 

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/cli.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/cli.py
@@ -399,17 +399,21 @@ def run(
                 f"Valid names: {sorted(known)} (or a 'generated_*' name from a prior run)."
             )
 
-    # Validate + convert delivery methods to the enum (parsed as plain strings to
+    # Convert known delivery methods to the enum (parsed as plain strings to
     # support comma-separated input, which typer's enum binding cannot do).
-    resolved_delivery_methods: list[DeliveryMethod] | None = None
+    # Unknown values are an open set — kept as raw strings (so a dataset's custom
+    # delivery method is still filterable) with a warning, not a hard error.
+    resolved_delivery_methods: list[DeliveryMethod | str] | None = None
     if delivery_tokens:
         valid = {m.value for m in DeliveryMethod}
-        invalid = [d for d in delivery_tokens if d not in valid]
-        if invalid:
-            raise typer.BadParameter(
-                f"Unknown delivery method(s): {invalid}. Valid: {sorted(valid)}."
+        unknown = [d for d in delivery_tokens if d not in valid]
+        if unknown:
+            typer.echo(
+                f"Warning: delivery method(s) {unknown} are not in DeliveryMethod {sorted(valid)}; "
+                "filtering by them literally (they will only match a dataset row spelled exactly the same).",
+                err=True,
             )
-        resolved_delivery_methods = [DeliveryMethod(d) for d in delivery_tokens]
+        resolved_delivery_methods = [DeliveryMethod(d) if d in valid else d for d in delivery_tokens]
 
     target_config = TargetConfig(system_prompt=system_prompt) if system_prompt else None
     targets: list[str] | str = target if len(target) > 1 else target[0]

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/cli.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/cli.py
@@ -13,7 +13,7 @@ from typing import Annotated, Any
 
 import typer
 
-from evaluatorq.redteam.contracts import DEFAULT_PIPELINE_MODEL, SaveMode, Vulnerability
+from evaluatorq.redteam.contracts import DEFAULT_PIPELINE_MODEL, DeliveryMethod, SaveMode, Vulnerability
 
 app = typer.Typer(
     name="redteam",
@@ -199,6 +199,30 @@ def run(
             ),
         ),
     ] = None,
+    strategies: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--strategy",
+            "-s",
+            help=(
+                "Restrict the run to attack strategies whose name matches one of "
+                "the supplied values. Repeatable. Filter applies to both registry "
+                "and LLM-generated strategies. Unknown names emit a warning."
+            ),
+        ),
+    ] = None,
+    delivery_methods: Annotated[
+        list[DeliveryMethod] | None,
+        typer.Option(
+            "--delivery-method",
+            "-d",
+            help=(
+                "Restrict the run to strategies using one of the listed delivery "
+                "methods. Repeatable. Combines with --strategy as AND. "
+                f"Available: {', '.join(m.value for m in DeliveryMethod)}."
+            ),
+        ),
+    ] = None,
     max_turns: Annotated[
         int,
         typer.Option(help="Maximum conversation turns for multi-turn attacks."),
@@ -357,6 +381,8 @@ def run(
                 mode=mode,
                 categories=categories,
                 vulnerabilities=vulnerabilities,
+                strategies=strategies,
+                delivery_methods=delivery_methods,
                 max_turns=max_turns,
                 max_per_category=max_per_category,
                 parallelism=parallelism,

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/cli.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/cli.py
@@ -207,7 +207,7 @@ def run(
             help=(
                 "Restrict the run to attack strategies whose name matches one of "
                 "the supplied values. Repeatable. Filter applies to both registry "
-                "and LLM-generated strategies. Unknown names emit a warning."
+                "and LLM-generated strategies. Unknown registry names are rejected."
             ),
         ),
     ] = None,
@@ -362,6 +362,19 @@ def run(
                     f"Unknown vulnerability ID: {v!r}. "
                     f"Valid IDs: {sorted(vi.value for vi in Vulnerability)}"
                 )
+
+    # Validate strategy names early: must be a registered strategy or a
+    # runtime-generated name (generated_* prefix). Mirrors --vulnerability.
+    if strategies:
+        from evaluatorq.redteam.adaptive.strategy_registry import known_strategy_names
+
+        known = known_strategy_names()
+        unknown = [s for s in strategies if s not in known and not s.startswith("generated_")]
+        if unknown:
+            raise typer.BadParameter(
+                f"Unknown strategy name(s): {unknown}. "
+                f"Valid names: {sorted(known)} (or a 'generated_*' name from a prior run)."
+            )
 
     target_config = TargetConfig(system_prompt=system_prompt) if system_prompt else None
     targets: list[str] | str = target if len(target) > 1 else target[0]

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/cli.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/cli.py
@@ -23,6 +23,20 @@ app = typer.Typer(
 )
 
 
+def _split_csv(values: list[str] | None) -> list[str] | None:
+    """Flatten comma-separated tokens within a repeatable CLI option.
+
+    Lets users write ``-d a,b``, ``-d a -d b``, or a mix of both. Blank tokens
+    (e.g. trailing commas or a bare ``-d ,``) are dropped; if nothing survives,
+    returns ``None`` so a malformed/empty filter reads as "flag omitted" rather
+    than the ambiguous empty-set, which would otherwise filter everything out.
+    """
+    if values is None:
+        return None
+    tokens = [item.strip() for value in values for item in value.split(",") if item.strip()]
+    return tokens or None
+
+
 def _configure_logging(verbosity: int) -> None:
     """Configure logging based on verbosity level."""
     if verbosity < 0:
@@ -183,7 +197,7 @@ def run(
         typer.Option(
             "--category",
             "-c",
-            help="OWASP categories to test (e.g. ASI01). Repeatable. Defaults to all.",
+            help="OWASP categories to test (e.g. ASI01). Repeatable and/or comma-separated. Defaults to all.",
         ),
     ] = None,
     vulnerabilities: Annotated[
@@ -193,7 +207,7 @@ def run(
             "-V",
             help=(
                 "Vulnerability IDs to test (e.g. 'goal_hijacking', 'prompt_injection'). "
-                "Repeatable. Also accepts OWASP codes (ASI01, LLM01). "
+                "Repeatable and/or comma-separated. Also accepts OWASP codes (ASI01, LLM01). "
                 "Takes precedence over --category. "
                 f"Available: {', '.join(v.value for v in Vulnerability)}."
             ),
@@ -206,19 +220,21 @@ def run(
             "-s",
             help=(
                 "Restrict the run to attack strategies whose name matches one of "
-                "the supplied values. Repeatable. Filter applies to both registry "
-                "and LLM-generated strategies. Unknown registry names are rejected."
+                "the supplied values. Repeatable and/or comma-separated "
+                "(-s a,b or -s a -s b). Filter applies to both registry and "
+                "LLM-generated strategies. Unknown registry names are rejected."
             ),
         ),
     ] = None,
     delivery_methods: Annotated[
-        list[DeliveryMethod] | None,
+        list[str] | None,
         typer.Option(
             "--delivery-method",
             "-d",
             help=(
-                "Restrict the run to strategies using one of the listed delivery "
-                "methods. Repeatable. Combines with --strategy as AND. "
+                "Restrict the run to attacks using one of the listed delivery "
+                "methods. Repeatable and/or comma-separated (-d a,b or -d a -d b). "
+                "Combines with --strategy as AND. "
                 f"Available: {', '.join(m.value for m in DeliveryMethod)}."
             ),
         ),
@@ -349,6 +365,13 @@ def run(
     from evaluatorq.redteam.exceptions import CancelledError, RedTeamError
     from evaluatorq.redteam.hooks import RichHooks
 
+    # Allow comma-separated values within repeatable flags (-s a,b == -s a -s b).
+    # Done before validation so the checks below see individual tokens.
+    strategies = _split_csv(strategies)
+    delivery_tokens = _split_csv(delivery_methods)
+    categories = _split_csv(categories)
+    vulnerabilities = _split_csv(vulnerabilities)
+
     # Validate vulnerability IDs early for a clean error message
     if vulnerabilities:
         from evaluatorq.redteam.vulnerability_registry import CATEGORY_TO_VULNERABILITY
@@ -376,6 +399,18 @@ def run(
                 f"Valid names: {sorted(known)} (or a 'generated_*' name from a prior run)."
             )
 
+    # Validate + convert delivery methods to the enum (parsed as plain strings to
+    # support comma-separated input, which typer's enum binding cannot do).
+    resolved_delivery_methods: list[DeliveryMethod] | None = None
+    if delivery_tokens:
+        valid = {m.value for m in DeliveryMethod}
+        invalid = [d for d in delivery_tokens if d not in valid]
+        if invalid:
+            raise typer.BadParameter(
+                f"Unknown delivery method(s): {invalid}. Valid: {sorted(valid)}."
+            )
+        resolved_delivery_methods = [DeliveryMethod(d) for d in delivery_tokens]
+
     target_config = TargetConfig(system_prompt=system_prompt) if system_prompt else None
     targets: list[str] | str = target if len(target) > 1 else target[0]
 
@@ -395,7 +430,7 @@ def run(
                 categories=categories,
                 vulnerabilities=vulnerabilities,
                 strategies=strategies,
-                delivery_methods=delivery_methods,
+                delivery_methods=resolved_delivery_methods,
                 max_turns=max_turns,
                 max_per_category=max_per_category,
                 parallelism=parallelism,

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/contracts.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/contracts.py
@@ -1129,7 +1129,10 @@ class AttackInfo(BaseModel):
     category: str = Field(description="Short-form category code (e.g., 'ASI01', 'LLM01') — kept for backwards compat")
     framework: Framework = Field(description="OWASP framework ('OWASP-ASI' or 'OWASP-LLM')")
     attack_technique: AttackTechnique
-    delivery_methods: list[DeliveryMethod] = Field(description='Delivery methods (always a list)')
+    delivery_methods: list[DeliveryMethod | str] = Field(
+        description='Delivery methods (always a list). Open set: known values are DeliveryMethod '
+        'members, custom dataset values are kept as raw strings.'
+    )
     turn_type: TurnType
     severity: Severity
     vulnerability_domain: VulnerabilityDomain | None = Field(

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/contracts.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/contracts.py
@@ -372,7 +372,11 @@ class RedTeamInput(BaseModel):
     vulnerability: str = Field(default='', description='Vulnerability identifier (primary key in new format)')
     category: str = Field(default='', description='Attack category (framework-specific) — kept for backwards compat')
     attack_technique: str = Field(default='', description='Specific attack technique used')
-    delivery_method: str = Field(default='', description='Jailbreak/delivery technique used')
+    delivery_method: DeliveryMethod | str = Field(
+        default='',
+        description='Jailbreak/delivery technique. Coerced to the DeliveryMethod enum when it '
+        'matches a known value (exact); unknown values are kept as a raw string (open-set).',
+    )
     severity: Severity = Field(description='Attack severity level')
     vulnerability_domain: VulnerabilityDomain = Field(description='Vulnerability domain (where the fix belongs)')
     framework: Framework = Field(default=Framework.OWASP_AGENTIC, description='Security framework identifier')
@@ -431,6 +435,22 @@ class RedTeamInput(BaseModel):
         """Normalize framework string aliases to canonical Framework enum values."""
         if isinstance(value, str):
             return normalize_framework(value)
+        return value
+
+    @field_validator('delivery_method', mode='before')
+    @classmethod
+    def _coerce_delivery_method(cls, value: Any) -> Any:
+        """Coerce a known delivery method to the DeliveryMethod enum (exact match).
+
+        Unknown or empty values pass through as a raw string — the field is an
+        open set, so a dataset may carry a delivery method the enum doesn't list.
+        No fuzzy normalization: a value either equals a DeliveryMethod or it does not.
+        """
+        if isinstance(value, str) and value:
+            try:
+                return DeliveryMethod(value)
+            except ValueError:
+                return value
         return value
 
     @model_validator(mode='after')

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
@@ -129,8 +129,8 @@ def load_owasp_agentic_dataset(
         num_samples: Maximum number of samples to load (None = all).
         categories: Filter to these OWASP category codes.
         delivery_methods: Filter to rows whose ``delivery_method`` matches one of
-            these values (case-insensitive). Applied before the ``num_samples``
-            cap. ``None`` disables the filter.
+            these values (exact match — no case/punctuation folding). Applied
+            before the ``num_samples`` cap. ``None`` disables the filter.
 
     Returns:
         List of DataPoint instances ready for evaluatorq evaluation.

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 from collections import Counter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -494,8 +493,8 @@ def _load_from_file(
         samples = _filter_by_categories(samples, categories, category_of=lambda s: s.input.category)
 
     if delivery_methods:
-        selected = {normalize_delivery_method(m) for m in delivery_methods}
-        samples = [s for s in samples if _matches_delivery(s.input.delivery_method, selected)]
+        selected = set(delivery_methods)
+        samples = [s for s in samples if s.input.delivery_method in selected]
         logger.info(f'Filtered to delivery methods: {sorted(selected)} ({len(samples)} samples)')
 
     num_samples = _normalize_num_samples(num_samples)
@@ -515,26 +514,6 @@ def _load_from_file(
     return datapoints
 
 
-def normalize_delivery_method(value: str) -> str:
-    """Normalize a free-form ``delivery_method`` for comparison against enum slugs.
-
-    ``RedTeamInput.delivery_method`` is an unconstrained string (default ``''``),
-    so we fold case and collapse whitespace/underscores to hyphens — letting
-    dataset values like ``'Direct Request'`` or ``'direct_request'`` match the
-    canonical ``'direct-request'`` :class:`DeliveryMethod` slug.
-    """
-    return re.sub(r'[\s_]+', '-', value.strip().lower())
-
-
-def _matches_delivery(value: str | None, selected: set[str]) -> bool:
-    """Membership test for the free-form ``delivery_method`` field.
-
-    ``selected`` must already be normalized via :func:`normalize_delivery_method`.
-    Empty/missing values never match.
-    """
-    return bool(value) and normalize_delivery_method(value) in selected
-
-
 def _apply_filters(
     datapoints: list[DataPoint],
     num_samples: int | None = None,
@@ -551,8 +530,8 @@ def _apply_filters(
         datapoints = _filter_by_categories(datapoints, categories, category_of=lambda dp: dp.inputs.get('category', ''))
 
     if delivery_methods:
-        selected = {normalize_delivery_method(m) for m in delivery_methods}
-        datapoints = [dp for dp in datapoints if _matches_delivery(dp.inputs.get('delivery_method'), selected)]
+        selected = set(delivery_methods)
+        datapoints = [dp for dp in datapoints if dp.inputs.get('delivery_method') in selected]
         logger.info(f'Filtered to delivery methods: {sorted(selected)} ({len(datapoints)} samples)')
 
     num_samples = _normalize_num_samples(num_samples)

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/frameworks/owasp/evaluatorq_bridge.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from collections import Counter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -116,6 +117,7 @@ def load_owasp_agentic_dataset(
     dataset: str | Path | None = None,
     num_samples: int | None = None,
     categories: list[str] | None = None,
+    delivery_methods: list[str] | None = None,
 ) -> list[DataPoint]:
     """Load red team dataset from various sources.
 
@@ -127,6 +129,9 @@ def load_owasp_agentic_dataset(
             - ``"hf:org/repo/filename.json"``: specific file in a HuggingFace repository
         num_samples: Maximum number of samples to load (None = all).
         categories: Filter to these OWASP category codes.
+        delivery_methods: Filter to rows whose ``delivery_method`` matches one of
+            these values (case-insensitive). Applied before the ``num_samples``
+            cap. ``None`` disables the filter.
 
     Returns:
         List of DataPoint instances ready for evaluatorq evaluation.
@@ -139,10 +144,11 @@ def load_owasp_agentic_dataset(
             filename=DEFAULT_HF_FILENAME,
             num_samples=num_samples,
             categories=categories,
+            delivery_methods=delivery_methods,
         )
 
     if isinstance(dataset, Path):
-        return _load_from_file(dataset, num_samples=num_samples, categories=categories)
+        return _load_from_file(dataset, num_samples=num_samples, categories=categories, delivery_methods=delivery_methods)
 
     s = str(dataset)
 
@@ -153,6 +159,7 @@ def load_owasp_agentic_dataset(
             filename=filename,
             num_samples=num_samples,
             categories=categories,
+            delivery_methods=delivery_methods,
         )
 
     if s.startswith('orq:'):
@@ -162,7 +169,9 @@ def load_owasp_agentic_dataset(
                 "Invalid dataset specifier 'orq:': provide a dataset ID after the colon, e.g. 'orq:my-dataset-id'"
             )
         datapoints = _fetch_all_datapoints(dataset_id)
-        datapoints = _apply_filters(datapoints, num_samples=num_samples, categories=categories)
+        datapoints = _apply_filters(
+            datapoints, num_samples=num_samples, categories=categories, delivery_methods=delivery_methods
+        )
         logger.info(f'Loaded {len(datapoints)} samples from ORQ dataset {dataset_id}')
         return datapoints
 
@@ -170,7 +179,7 @@ def load_owasp_agentic_dataset(
     path = Path(s)
     if not path.exists():
         raise FileNotFoundError(f'Dataset file not found: {path}. For HuggingFace datasets, use "hf:org/repo" format.')
-    return _load_from_file(path, num_samples=num_samples, categories=categories)
+    return _load_from_file(path, num_samples=num_samples, categories=categories, delivery_methods=delivery_methods)
 
 
 def _parse_hf_source(rest: str) -> tuple[str, str]:
@@ -366,6 +375,7 @@ def _fetch_from_huggingface(
     filename: str = DEFAULT_HF_FILENAME,
     num_samples: int | None = None,
     categories: list[str] | None = None,
+    delivery_methods: list[str] | None = None,
 ) -> list[DataPoint]:
     """Fetch red team samples from a HuggingFace dataset repository."""
     try:
@@ -391,7 +401,9 @@ def _fetch_from_huggingface(
             'local --dataset path, or use --mode dynamic to skip static datapoints.'
         )
         raise DatasetError(msg) from e
-    datapoints = _load_from_file(local_path, num_samples=num_samples, categories=categories)
+    datapoints = _load_from_file(
+        local_path, num_samples=num_samples, categories=categories, delivery_methods=delivery_methods
+    )
     logger.info(f'Loaded {len(datapoints)} samples from HuggingFace ({repo})')
     return datapoints
 
@@ -459,6 +471,7 @@ def _load_from_file(
     path: str | Path,
     num_samples: int | None = None,
     categories: list[str] | None = None,
+    delivery_methods: list[str] | None = None,
 ) -> list[DataPoint]:
     """Load OWASP dataset from a local JSON file in ``{"samples": [...]}`` format."""
     path = Path(path)
@@ -480,6 +493,11 @@ def _load_from_file(
     if categories:
         samples = _filter_by_categories(samples, categories, category_of=lambda s: s.input.category)
 
+    if delivery_methods:
+        selected = {normalize_delivery_method(m) for m in delivery_methods}
+        samples = [s for s in samples if _matches_delivery(s.input.delivery_method, selected)]
+        logger.info(f'Filtered to delivery methods: {sorted(selected)} ({len(samples)} samples)')
+
     num_samples = _normalize_num_samples(num_samples)
     if num_samples is not None:
         samples = samples[:num_samples]
@@ -497,14 +515,45 @@ def _load_from_file(
     return datapoints
 
 
+def normalize_delivery_method(value: str) -> str:
+    """Normalize a free-form ``delivery_method`` for comparison against enum slugs.
+
+    ``RedTeamInput.delivery_method`` is an unconstrained string (default ``''``),
+    so we fold case and collapse whitespace/underscores to hyphens — letting
+    dataset values like ``'Direct Request'`` or ``'direct_request'`` match the
+    canonical ``'direct-request'`` :class:`DeliveryMethod` slug.
+    """
+    return re.sub(r'[\s_]+', '-', value.strip().lower())
+
+
+def _matches_delivery(value: str | None, selected: set[str]) -> bool:
+    """Membership test for the free-form ``delivery_method`` field.
+
+    ``selected`` must already be normalized via :func:`normalize_delivery_method`.
+    Empty/missing values never match.
+    """
+    return bool(value) and normalize_delivery_method(value) in selected
+
+
 def _apply_filters(
     datapoints: list[DataPoint],
     num_samples: int | None = None,
     categories: list[str] | None = None,
+    delivery_methods: list[str] | None = None,
 ) -> list[DataPoint]:
-    """Apply category and sample-count filters to datapoints."""
+    """Apply category, delivery-method, and sample-count filters to datapoints.
+
+    Category and delivery-method filters run BEFORE the ``num_samples`` cap so the
+    cap limits the already-filtered set rather than slicing first and filtering the
+    remainder (which would yield fewer than ``num_samples`` rows).
+    """
     if categories:
         datapoints = _filter_by_categories(datapoints, categories, category_of=lambda dp: dp.inputs.get('category', ''))
+
+    if delivery_methods:
+        selected = {normalize_delivery_method(m) for m in delivery_methods}
+        datapoints = [dp for dp in datapoints if _matches_delivery(dp.inputs.get('delivery_method'), selected)]
+        logger.info(f'Filtered to delivery methods: {sorted(selected)} ({len(datapoints)} samples)')
 
     num_samples = _normalize_num_samples(num_samples)
     if num_samples is not None:

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/reports/converters.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/reports/converters.py
@@ -276,9 +276,11 @@ def static_sample_to_result(
     vuln = resolve_category_safe(category)
     vulnerability_str = vuln.value if vuln else ''
 
-    # Wrap singular delivery_method into list
+    # Wrap singular delivery_method into list. inp.delivery_method is already
+    # coerced (DeliveryMethod for known values, raw str for custom ones), so use
+    # it as-is — re-wrapping via DeliveryMethod() would crash on a custom value.
     dm = inp.delivery_method
-    delivery_methods: list[DeliveryMethod] = [DeliveryMethod(dm)] if dm else []
+    delivery_methods: list[DeliveryMethod | str] = [dm] if dm else []
     evaluator_meta = get_evaluator_metadata_for_category(category) or {}
 
     attack = AttackInfo(
@@ -462,7 +464,9 @@ def dynamic_evaluatorq_results_to_report(
             category=category,
             framework=cast('Framework', infer_framework(category)),
             attack_technique=strategy.attack_technique,
-            delivery_methods=strategy.delivery_methods,
+            # AttackInfo.delivery_methods is the open set (DeliveryMethod | str); a
+            # strategy's closed list[DeliveryMethod] is valid content (list is invariant).
+            delivery_methods=cast('list[DeliveryMethod | str]', strategy.delivery_methods),
             turn_type=strategy.turn_type,
             severity=strategy.severity,
             vulnerability_domain=vuln_def.domain if vuln_def else None,

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -59,7 +59,7 @@ from evaluatorq.redteam.contracts import (
     Vulnerability,
     normalize_category,
 )
-from evaluatorq.redteam.exceptions import CancelledError, CredentialError
+from evaluatorq.redteam.exceptions import CancelledError, CredentialError, RedTeamError
 from evaluatorq.redteam.hooks import ConfirmPayload, DefaultHooks, PipelineHooks
 from evaluatorq.redteam.reports.recommendations import generate_focus_area_recommendations
 from evaluatorq.redteam.runtime.jobs import _build_messages, _sanitize_job_name, create_model_job
@@ -341,12 +341,18 @@ async def red_team(
             strategies and LLM-generated strategies, and runs before the
             ``max_per_category`` cap so explicit selections survive the
             per-category limit. Unknown registry names are rejected at the CLI
-            boundary; names that match no strategy (or yield no datapoints) emit
-            a warning. ``None`` disables the filter.
-        delivery_methods: Restrict the run to strategies whose
-            ``delivery_methods`` list overlaps the supplied selection. Combines
-            with ``strategies`` using AND semantics. An empty intersection emits
-            a warning. ``None`` disables the filter.
+            boundary; names that match no datapoint emit a warning. Does not
+            apply to static (dataset) datapoints, which carry no strategy name —
+            a warning is emitted if combined with ``static`` mode. ``None``
+            disables the filter.
+        delivery_methods: Restrict the run to attacks whose delivery method
+            overlaps the supplied selection. Applies to dynamic strategies
+            (``AttackStrategy.delivery_methods``) and to static datapoints
+            (``inputs['delivery_method']``). Combines with ``strategies`` using
+            AND semantics. Methods matching no datapoint emit a warning. ``None``
+            disables the filter. When a supplied filter leaves zero datapoints to
+            run, ``red_team`` raises :class:`RedTeamError` rather than silently
+            running nothing.
         max_turns: Maximum conversation turns for multi-turn attacks.
         max_per_category: Cap strategies per category (None = no cap).
         llm_config: Role-based LLM configuration. Use ``LLMConfig(attacker=LLMCallConfig(...),
@@ -651,6 +657,8 @@ async def red_team(
             output_dir=resolved_output_dir,
             target_config=target_config,
             pipeline_config=config,
+            resolved_strategy_names=resolved_strategy_names,
+            resolved_delivery_methods=resolved_delivery_methods,
         )
     else:
         msg = f'Invalid mode {mode!r}. Must be "dynamic", "static", or "hybrid".'
@@ -948,30 +956,70 @@ def _make_agent_backend(*, target_config: TargetConfig | None, pipeline_config: 
     )
 
 
-def _warn_on_filter_mismatch(
+def _delivery_method_values(delivery_methods: set[DeliveryMethod] | None) -> list[str] | None:
+    """Convert a DeliveryMethod set to enum-value strings for the dataset loader.
+
+    Static rows are filtered by delivery method inside ``load_owasp_agentic_dataset``
+    (before its ``num_samples`` cap), which takes plain string values. ``None``
+    stays ``None`` so the loader leaves the filter disabled.
+    """
+    return [m.value for m in delivery_methods] if delivery_methods is not None else None
+
+
+def _check_filter_results(
     datapoints: list[DataPoint],
     strategy_names: set[str] | None,
     delivery_methods: set[DeliveryMethod] | None,
+    *,
+    names_apply: bool = True,
 ) -> None:
-    """Warn when a strategy/delivery-method filter matched less than requested.
+    """Surface strategy/delivery-method filter mismatches; fail on an empty run.
 
-    Emits a warning for requested strategy names that produced no datapoints, and
-    for an entirely empty filter intersection. Called from both the single-target
-    and multi-target dynamic generation paths so warnings fire on either.
+    Warns for any requested strategy name or delivery method that matched no
+    datapoint, then raises :class:`RedTeamError` when a user-supplied filter
+    leaves zero datapoints to run — a silent zero-attack run that still exits 0
+    is the worst outcome for an attack tool. Called on the *final* per-target
+    datapoint set (dynamic + static combined) so warnings and the empty-run
+    guard account for every path.
+
+    ``names_apply=False`` suppresses per-name warnings on paths whose datapoints
+    never carry a strategy name (static mode), where the caller warns once that
+    name filtering does not apply instead.
     """
     if strategy_names is None and delivery_methods is None:
         return
-    matched_names = {dp.inputs.get('strategy', {}).get('name') for dp in datapoints}
-    matched_names.discard(None)
-    if strategy_names is not None:
+
+    matched_names: set[str] = set()
+    matched_methods: set[str] = set()
+    # Normalize delivery methods the same way the dataset loader does, so a row
+    # kept by the case-insensitive loader filter is not then reported "unmatched".
+    from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import normalize_delivery_method
+
+    for dp in datapoints:
+        strategy = dp.inputs.get('strategy')
+        if isinstance(strategy, dict):
+            name = strategy.get('name')
+            if name:
+                matched_names.add(name)
+            matched_methods.update(normalize_delivery_method(m) for m in (strategy.get('delivery_methods') or []))
+        single = dp.inputs.get('delivery_method')  # static datapoint shape (singular)
+        if single:
+            matched_methods.add(normalize_delivery_method(single))
+
+    if strategy_names is not None and names_apply:
         unmatched = sorted(strategy_names - matched_names)
         if unmatched:
-            logger.warning(f'Unmatched strategy name(s): {unmatched} — no datapoints generated for them.')
+            logger.warning(f'Unmatched strategy name(s): {unmatched} — no datapoints matched.')
+    if delivery_methods is not None:
+        unmatched_methods = sorted({normalize_delivery_method(m.value) for m in delivery_methods} - matched_methods)
+        if unmatched_methods:
+            logger.warning(f'Unmatched delivery method(s): {unmatched_methods} — no datapoints use them.')
+
     if not datapoints:
         names_repr = sorted(strategy_names) if strategy_names else None
         methods_repr = sorted(m.value for m in delivery_methods) if delivery_methods else None
-        logger.warning(
-            'Empty intersection: filter selection produced zero datapoints. '
+        raise RedTeamError(
+            'Filter selection produced zero datapoints — nothing to run. '
             f'(strategies={names_repr}, delivery_methods={methods_repr})'
         )
 
@@ -1113,8 +1161,6 @@ async def _prepare_target(
                 delivery_methods=resolved_delivery_methods,
             )
 
-        _warn_on_filter_mismatch(dynamic_datapoints, resolved_strategy_names, resolved_delivery_methods)
-
         if (
             max_dynamic_datapoints is not None
             and max_dynamic_datapoints > 0
@@ -1156,11 +1202,14 @@ async def _prepare_target(
             else:
                 from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import load_owasp_agentic_dataset
 
-                # Load static datapoints
+                # Load static datapoints. The delivery-method filter is applied inside
+                # the loader (before the num_samples cap); --strategy can't apply to
+                # static rows, which carry no strategy name.
                 static_datapoints = load_owasp_agentic_dataset(
                     dataset=dataset,
                     num_samples=max_static_datapoints,
                     categories=categories,
+                    delivery_methods=_delivery_method_values(resolved_delivery_methods),
                 )
 
             # Tag with hybrid_source only (no target_tag — datapoints are shared)
@@ -1182,6 +1231,7 @@ async def _prepare_target(
                     },
                 )
             )
+            _check_filter_results(all_datapoints, resolved_strategy_names, resolved_delivery_methods)
 
         # Build the static job via shared helper
         sys_prompt = target_config.system_prompt if target_config else None
@@ -1212,6 +1262,7 @@ async def _prepare_target(
             await await_maybe(
                 hooks.on_stage_end(PipelineStage.DATAPOINT_GENERATION, {'num_datapoints': len(all_datapoints)})
             )
+            _check_filter_results(all_datapoints, resolved_strategy_names, resolved_delivery_methods)
 
         # Build the dynamic dispatcher job
         @job(f'redteam:dynamic:{safe_target}')
@@ -1596,10 +1647,14 @@ async def _run_dynamic_or_hybrid(
         if mode == Pipeline.HYBRID:
             from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import load_owasp_agentic_dataset
 
+            # The delivery-method filter is applied inside the loader (before the
+            # num_samples cap) so the shared dataset is consistent across every
+            # target; --strategy can't apply to static rows (no strategy name).
             static_data = load_owasp_agentic_dataset(
                 dataset=dataset,
                 num_samples=max_static_datapoints,
                 categories=categories,
+                delivery_methods=_delivery_method_values(resolved_delivery_methods),
             )
             est_static = len(static_data)
 
@@ -1735,6 +1790,7 @@ async def _run_dynamic_or_hybrid(
 
                 at_safe = _make_safe_target(at_label)
 
+                at_is_generating = shared_at_dps is None
                 if shared_at_dps is None:
                     # This is the first target overall — generate datapoints
                     await await_maybe(
@@ -1781,7 +1837,6 @@ async def _run_dynamic_or_hybrid(
                             strategy_names=resolved_strategy_names,
                             delivery_methods=resolved_delivery_methods,
                         )
-                    _warn_on_filter_mismatch(at_dps, resolved_strategy_names, resolved_delivery_methods)
                     if (
                         max_dynamic_datapoints is not None
                         and max_dynamic_datapoints > 0
@@ -1867,6 +1922,9 @@ async def _run_dynamic_or_hybrid(
                     ) -> Any:
                         result = await _inner(data, row)
                         return result.get('output', result) if isinstance(result, dict) else result
+
+                if at_is_generating:
+                    _check_filter_results(at_all_dps, resolved_strategy_names, resolved_delivery_methods)
 
                 prepared_targets.append(
                     PreparedTarget(
@@ -2275,6 +2333,8 @@ async def _run_static(
     output_dir: Path | None = None,
     target_config: TargetConfig | None = None,
     pipeline_config: LLMConfig | None = None,
+    resolved_strategy_names: set[str] | None = None,
+    resolved_delivery_methods: set[DeliveryMethod] | None = None,
 ) -> RedTeamReport:
     """Run static red teaming for multiple targets in a single ``evaluatorq()`` call.
 
@@ -2305,6 +2365,7 @@ async def _run_static(
         dataset=dataset,
         num_samples=max_static_datapoints,
         categories=categories,
+        delivery_methods=_delivery_method_values(resolved_delivery_methods),
     )
 
     # Filter out datapoints whose category has no registered evaluator
@@ -2327,7 +2388,16 @@ async def _run_static(
             raise ValueError(msg)
         data = filtered_data  # type: ignore[assignment]
 
+    # The delivery-method filter was applied at load time (above). Strategy-name
+    # selection cannot apply to static rows (dataset records with no strategy
+    # name), so warn that it is ignored rather than silently dropping the flag.
+    if resolved_strategy_names is not None:
+        logger.warning(
+            '--strategy does not apply to static datapoints (dataset rows carry no strategy name); '
+            f'ignoring strategy filter {sorted(resolved_strategy_names)} in static mode.'
+        )
     if isinstance(data, list):
+        _check_filter_results(data, None, resolved_delivery_methods, names_apply=False)
         _save_stage(output_dir, '01_datapoints.json', json.dumps([dp.inputs for dp in data], indent=2, default=str))
 
     # Build one job per target using the shared helper

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -1020,7 +1020,14 @@ def _check_filter_results(
     if delivery_methods is not None:
         unmatched_methods = sorted(set(_delivery_method_values(delivery_methods) or []) - matched_methods)
         if unmatched_methods:
-            logger.warning(f'Unmatched delivery method(s): {unmatched_methods} — no datapoints use them.')
+            msg = f'Unmatched delivery method(s): {unmatched_methods} — no datapoints use them.'
+            # When some methods DID match, name what's actually present so a
+            # spelling/case mismatch is visible (matching is exact). On a fully
+            # empty run matched_methods is empty and the RedTeamError below reports
+            # the dataset's present methods instead.
+            if matched_methods:
+                msg += f' Present: {sorted(matched_methods)}.'
+            logger.warning(msg)
 
     if not datapoints:
         names_repr = sorted(strategy_names) if strategy_names else None

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -48,6 +48,7 @@ from evaluatorq.redteam.backends.registry import create_async_llm_client, resolv
 from evaluatorq.redteam.contracts import (
     PIPELINE_CONFIG,
     AgentContext,
+    DeliveryMethod,
     LLMConfig,
     Pipeline,
     PipelineStage,
@@ -298,6 +299,8 @@ async def red_team(
     mode: Pipeline | str = Pipeline.DYNAMIC,
     categories: list[str] | None = None,
     vulnerabilities: list[str] | None = None,
+    strategies: list[str] | None = None,
+    delivery_methods: list[DeliveryMethod] | None = None,
     max_turns: int = 5,
     max_per_category: int | None = None,
     parallelism: int = 10,
@@ -333,6 +336,16 @@ async def red_team(
             Defaults to all available categories. Ignored if ``vulnerabilities`` is set.
         vulnerabilities: Vulnerability IDs to test (e.g., ``["goal_hijacking", "prompt_injection"]``).
             Takes precedence over ``categories``.
+        strategies: Restrict the run to attack strategies whose ``name`` matches
+            one of the supplied values. Filtering applies to both registry
+            strategies and LLM-generated strategies, and runs before the
+            ``max_per_category`` cap so explicit selections survive the
+            per-category limit. Unknown names emit a warning and are ignored.
+            ``None`` disables the filter.
+        delivery_methods: Restrict the run to strategies whose
+            ``delivery_methods`` list overlaps the supplied selection. Combines
+            with ``strategies`` using AND semantics. Unknown values emit a
+            warning and are ignored. ``None`` disables the filter.
         max_turns: Maximum conversation turns for multi-turn attacks.
         max_per_category: Cap strategies per category (None = no cap).
         llm_config: Role-based LLM configuration. Use ``LLMConfig(attacker=LLMCallConfig(...),
@@ -493,6 +506,12 @@ async def red_team(
         if is_huggingface_source(dataset):
             ensure_huggingface_available()
 
+    # Convert filter inputs to sets for the planner. Pass through verbatim —
+    # do not pre-validate against the registry. Unknown names and empty
+    # intersections are detected post-filter from the actually-matched set.
+    resolved_strategy_names: set[str] | None = set(strategies) if strategies is not None else None
+    resolved_delivery_methods: set[DeliveryMethod] | None = set(delivery_methods) if delivery_methods is not None else None
+
     resolved_vulns: list[Vulnerability] | None
     if vulnerabilities:
         resolved_vulns = resolve_vulnerabilities(vulnerabilities)
@@ -610,6 +629,8 @@ async def red_team(
             attacker_instructions=attacker_instructions,
             verbosity=verbosity,
             pipeline_config=config,
+            resolved_strategy_names=resolved_strategy_names,
+            resolved_delivery_methods=resolved_delivery_methods,
         )
     elif resolved_mode == Pipeline.STATIC:
         report = await _run_static(
@@ -951,6 +972,8 @@ async def _prepare_target(
     prefetched_static_data: list[Any] | None = None,
     verbosity: int = 0,
     pipeline_config: LLMConfig | None = None,
+    resolved_strategy_names: set[str] | None = None,
+    resolved_delivery_methods: set[DeliveryMethod] | None = None,
 ) -> PreparedTarget:
     """Prepare all per-target state for a dynamic or hybrid run.
 
@@ -1037,6 +1060,8 @@ async def _prepare_target(
                 attacker_instructions=attacker_instructions,
                 pipeline_config=pipeline_config,
                 agent_capabilities=prefetched_agent_capabilities,
+                strategy_names=resolved_strategy_names,
+                delivery_methods=resolved_delivery_methods,
             )
         else:
             # Fallback: categories that could not be resolved to vulnerabilities
@@ -1053,7 +1078,27 @@ async def _prepare_target(
                 attacker_instructions=attacker_instructions,
                 pipeline_config=pipeline_config,
                 agent_capabilities=prefetched_agent_capabilities,
+                strategy_names=resolved_strategy_names,
+                delivery_methods=resolved_delivery_methods,
             )
+
+        # Detect unknown strategy names (requested but never matched by the
+        # filter) and empty-intersection (filter set but no datapoints).
+        if resolved_strategy_names is not None or resolved_delivery_methods is not None:
+            matched_names = {dp.inputs.get('strategy', {}).get('name') for dp in dynamic_datapoints}
+            matched_names.discard(None)
+            if resolved_strategy_names is not None:
+                unmatched = sorted(resolved_strategy_names - matched_names)
+                if unmatched:
+                    logger.warning(
+                        f'Unknown or unmatched strategy name(s): {unmatched} — no datapoints generated for them.'
+                    )
+            if not dynamic_datapoints:
+                logger.warning(
+                    'Empty intersection: filter selection produced zero datapoints. '
+                    f'(strategies={sorted(resolved_strategy_names) if resolved_strategy_names else None}, '
+                    f'delivery_methods={sorted(m.value for m in resolved_delivery_methods) if resolved_delivery_methods else None})'
+                )
 
         if (
             max_dynamic_datapoints is not None
@@ -1216,6 +1261,8 @@ async def _run_dynamic_or_hybrid(
     attacker_instructions: str | None = None,
     verbosity: int = 0,
     pipeline_config: LLMConfig | None = None,
+    resolved_strategy_names: set[str] | None = None,
+    resolved_delivery_methods: set[DeliveryMethod] | None = None,
 ) -> RedTeamReport:
     """Run dynamic or hybrid red teaming for multiple targets in a single evaluatorq call.
 
@@ -1591,6 +1638,8 @@ async def _run_dynamic_or_hybrid(
             attacker_instructions=attacker_instructions,
             verbosity=verbosity,
             pipeline_config=pipeline_config,
+            resolved_strategy_names=resolved_strategy_names,
+            resolved_delivery_methods=resolved_delivery_methods,
         )
 
         prepared_targets: list[PreparedTarget]
@@ -1697,6 +1746,8 @@ async def _run_dynamic_or_hybrid(
                             attacker_instructions=attacker_instructions,
                             pipeline_config=pipeline_config,
                             agent_capabilities=at_pref_caps,
+                            strategy_names=resolved_strategy_names,
+                            delivery_methods=resolved_delivery_methods,
                         )
                     else:
                         at_dps, at_filter_meta = await generate_dynamic_datapoints(
@@ -1712,6 +1763,8 @@ async def _run_dynamic_or_hybrid(
                             attacker_instructions=attacker_instructions,
                             pipeline_config=pipeline_config,
                             agent_capabilities=at_pref_caps,
+                            strategy_names=resolved_strategy_names,
+                            delivery_methods=resolved_delivery_methods,
                         )
                     if (
                         max_dynamic_datapoints is not None

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -340,12 +340,13 @@ async def red_team(
             one of the supplied values. Filtering applies to both registry
             strategies and LLM-generated strategies, and runs before the
             ``max_per_category`` cap so explicit selections survive the
-            per-category limit. Unknown names emit a warning and are ignored.
-            ``None`` disables the filter.
+            per-category limit. Unknown registry names are rejected at the CLI
+            boundary; names that match no strategy (or yield no datapoints) emit
+            a warning. ``None`` disables the filter.
         delivery_methods: Restrict the run to strategies whose
             ``delivery_methods`` list overlaps the supplied selection. Combines
-            with ``strategies`` using AND semantics. Unknown values emit a
-            warning and are ignored. ``None`` disables the filter.
+            with ``strategies`` using AND semantics. An empty intersection emits
+            a warning. ``None`` disables the filter.
         max_turns: Maximum conversation turns for multi-turn attacks.
         max_per_category: Cap strategies per category (None = no cap).
         llm_config: Role-based LLM configuration. Use ``LLMConfig(attacker=LLMCallConfig(...),
@@ -506,11 +507,13 @@ async def red_team(
         if is_huggingface_source(dataset):
             ensure_huggingface_available()
 
-    # Convert filter inputs to sets for the planner. Pass through verbatim —
-    # do not pre-validate against the registry. Unknown names and empty
-    # intersections are detected post-filter from the actually-matched set.
+    # Convert filter inputs to sets for the planner. Unknown registry names are
+    # rejected at the CLI boundary; here we pass through verbatim and detect
+    # empty/unmatched intersections post-filter from the actually-matched set.
     resolved_strategy_names: set[str] | None = set(strategies) if strategies is not None else None
-    resolved_delivery_methods: set[DeliveryMethod] | None = set(delivery_methods) if delivery_methods is not None else None
+    resolved_delivery_methods: set[DeliveryMethod] | None = (
+        set(delivery_methods) if delivery_methods is not None else None
+    )
 
     resolved_vulns: list[Vulnerability] | None
     if vulnerabilities:
@@ -945,6 +948,34 @@ def _make_agent_backend(*, target_config: TargetConfig | None, pipeline_config: 
     )
 
 
+def _warn_on_filter_mismatch(
+    datapoints: list[DataPoint],
+    strategy_names: set[str] | None,
+    delivery_methods: set[DeliveryMethod] | None,
+) -> None:
+    """Warn when a strategy/delivery-method filter matched less than requested.
+
+    Emits a warning for requested strategy names that produced no datapoints, and
+    for an entirely empty filter intersection. Called from both the single-target
+    and multi-target dynamic generation paths so warnings fire on either.
+    """
+    if strategy_names is None and delivery_methods is None:
+        return
+    matched_names = {dp.inputs.get('strategy', {}).get('name') for dp in datapoints}
+    matched_names.discard(None)
+    if strategy_names is not None:
+        unmatched = sorted(strategy_names - matched_names)
+        if unmatched:
+            logger.warning(f'Unmatched strategy name(s): {unmatched} — no datapoints generated for them.')
+    if not datapoints:
+        names_repr = sorted(strategy_names) if strategy_names else None
+        methods_repr = sorted(m.value for m in delivery_methods) if delivery_methods else None
+        logger.warning(
+            'Empty intersection: filter selection produced zero datapoints. '
+            f'(strategies={names_repr}, delivery_methods={methods_repr})'
+        )
+
+
 async def _prepare_target(
     *,
     target: str,
@@ -1082,23 +1113,7 @@ async def _prepare_target(
                 delivery_methods=resolved_delivery_methods,
             )
 
-        # Detect unknown strategy names (requested but never matched by the
-        # filter) and empty-intersection (filter set but no datapoints).
-        if resolved_strategy_names is not None or resolved_delivery_methods is not None:
-            matched_names = {dp.inputs.get('strategy', {}).get('name') for dp in dynamic_datapoints}
-            matched_names.discard(None)
-            if resolved_strategy_names is not None:
-                unmatched = sorted(resolved_strategy_names - matched_names)
-                if unmatched:
-                    logger.warning(
-                        f'Unknown or unmatched strategy name(s): {unmatched} — no datapoints generated for them.'
-                    )
-            if not dynamic_datapoints:
-                logger.warning(
-                    'Empty intersection: filter selection produced zero datapoints. '
-                    f'(strategies={sorted(resolved_strategy_names) if resolved_strategy_names else None}, '
-                    f'delivery_methods={sorted(m.value for m in resolved_delivery_methods) if resolved_delivery_methods else None})'
-                )
+        _warn_on_filter_mismatch(dynamic_datapoints, resolved_strategy_names, resolved_delivery_methods)
 
         if (
             max_dynamic_datapoints is not None
@@ -1766,6 +1781,7 @@ async def _run_dynamic_or_hybrid(
                             strategy_names=resolved_strategy_names,
                             delivery_methods=resolved_delivery_methods,
                         )
+                    _warn_on_filter_mismatch(at_dps, resolved_strategy_names, resolved_delivery_methods)
                     if (
                         max_dynamic_datapoints is not None
                         and max_dynamic_datapoints > 0

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -300,7 +300,7 @@ async def red_team(
     categories: list[str] | None = None,
     vulnerabilities: list[str] | None = None,
     strategies: list[str] | None = None,
-    delivery_methods: list[DeliveryMethod] | None = None,
+    delivery_methods: list[DeliveryMethod | str] | None = None,
     max_turns: int = 5,
     max_per_category: int | None = None,
     parallelism: int = 10,
@@ -517,7 +517,7 @@ async def red_team(
     # rejected at the CLI boundary; here we pass through verbatim and detect
     # empty/unmatched intersections post-filter from the actually-matched set.
     resolved_strategy_names: set[str] | None = set(strategies) if strategies is not None else None
-    resolved_delivery_methods: set[DeliveryMethod] | None = (
+    resolved_delivery_methods: set[DeliveryMethod | str] | None = (
         set(delivery_methods) if delivery_methods is not None else None
     )
 
@@ -956,20 +956,24 @@ def _make_agent_backend(*, target_config: TargetConfig | None, pipeline_config: 
     )
 
 
-def _delivery_method_values(delivery_methods: set[DeliveryMethod] | None) -> list[str] | None:
-    """Convert a DeliveryMethod set to enum-value strings for the dataset loader.
+def _delivery_method_values(delivery_methods: set[DeliveryMethod | str] | None) -> list[str] | None:
+    """Convert a delivery-method selection to plain strings for the dataset loader.
 
-    Static rows are filtered by delivery method inside ``load_owasp_agentic_dataset``
-    (before its ``num_samples`` cap), which takes plain string values. ``None``
-    stays ``None`` so the loader leaves the filter disabled.
+    The selection is an open set: known methods are :class:`DeliveryMethod` enum
+    members, unknown ones are raw strings. Both become their string value for the
+    loader (which filters by exact string match). Static rows are filtered inside
+    ``load_owasp_agentic_dataset`` before its ``num_samples`` cap. ``None`` stays
+    ``None`` so the loader leaves the filter disabled.
     """
-    return [m.value for m in delivery_methods] if delivery_methods is not None else None
+    if delivery_methods is None:
+        return None
+    return [m.value if isinstance(m, DeliveryMethod) else m for m in delivery_methods]
 
 
 def _check_filter_results(
     datapoints: list[DataPoint],
     strategy_names: set[str] | None,
-    delivery_methods: set[DeliveryMethod] | None,
+    delivery_methods: set[DeliveryMethod | str] | None,
     *,
     names_apply: bool = True,
     present_methods: list[str] | None = None,
@@ -998,33 +1002,29 @@ def _check_filter_results(
 
     matched_names: set[str] = set()
     matched_methods: set[str] = set()
-    # Normalize delivery methods the same way the dataset loader does, so a row
-    # kept by the case-insensitive loader filter is not then reported "unmatched".
-    from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import normalize_delivery_method
-
     for dp in datapoints:
         strategy = dp.inputs.get('strategy')
         if isinstance(strategy, dict):
             name = strategy.get('name')
             if name:
                 matched_names.add(name)
-            matched_methods.update(normalize_delivery_method(m) for m in (strategy.get('delivery_methods') or []))
+            matched_methods.update(strategy.get('delivery_methods') or [])
         single = dp.inputs.get('delivery_method')  # static datapoint shape (singular)
         if single:
-            matched_methods.add(normalize_delivery_method(single))
+            matched_methods.add(single)
 
     if strategy_names is not None and names_apply:
         unmatched = sorted(strategy_names - matched_names)
         if unmatched:
             logger.warning(f'Unmatched strategy name(s): {unmatched} — no datapoints matched.')
     if delivery_methods is not None:
-        unmatched_methods = sorted({normalize_delivery_method(m.value) for m in delivery_methods} - matched_methods)
+        unmatched_methods = sorted(set(_delivery_method_values(delivery_methods) or []) - matched_methods)
         if unmatched_methods:
             logger.warning(f'Unmatched delivery method(s): {unmatched_methods} — no datapoints use them.')
 
     if not datapoints:
         names_repr = sorted(strategy_names) if strategy_names else None
-        methods_repr = sorted(m.value for m in delivery_methods) if delivery_methods else None
+        methods_repr = sorted(_delivery_method_values(delivery_methods) or []) if delivery_methods else None
         msg = (
             'Filter selection produced zero datapoints — nothing to run. '
             f'(strategies={names_repr}, delivery_methods={methods_repr})'
@@ -1062,7 +1062,7 @@ async def _prepare_target(
     verbosity: int = 0,
     pipeline_config: LLMConfig | None = None,
     resolved_strategy_names: set[str] | None = None,
-    resolved_delivery_methods: set[DeliveryMethod] | None = None,
+    resolved_delivery_methods: set[DeliveryMethod | str] | None = None,
 ) -> PreparedTarget:
     """Prepare all per-target state for a dynamic or hybrid run.
 
@@ -1338,7 +1338,7 @@ async def _run_dynamic_or_hybrid(
     verbosity: int = 0,
     pipeline_config: LLMConfig | None = None,
     resolved_strategy_names: set[str] | None = None,
-    resolved_delivery_methods: set[DeliveryMethod] | None = None,
+    resolved_delivery_methods: set[DeliveryMethod | str] | None = None,
 ) -> RedTeamReport:
     """Run dynamic or hybrid red teaming for multiple targets in a single evaluatorq call.
 
@@ -2344,7 +2344,7 @@ async def _run_static(
     target_config: TargetConfig | None = None,
     pipeline_config: LLMConfig | None = None,
     resolved_strategy_names: set[str] | None = None,
-    resolved_delivery_methods: set[DeliveryMethod] | None = None,
+    resolved_delivery_methods: set[DeliveryMethod | str] | None = None,
 ) -> RedTeamReport:
     """Run static red teaming for multiple targets in a single ``evaluatorq()`` call.
 

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -972,6 +972,7 @@ def _check_filter_results(
     delivery_methods: set[DeliveryMethod] | None,
     *,
     names_apply: bool = True,
+    present_methods: list[str] | None = None,
 ) -> None:
     """Surface strategy/delivery-method filter mismatches; fail on an empty run.
 
@@ -985,6 +986,12 @@ def _check_filter_results(
     ``names_apply=False`` suppresses per-name warnings on paths whose datapoints
     never carry a strategy name (static mode), where the caller warns once that
     name filtering does not apply instead.
+
+    ``present_methods`` (static path) lists the ``delivery_method`` values
+    actually present in the dataset; when an empty run is caused by a delivery
+    filter, they are surfaced in the error so the user sees a spelling mismatch
+    (``you asked for 'crescendo', the dataset uses 'Crescendo attack'``) rather
+    than a bare "zero datapoints".
     """
     if strategy_names is None and delivery_methods is None:
         return
@@ -1018,10 +1025,13 @@ def _check_filter_results(
     if not datapoints:
         names_repr = sorted(strategy_names) if strategy_names else None
         methods_repr = sorted(m.value for m in delivery_methods) if delivery_methods else None
-        raise RedTeamError(
+        msg = (
             'Filter selection produced zero datapoints — nothing to run. '
             f'(strategies={names_repr}, delivery_methods={methods_repr})'
         )
+        if present_methods:
+            msg += f' Delivery methods present in the dataset: {present_methods}.'
+        raise RedTeamError(msg)
 
 
 async def _prepare_target(
@@ -2397,7 +2407,14 @@ async def _run_static(
             f'ignoring strategy filter {sorted(resolved_strategy_names)} in static mode.'
         )
     if isinstance(data, list):
-        _check_filter_results(data, None, resolved_delivery_methods, names_apply=False)
+        # On an empty delivery-filtered static run, reload unfiltered (cheap, error
+        # path only) to report the delivery_method values the dataset actually
+        # carries — surfacing spelling/format drift instead of a bare "zero datapoints".
+        present_methods: list[str] | None = None
+        if resolved_delivery_methods is not None and not data:
+            present_rows = load_owasp_agentic_dataset(dataset=dataset, categories=categories)
+            present_methods = sorted({m for dp in present_rows if (m := dp.inputs.get('delivery_method'))})
+        _check_filter_results(data, None, resolved_delivery_methods, names_apply=False, present_methods=present_methods)
         _save_stage(output_dir, '01_datapoints.json', json.dumps([dp.inputs for dp in data], indent=2, default=str))
 
     # Build one job per target using the shared helper

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/ui/dashboard.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/ui/dashboard.py
@@ -364,7 +364,7 @@ def _render_sidebar_filters(results: list[RedTeamResult]) -> list[RedTeamResult]
     all_categories = sorted({r.attack.category for r in results})
     all_severities = [s for s in SEVERITY_ORDER if any(r.attack.severity.value == s for r in results)]
     all_techniques = sorted({r.attack.attack_technique.value for r in results})
-    all_delivery = sorted({dm.value for r in results for dm in (r.attack.delivery_methods or [])})
+    all_delivery = sorted({getattr(dm, "value", dm) for r in results for dm in (r.attack.delivery_methods or [])})
     all_vulnerabilities = sorted({r.attack.vulnerability for r in results if r.attack.vulnerability})
     all_agents = sorted({r.agent.key or r.agent.display_name or "unknown" for r in results})
 
@@ -470,7 +470,11 @@ def _render_sidebar_filters(results: list[RedTeamResult]) -> list[RedTeamResult]
         filtered = [r for r in filtered if r.attack.attack_technique.value in sel_techniques]
 
     if all_delivery and set(sel_delivery) != set(all_delivery):
-        filtered = [r for r in filtered if any(dm.value in sel_delivery for dm in (r.attack.delivery_methods or []))]
+        filtered = [
+            r
+            for r in filtered
+            if any(getattr(dm, "value", dm) in sel_delivery for dm in (r.attack.delivery_methods or []))
+        ]
 
     if all_vulnerabilities and set(sel_vulnerabilities) != set(all_vulnerabilities):
         filtered = [r for r in filtered if r.attack.vulnerability in sel_vulnerabilities]
@@ -1321,7 +1325,7 @@ def _render_interactive_breakdown(results: list[RedTeamResult], summary: ReportS
         if dim == "attack_technique":
             return r.attack.attack_technique.value
         if dim == "delivery_method":
-            return r.attack.delivery_methods[0].value if r.attack.delivery_methods else "unknown"
+            return getattr(r.attack.delivery_methods[0], "value", r.attack.delivery_methods[0]) if r.attack.delivery_methods else "unknown"
         if dim == "turn_type":
             return r.attack.turn_type.value if r.attack.turn_type else "unknown"
         if dim == "source":
@@ -1854,7 +1858,7 @@ def _render_result_detail(result: RedTeamResult) -> None:
     mc5.markdown(f"**Turn Type:** {atk.turn_type.value}")
 
     if atk.delivery_methods:
-        st.markdown(f"**Delivery Methods:** {', '.join(dm.value for dm in atk.delivery_methods)}")
+        st.markdown(f"**Delivery Methods:** {', '.join(getattr(dm, 'value', dm) for dm in atk.delivery_methods)}")
 
     # Execution details
     if result.execution:

--- a/packages/evaluatorq-py/tests/redteam/e2e/test_hybrid_pipeline.py
+++ b/packages/evaluatorq-py/tests/redteam/e2e/test_hybrid_pipeline.py
@@ -56,6 +56,39 @@ async def test_full_hybrid_run(
 
 
 @pytest.mark.asyncio
+async def test_hybrid_delivery_filter_threads_to_static(
+    mock_llm_client: DeterministicAsyncOpenAI,
+    mock_backend_bundle: MockBackend,
+    static_dataset_path: Path,
+) -> None:
+    """A delivery filter threads through the hybrid static-load path without breaking it.
+
+    All fixture rows use 'direct-request', so filtering to it keeps the static
+    rows; the run must still succeed and include static datapoints (a dropped
+    delivery_methods kwarg at the hybrid load site would not regress this, but an
+    over-eager empty/hard-fail or a crash would).
+    """
+    from evaluatorq.redteam.contracts import DeliveryMethod
+
+    with _hybrid_patches(mock_backend_bundle):
+        report = await red_team(
+            "agent:e2e-test-agent",
+            mode="hybrid",
+            categories=["ASI01"],
+            generate_strategies=False,
+            delivery_methods=[DeliveryMethod.DIRECT_REQUEST],
+            parallelism=2,
+            llm_client=cast(AsyncOpenAI, cast(object, mock_llm_client)),
+            dataset=str(static_dataset_path),
+        )
+
+    errors = validate_report_structure(report, expected_pipeline="hybrid", min_results=1)
+    assert not errors, f"Report validation errors: {errors}"
+    breakdown = report.summary.datapoint_breakdown or {}
+    assert breakdown.get("static", 0) >= 1, f"Expected static rows to survive the filter, got {breakdown}"
+
+
+@pytest.mark.asyncio
 async def test_hybrid_independent_caps(
     mock_llm_client: DeterministicAsyncOpenAI,
     mock_backend_bundle: MockBackend,

--- a/packages/evaluatorq-py/tests/redteam/e2e/test_multi_target.py
+++ b/packages/evaluatorq-py/tests/redteam/e2e/test_multi_target.py
@@ -42,3 +42,26 @@ async def test_multi_target_static_merge(
     agent_models = {r.agent.model for r in report.results}
     assert "model-a" in agent_models, f"Expected model-a in results, got {agent_models}"
     assert "model-b" in agent_models, f"Expected model-b in results, got {agent_models}"
+
+
+@pytest.mark.asyncio
+async def test_multi_target_empty_delivery_filter_hard_fails(
+    mock_llm_client: DeterministicAsyncOpenAI,
+    static_dataset_path: Path,
+) -> None:
+    """A delivery filter matching no rows hard-fails the whole multi-target run."""
+    from evaluatorq.redteam.contracts import DeliveryMethod
+    from evaluatorq.redteam.exceptions import RedTeamError
+
+    client = cast(AsyncOpenAI, cast(object, mock_llm_client))
+    targets = [OpenAIModelTarget("model-a", client=client), OpenAIModelTarget("model-b", client=client)]
+
+    with pytest.raises(RedTeamError, match="zero datapoints"):
+        await red_team(
+            targets,
+            mode="static",
+            delivery_methods=[DeliveryMethod.BASE64],  # no fixture row uses this
+            parallelism=2,
+            dataset=str(static_dataset_path),
+            llm_client=client,
+        )

--- a/packages/evaluatorq-py/tests/redteam/e2e/test_static_pipeline.py
+++ b/packages/evaluatorq-py/tests/redteam/e2e/test_static_pipeline.py
@@ -131,11 +131,13 @@ async def test_static_delivery_method_empty_match_hard_fails(
     mock_backend_bundle: MockBackend,
     static_dataset_path: Path,
 ) -> None:
-    """A delivery filter matching no static row raises rather than running nothing."""
+    """A delivery filter matching no static row raises, naming the dataset's actual methods."""
     from evaluatorq.redteam.contracts import DeliveryMethod
     from evaluatorq.redteam.exceptions import RedTeamError
 
-    with _static_patches(mock_backend_bundle), pytest.raises(RedTeamError, match="zero datapoints"):
+    # All fixture rows use 'direct-request'; filtering to base64 empties the run.
+    # The error must surface what the dataset actually carries.
+    with _static_patches(mock_backend_bundle), pytest.raises(RedTeamError, match="direct-request") as exc:
         await red_team(
             "agent:e2e-static-model",
             mode="static",
@@ -144,6 +146,7 @@ async def test_static_delivery_method_empty_match_hard_fails(
             dataset=str(static_dataset_path),
             llm_client=cast(AsyncOpenAI, cast(object, mock_llm_client)),
         )
+    assert "zero datapoints" in str(exc.value)
 
 
 @pytest.mark.asyncio

--- a/packages/evaluatorq-py/tests/redteam/e2e/test_static_pipeline.py
+++ b/packages/evaluatorq-py/tests/redteam/e2e/test_static_pipeline.py
@@ -100,6 +100,53 @@ async def test_static_category_filtering(
 
 
 @pytest.mark.asyncio
+async def test_static_delivery_method_filtering(
+    mock_llm_client: DeterministicAsyncOpenAI,
+    mock_backend_bundle: MockBackend,
+    static_dataset_path: Path,
+) -> None:
+    """delivery_methods filter on the full static path lets matching rows reach jobs.
+
+    All 3 fixture rows are 'direct-request', so filtering to it keeps all 3 — proving
+    the filter threads end-to-end through red_team(mode='static') to the results.
+    """
+    from evaluatorq.redteam.contracts import DeliveryMethod
+
+    with _static_patches(mock_backend_bundle):
+        report = await red_team(
+            "agent:e2e-static-model",
+            mode="static",
+            delivery_methods=[DeliveryMethod.DIRECT_REQUEST],
+            parallelism=2,
+            dataset=str(static_dataset_path),
+            llm_client=cast(AsyncOpenAI, cast(object, mock_llm_client)),
+        )
+
+    assert report.total_results == 3
+
+
+@pytest.mark.asyncio
+async def test_static_delivery_method_empty_match_hard_fails(
+    mock_llm_client: DeterministicAsyncOpenAI,
+    mock_backend_bundle: MockBackend,
+    static_dataset_path: Path,
+) -> None:
+    """A delivery filter matching no static row raises rather than running nothing."""
+    from evaluatorq.redteam.contracts import DeliveryMethod
+    from evaluatorq.redteam.exceptions import RedTeamError
+
+    with _static_patches(mock_backend_bundle), pytest.raises(RedTeamError, match="zero datapoints"):
+        await red_team(
+            "agent:e2e-static-model",
+            mode="static",
+            delivery_methods=[DeliveryMethod.BASE64],  # no fixture row uses this
+            parallelism=2,
+            dataset=str(static_dataset_path),
+            llm_client=cast(AsyncOpenAI, cast(object, mock_llm_client)),
+        )
+
+
+@pytest.mark.asyncio
 async def test_static_datapoint_capping(
     mock_llm_client: DeterministicAsyncOpenAI,
     mock_backend_bundle: MockBackend,

--- a/packages/evaluatorq-py/tests/redteam/test_cli.py
+++ b/packages/evaluatorq-py/tests/redteam/test_cli.py
@@ -11,11 +11,11 @@ Covers:
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
+
 from click.testing import Result as CliResult
 from typer.testing import CliRunner
 
 from evaluatorq.redteam.cli import app
-
 
 runner = CliRunner()
 
@@ -85,6 +85,14 @@ class TestVulnerabilityShortFlag:
         assert result.exit_code == 0, result.output
         _kwargs = mock_rt.call_args.kwargs
         assert _kwargs["vulnerabilities"] == ["tool_misuse"]
+
+    def test_comma_separated_vulnerabilities(self):
+        """-V accepts comma-separated IDs, split before validation."""
+        result, mock_rt = _run_with_mocked_red_team(
+            ["run", "--target", "agent:test-agent", "-V", "goal_hijacking,prompt_injection", "--yes"]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_rt.call_args.kwargs["vulnerabilities"] == ["goal_hijacking", "prompt_injection"]
 
 
 # ---------------------------------------------------------------------------
@@ -248,6 +256,22 @@ class TestStrategyFlag:
         assert result.exit_code == 0, result.output
         assert mock_rt.call_args.kwargs["strategies"] == ["jailbreak_dan"]
 
+    def test_comma_separated_strategies(self):
+        result, mock_rt = _run_with_mocked_red_team(
+            ["run", "--target", "agent:test-agent", "-s", "direct_override,crescendo_injection", "--yes"]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_rt.call_args.kwargs["strategies"] == ["direct_override", "crescendo_injection"]
+
+    def test_comma_separated_strategy_with_invalid_token_rejected(self):
+        # One bad token in a CSV list is rejected via the known_strategy_names
+        # branch (distinct from the delivery-method enum validation).
+        result, mock_rt = _run_with_mocked_red_team(
+            ["run", "--target", "agent:test-agent", "-s", "direct_override,definitely_not_a_strategy", "--yes"]
+        )
+        assert result.exit_code != 0
+        mock_rt.assert_not_called()
+
     def test_strategy_defaults_to_none_when_omitted(self):
         result, mock_rt = _run_with_mocked_red_team(
             ["run", "--target", "agent:test-agent", "--yes"]
@@ -311,12 +335,13 @@ class TestDeliveryMethodFlag:
         assert result.exit_code == 0, result.output
         assert mock_rt.call_args.kwargs["delivery_methods"] == [DeliveryMethod.LEETSPEAK]
 
-    def test_delivery_method_unknown_value_rejected_by_typer(self):
-        # Typer/Click rejects values outside the DeliveryMethod enum at parse time.
-        result, _mock_rt = _run_with_mocked_red_team(
+    def test_delivery_method_unknown_value_rejected(self):
+        # Values outside the DeliveryMethod enum are rejected (BadParameter), no run.
+        result, mock_rt = _run_with_mocked_red_team(
             ["run", "--target", "agent:test-agent", "-d", "not-a-real-method", "--yes"]
         )
         assert result.exit_code != 0
+        mock_rt.assert_not_called()
 
     def test_delivery_method_defaults_to_none_when_omitted(self):
         result, mock_rt = _run_with_mocked_red_team(
@@ -324,6 +349,25 @@ class TestDeliveryMethodFlag:
         )
         assert result.exit_code == 0, result.output
         assert mock_rt.call_args.kwargs["delivery_methods"] is None
+
+    def test_comma_separated_delivery_methods(self):
+        from evaluatorq.redteam.contracts import DeliveryMethod
+
+        result, mock_rt = _run_with_mocked_red_team(
+            ["run", "--target", "agent:test-agent", "-d", "crescendo,base64", "--yes"]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_rt.call_args.kwargs["delivery_methods"] == [
+            DeliveryMethod.CRESCENDO,
+            DeliveryMethod.BASE64,
+        ]
+
+    def test_comma_separated_with_invalid_token_rejected(self):
+        result, mock_rt = _run_with_mocked_red_team(
+            ["run", "--target", "agent:test-agent", "-d", "crescendo,bogus", "--yes"]
+        )
+        assert result.exit_code != 0
+        mock_rt.assert_not_called()
 
 
 class TestStrategyAndDeliveryMethodCombined:

--- a/packages/evaluatorq-py/tests/redteam/test_cli.py
+++ b/packages/evaluatorq-py/tests/redteam/test_cli.py
@@ -335,13 +335,15 @@ class TestDeliveryMethodFlag:
         assert result.exit_code == 0, result.output
         assert mock_rt.call_args.kwargs["delivery_methods"] == [DeliveryMethod.LEETSPEAK]
 
-    def test_delivery_method_unknown_value_rejected(self):
-        # Values outside the DeliveryMethod enum are rejected (BadParameter), no run.
+    def test_delivery_method_unknown_value_accepted_as_open_set(self):
+        # Unknown delivery methods are an open set: accepted (with a warning) and
+        # forwarded as a raw string so a dataset's custom method stays filterable.
         result, mock_rt = _run_with_mocked_red_team(
             ["run", "--target", "agent:test-agent", "-d", "not-a-real-method", "--yes"]
         )
-        assert result.exit_code != 0
-        mock_rt.assert_not_called()
+        assert result.exit_code == 0, result.output
+        assert mock_rt.call_args.kwargs["delivery_methods"] == ["not-a-real-method"]
+        assert "not in DeliveryMethod" in result.output
 
     def test_delivery_method_defaults_to_none_when_omitted(self):
         result, mock_rt = _run_with_mocked_red_team(
@@ -362,12 +364,15 @@ class TestDeliveryMethodFlag:
             DeliveryMethod.BASE64,
         ]
 
-    def test_comma_separated_with_invalid_token_rejected(self):
+    def test_comma_separated_mixes_known_and_unknown(self):
+        # Known token -> enum, unknown token -> raw string (open set), both forwarded.
+        from evaluatorq.redteam.contracts import DeliveryMethod
+
         result, mock_rt = _run_with_mocked_red_team(
             ["run", "--target", "agent:test-agent", "-d", "crescendo,bogus", "--yes"]
         )
-        assert result.exit_code != 0
-        mock_rt.assert_not_called()
+        assert result.exit_code == 0, result.output
+        assert mock_rt.call_args.kwargs["delivery_methods"] == [DeliveryMethod.CRESCENDO, "bogus"]
 
 
 class TestStrategyAndDeliveryMethodCombined:

--- a/packages/evaluatorq-py/tests/redteam/test_cli.py
+++ b/packages/evaluatorq-py/tests/redteam/test_cli.py
@@ -206,3 +206,124 @@ class TestVulnerabilityHelpText:
         """Help text mentions OWASP category codes are also accepted (e.g. ASI01)."""
         output = self._get_help_output()
         assert "ASI01" in output or "LLM01" in output
+
+
+# ---------------------------------------------------------------------------
+# 4. --strategy / --delivery-method flags
+# ---------------------------------------------------------------------------
+
+
+class TestStrategyFlag:
+    """--strategy / -s short and long form, single + repeated."""
+
+    def test_short_flag_s_accepted_single_value(self):
+        result, mock_rt = _run_with_mocked_red_team(
+            ["run", "--target", "agent:test-agent", "-s", "direct_injection_attack", "--yes"]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_rt.call_args.kwargs["strategies"] == ["direct_injection_attack"]
+
+    def test_short_flag_s_repeats(self):
+        result, mock_rt = _run_with_mocked_red_team(
+            [
+                "run",
+                "--target", "agent:test-agent",
+                "-s", "direct_injection_attack",
+                "-s", "crescendo_injection",
+                "--yes",
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_rt.call_args.kwargs["strategies"] == [
+            "direct_injection_attack",
+            "crescendo_injection",
+        ]
+
+    def test_long_flag_strategy(self):
+        result, mock_rt = _run_with_mocked_red_team(
+            ["run", "--target", "agent:test-agent", "--strategy", "alpha", "--yes"]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_rt.call_args.kwargs["strategies"] == ["alpha"]
+
+    def test_strategy_defaults_to_none_when_omitted(self):
+        result, mock_rt = _run_with_mocked_red_team(
+            ["run", "--target", "agent:test-agent", "--yes"]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_rt.call_args.kwargs["strategies"] is None
+
+
+class TestDeliveryMethodFlag:
+    """--delivery-method / -d short and long form, enum validation."""
+
+    def test_short_flag_d_accepted_single_value(self):
+        from evaluatorq.redteam.contracts import DeliveryMethod
+
+        result, mock_rt = _run_with_mocked_red_team(
+            ["run", "--target", "agent:test-agent", "-d", "crescendo", "--yes"]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_rt.call_args.kwargs["delivery_methods"] == [DeliveryMethod.CRESCENDO]
+
+    def test_short_flag_d_repeats(self):
+        from evaluatorq.redteam.contracts import DeliveryMethod
+
+        result, mock_rt = _run_with_mocked_red_team(
+            [
+                "run",
+                "--target", "agent:test-agent",
+                "-d", "crescendo",
+                "-d", "base64",
+                "--yes",
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_rt.call_args.kwargs["delivery_methods"] == [
+            DeliveryMethod.CRESCENDO,
+            DeliveryMethod.BASE64,
+        ]
+
+    def test_long_flag_delivery_method(self):
+        from evaluatorq.redteam.contracts import DeliveryMethod
+
+        result, mock_rt = _run_with_mocked_red_team(
+            ["run", "--target", "agent:test-agent", "--delivery-method", "leetspeak", "--yes"]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_rt.call_args.kwargs["delivery_methods"] == [DeliveryMethod.LEETSPEAK]
+
+    def test_delivery_method_unknown_value_rejected_by_typer(self):
+        # Typer/Click rejects values outside the DeliveryMethod enum at parse time.
+        result, _mock_rt = _run_with_mocked_red_team(
+            ["run", "--target", "agent:test-agent", "-d", "not-a-real-method", "--yes"]
+        )
+        assert result.exit_code != 0
+
+    def test_delivery_method_defaults_to_none_when_omitted(self):
+        result, mock_rt = _run_with_mocked_red_team(
+            ["run", "--target", "agent:test-agent", "--yes"]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_rt.call_args.kwargs["delivery_methods"] is None
+
+
+class TestStrategyAndDeliveryMethodCombined:
+    """--strategy and --delivery-method can be combined freely."""
+
+    def test_both_flags_forwarded_together(self):
+        from evaluatorq.redteam.contracts import DeliveryMethod
+
+        result, mock_rt = _run_with_mocked_red_team(
+            [
+                "run",
+                "--target", "agent:test-agent",
+                "-s", "crescendo_injection",
+                "-d", "crescendo",
+                "--yes",
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        kwargs = mock_rt.call_args.kwargs
+        assert kwargs["strategies"] == ["crescendo_injection"]
+        assert kwargs["delivery_methods"] == [DeliveryMethod.CRESCENDO]

--- a/packages/evaluatorq-py/tests/redteam/test_cli.py
+++ b/packages/evaluatorq-py/tests/redteam/test_cli.py
@@ -173,7 +173,9 @@ class TestVulnerabilityHelpText:
 
     def _get_help_output(self) -> str:
         import re
-        result = runner.invoke(app, ["run", "--help"])
+        # TERM=dumb + wide COLUMNS: stop rich from routing help to its own
+        # terminal console (empty captured output) or wrapping flag tokens.
+        result = runner.invoke(app, ["run", "--help"], env={"TERM": "dumb", "COLUMNS": "200"})
         # Strip ANSI escape codes so assertions work regardless of terminal width
         return re.sub(r'\x1b\[[0-9;]*m', '', result.output)
 
@@ -218,33 +220,33 @@ class TestStrategyFlag:
 
     def test_short_flag_s_accepted_single_value(self):
         result, mock_rt = _run_with_mocked_red_team(
-            ["run", "--target", "agent:test-agent", "-s", "direct_injection_attack", "--yes"]
+            ["run", "--target", "agent:test-agent", "-s", "direct_override", "--yes"]
         )
         assert result.exit_code == 0, result.output
-        assert mock_rt.call_args.kwargs["strategies"] == ["direct_injection_attack"]
+        assert mock_rt.call_args.kwargs["strategies"] == ["direct_override"]
 
     def test_short_flag_s_repeats(self):
         result, mock_rt = _run_with_mocked_red_team(
             [
                 "run",
                 "--target", "agent:test-agent",
-                "-s", "direct_injection_attack",
+                "-s", "direct_override",
                 "-s", "crescendo_injection",
                 "--yes",
             ]
         )
         assert result.exit_code == 0, result.output
         assert mock_rt.call_args.kwargs["strategies"] == [
-            "direct_injection_attack",
+            "direct_override",
             "crescendo_injection",
         ]
 
     def test_long_flag_strategy(self):
         result, mock_rt = _run_with_mocked_red_team(
-            ["run", "--target", "agent:test-agent", "--strategy", "alpha", "--yes"]
+            ["run", "--target", "agent:test-agent", "--strategy", "jailbreak_dan", "--yes"]
         )
         assert result.exit_code == 0, result.output
-        assert mock_rt.call_args.kwargs["strategies"] == ["alpha"]
+        assert mock_rt.call_args.kwargs["strategies"] == ["jailbreak_dan"]
 
     def test_strategy_defaults_to_none_when_omitted(self):
         result, mock_rt = _run_with_mocked_red_team(
@@ -252,6 +254,22 @@ class TestStrategyFlag:
         )
         assert result.exit_code == 0, result.output
         assert mock_rt.call_args.kwargs["strategies"] is None
+
+    def test_unknown_strategy_name_rejected(self):
+        result, mock_rt = _run_with_mocked_red_team(
+            ["run", "--target", "agent:test-agent", "--strategy", "definitely_not_a_strategy", "--yes"]
+        )
+        assert result.exit_code == 2  # typer.BadParameter
+        mock_rt.assert_not_called()
+
+    def test_generated_prefix_name_accepted(self):
+        # Runtime-generated strategy names (generated_*) are not in the registry
+        # but must still pass validation so a user can re-filter a prior run.
+        result, mock_rt = _run_with_mocked_red_team(
+            ["run", "--target", "agent:test-agent", "--strategy", "generated_single_01_foo", "--yes"]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_rt.call_args.kwargs["strategies"] == ["generated_single_01_foo"]
 
 
 class TestDeliveryMethodFlag:

--- a/packages/evaluatorq-py/tests/redteam/test_converters.py
+++ b/packages/evaluatorq-py/tests/redteam/test_converters.py
@@ -753,6 +753,19 @@ class TestStaticSampleToResult:
         assert result.evaluation.passed is True
         assert result.evaluation.explanation == 'Resistant'
 
+    def test_known_delivery_method_becomes_enum(self):
+        sample = self._base_sample()  # delivery_method='direct-request'
+        result = static_sample_to_result(sample, agent_key='my-agent')
+        assert result.attack.delivery_methods == [DeliveryMethod.DIRECT_REQUEST]
+
+    def test_custom_delivery_method_does_not_crash(self):
+        # Open set: a dataset row with a non-enum delivery_method must convert
+        # without raising (regression: DeliveryMethod('my-custom') used to crash).
+        sample = self._base_sample()
+        sample['input'] = {**sample['input'], 'delivery_method': 'my-custom-method'}
+        result = static_sample_to_result(sample, agent_key='my-agent')
+        assert result.attack.delivery_methods == ['my-custom-method']
+
     def test_no_value_evaluation_value_is_none(self):
         sample = self._base_sample()
         sample['evaluation_result'] = {'explanation': 'no score here'}

--- a/packages/evaluatorq-py/tests/redteam/test_method_selection.py
+++ b/packages/evaluatorq-py/tests/redteam/test_method_selection.py
@@ -144,3 +144,57 @@ class TestRegistryNameUniqueness:
         assert all(s.name == sample_name for s in kept)
 
 
+def _capture_warnings(fn) -> list[str]:
+    """Run fn() with a temporary loguru sink and return WARNING-level messages."""
+    from loguru import logger
+
+    msgs: list[str] = []
+    sink_id = logger.add(msgs.append, level="WARNING")
+    try:
+        fn()
+    finally:
+        logger.remove(sink_id)
+    return msgs
+
+
+class TestWarnOnFilterMismatch:
+    """Runner-level warning behavior shared by single- and multi-target paths."""
+
+    def _dps(self, *names: str) -> list:
+        from evaluatorq import DataPoint
+
+        return [DataPoint(inputs={"strategy": {"name": n}}) for n in names]
+
+    def test_no_filter_emits_nothing(self) -> None:
+        from evaluatorq.redteam.runner import _warn_on_filter_mismatch
+
+        msgs = _capture_warnings(lambda: _warn_on_filter_mismatch(self._dps("alpha"), None, None))
+        assert msgs == []
+
+    def test_unmatched_name_warns(self) -> None:
+        from evaluatorq.redteam.runner import _warn_on_filter_mismatch
+
+        msgs = _capture_warnings(
+            lambda: _warn_on_filter_mismatch(self._dps("alpha"), {"alpha", "ghost"}, None)
+        )
+        assert any("Unmatched strategy name(s)" in m and "ghost" in m for m in msgs)
+        # 'alpha' matched, so it must not be reported as unmatched.
+        assert not any("alpha" in m for m in msgs)
+
+    def test_all_names_matched_no_warning(self) -> None:
+        from evaluatorq.redteam.runner import _warn_on_filter_mismatch
+
+        msgs = _capture_warnings(
+            lambda: _warn_on_filter_mismatch(self._dps("alpha", "beta"), {"alpha"}, None)
+        )
+        assert msgs == []
+
+    def test_empty_intersection_warns(self) -> None:
+        from evaluatorq.redteam.runner import _warn_on_filter_mismatch
+
+        msgs = _capture_warnings(
+            lambda: _warn_on_filter_mismatch([], {"alpha"}, {DeliveryMethod.CRESCENDO})
+        )
+        assert any("Empty intersection" in m for m in msgs)
+
+

--- a/packages/evaluatorq-py/tests/redteam/test_method_selection.py
+++ b/packages/evaluatorq-py/tests/redteam/test_method_selection.py
@@ -1,10 +1,15 @@
 """Tests for strategy-name / delivery-method selection in red_team().
 
-Covers the predicate behavior in `_filter_by_method` directly, plus runner-level
-warning behavior for unknown names and empty intersections.
+Covers the predicate behavior in `_filter_by_method` directly, the filter
+threaded end-to-end through the planner (including the filter-before-cap
+ordering and the category-fallback path), plus runner-level warn/hard-fail
+behavior for unknown names, unmatched delivery methods, and empty intersections.
 """
 
 from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -13,12 +18,43 @@ from evaluatorq.redteam.adaptive.strategy_registry import (
     _filter_by_method,
 )
 from evaluatorq.redteam.contracts import (
+    AgentContext,
     AttackStrategy,
     AttackTechnique,
     DeliveryMethod,
+    MemoryStoreInfo,
     Severity,
+    ToolInfo,
     TurnType,
+    Vulnerability,
 )
+
+
+def _capable_agent_context() -> AgentContext:
+    """Agent context with tools + memory so capability filtering keeps >=2 strategies."""
+    return AgentContext(
+        key='test-agent',
+        tools=[ToolInfo(name='search')],
+        memory_stores=[MemoryStoreInfo(id='ms_001', key='history')],
+    )
+
+
+async def _plan(vulns, **kwargs):
+    """Invoke the planner with the shared no-LLM defaults used across these tests."""
+    from evaluatorq.redteam.adaptive.strategy_planner import plan_strategies_for_vulnerabilities
+
+    base = dict(
+        agent_context=_capable_agent_context(),
+        vulnerabilities=vulns,
+        llm_client=None,
+        attack_model='test-model',
+        max_turns=5,
+        max_per_category=None,
+        generate_additional_strategies=False,
+        generated_strategy_count=0,
+    )
+    base.update(kwargs)
+    return await plan_strategies_for_vulnerabilities(**base)
 
 
 def _make_strategy(
@@ -157,44 +193,285 @@ def _capture_warnings(fn) -> list[str]:
     return msgs
 
 
-class TestWarnOnFilterMismatch:
-    """Runner-level warning behavior shared by single- and multi-target paths."""
+def _static_dps(*methods: str) -> list:
+    """Static (dataset-shaped) datapoints with a singular `delivery_method` field."""
+    from evaluatorq import DataPoint
 
-    def _dps(self, *names: str) -> list:
+    return [DataPoint(inputs={"delivery_method": m, "category": "ASI01"}) for m in methods]
+
+
+class TestCheckFilterResults:
+    """Runner-level warn + hard-fail behavior shared by single/multi-target paths."""
+
+    def _dps(self, *names: str, methods: list[str] | None = None) -> list:
         from evaluatorq import DataPoint
 
-        return [DataPoint(inputs={"strategy": {"name": n}}) for n in names]
+        return [
+            DataPoint(inputs={"strategy": {"name": n, "delivery_methods": methods or []}})
+            for n in names
+        ]
 
     def test_no_filter_emits_nothing(self) -> None:
-        from evaluatorq.redteam.runner import _warn_on_filter_mismatch
+        from evaluatorq.redteam.runner import _check_filter_results
 
-        msgs = _capture_warnings(lambda: _warn_on_filter_mismatch(self._dps("alpha"), None, None))
+        msgs = _capture_warnings(lambda: _check_filter_results(self._dps("alpha"), None, None))
         assert msgs == []
 
     def test_unmatched_name_warns(self) -> None:
-        from evaluatorq.redteam.runner import _warn_on_filter_mismatch
+        from evaluatorq.redteam.runner import _check_filter_results
 
         msgs = _capture_warnings(
-            lambda: _warn_on_filter_mismatch(self._dps("alpha"), {"alpha", "ghost"}, None)
+            lambda: _check_filter_results(self._dps("alpha"), {"alpha", "ghost"}, None)
         )
         assert any("Unmatched strategy name(s)" in m and "ghost" in m for m in msgs)
         # 'alpha' matched, so it must not be reported as unmatched.
         assert not any("alpha" in m for m in msgs)
 
     def test_all_names_matched_no_warning(self) -> None:
-        from evaluatorq.redteam.runner import _warn_on_filter_mismatch
+        from evaluatorq.redteam.runner import _check_filter_results
 
         msgs = _capture_warnings(
-            lambda: _warn_on_filter_mismatch(self._dps("alpha", "beta"), {"alpha"}, None)
+            lambda: _check_filter_results(self._dps("alpha", "beta"), {"alpha"}, None)
         )
         assert msgs == []
 
-    def test_empty_intersection_warns(self) -> None:
-        from evaluatorq.redteam.runner import _warn_on_filter_mismatch
+    def test_unmatched_delivery_method_warns(self) -> None:
+        # #2: a requested delivery method that matches no datapoint must warn,
+        # even when another method matched and the run is non-empty.
+        from evaluatorq.redteam.runner import _check_filter_results
+
+        dps = self._dps("alpha", methods=["crescendo"])
+        msgs = _capture_warnings(
+            lambda: _check_filter_results(
+                dps, None, {DeliveryMethod.CRESCENDO, DeliveryMethod.BASE64}
+            )
+        )
+        assert any("Unmatched delivery method(s)" in m and "base64" in m for m in msgs)
+        # 'crescendo' matched, so it must not be reported as unmatched.
+        assert not any("crescendo" in m for m in msgs if "Unmatched delivery" in m)
+
+    def test_delivery_method_only_no_warning_when_matched(self) -> None:
+        from evaluatorq.redteam.runner import _check_filter_results
+
+        dps = self._dps("alpha", methods=["crescendo"])
+        msgs = _capture_warnings(
+            lambda: _check_filter_results(dps, None, {DeliveryMethod.CRESCENDO})
+        )
+        assert msgs == []
+
+    def test_empty_intersection_raises(self) -> None:
+        # #1: an empty filtered run is a hard failure, not a warning.
+        from evaluatorq.redteam.exceptions import RedTeamError
+        from evaluatorq.redteam.runner import _check_filter_results
+
+        with pytest.raises(RedTeamError, match="zero datapoints"):
+            _check_filter_results([], {"alpha"}, {DeliveryMethod.CRESCENDO})
+
+    def test_no_raise_without_user_filter(self) -> None:
+        # Empty datapoints + no filter must not raise (unrelated empty runs).
+        from evaluatorq.redteam.runner import _check_filter_results
+
+        _check_filter_results([], None, None)  # must not raise
+
+    def test_static_names_apply_false_suppresses_name_warning(self) -> None:
+        # Static path: strategy names never match (no strategy name on rows), so
+        # names_apply=False suppresses the per-name warning.
+        from evaluatorq.redteam.runner import _check_filter_results
 
         msgs = _capture_warnings(
-            lambda: _warn_on_filter_mismatch([], {"alpha"}, {DeliveryMethod.CRESCENDO})
+            lambda: _check_filter_results(
+                _static_dps("crescendo"), {"alpha"}, {DeliveryMethod.CRESCENDO}, names_apply=False
+            )
         )
-        assert any("Empty intersection" in m for m in msgs)
+        assert not any("Unmatched strategy name(s)" in m for m in msgs)
+
+    def test_static_delivery_method_matched_via_singular_field(self) -> None:
+        from evaluatorq.redteam.runner import _check_filter_results
+
+        msgs = _capture_warnings(
+            lambda: _check_filter_results(
+                _static_dps("crescendo"), None, {DeliveryMethod.CRESCENDO}, names_apply=False
+            )
+        )
+        assert msgs == []
+
+    def test_case_and_punctuation_drift_no_false_unmatched_warning(self) -> None:
+        # A static row spelled 'Direct Request' (case + space) is kept by the
+        # loader's normalized match, so it must NOT be reported "unmatched" here.
+        from evaluatorq.redteam.runner import _check_filter_results
+
+        msgs = _capture_warnings(
+            lambda: _check_filter_results(
+                _static_dps("Direct Request"), None, {DeliveryMethod.DIRECT_REQUEST}, names_apply=False
+            )
+        )
+        assert msgs == []
+
+    def test_mixed_dynamic_and_static_datapoints(self) -> None:
+        # The docstring claims the check covers a combined dynamic+static set
+        # (hybrid mode). A dynamic strategy provides the name match; a static row
+        # provides the delivery-method match via its singular field.
+        from evaluatorq.redteam.runner import _check_filter_results
+
+        mixed = self._dps("alpha", methods=["crescendo"]) + _static_dps("base64")
+        msgs = _capture_warnings(
+            lambda: _check_filter_results(
+                mixed, {"alpha"}, {DeliveryMethod.CRESCENDO, DeliveryMethod.BASE64}
+            )
+        )
+        # Both the name and both methods matched somewhere in the combined set.
+        assert msgs == []
 
 
+# ---------------------------------------------------------------------------
+# 4. Filter threaded end-to-end through the planner (no LLM)
+# ---------------------------------------------------------------------------
+
+
+VULN = Vulnerability.GOAL_HIJACKING
+
+
+class TestPlannerFilterIntegration:
+    """The filter must actually run inside the planner, not just in isolation.
+
+    These exercise the real registry through the no-LLM planner path so a
+    dropped ``strategy_names=``/``delivery_methods=`` kwarg at any planner call
+    site fails a test.
+    """
+
+    @pytest.mark.asyncio
+    async def test_filter_by_name_narrows_planner_output(self) -> None:
+        base, _, _ = await _plan([VULN])
+        names = [s.name for s in base[VULN]]
+        assert len(names) >= 2, 'need >=2 applicable strategies for a meaningful filter'
+        target = names[-1]
+
+        filtered, _, _ = await _plan([VULN], strategy_names={target})
+        assert [s.name for s in filtered[VULN]] == [target]
+
+    @pytest.mark.asyncio
+    async def test_filter_by_delivery_method_narrows_planner_output(self) -> None:
+        base, _, _ = await _plan([VULN])
+        # Find a delivery method that some — but not all — strategies use, so the
+        # filter provably EXCLUDES something (not a vacuous all-pass assertion).
+        method = next(
+            (m for s in base[VULN] for m in s.delivery_methods
+             if not all(m in t.delivery_methods for t in base[VULN])),
+            None,
+        )
+        assert method is not None, 'need a non-universal delivery method for a meaningful filter'
+
+        filtered, _, _ = await _plan([VULN], delivery_methods={method})
+        assert filtered[VULN]  # at least the source strategy survives
+        assert all(method in s.delivery_methods for s in filtered[VULN])  # survivors all match
+        assert len(filtered[VULN]) < len(base[VULN])  # filter excluded at least one
+
+    @pytest.mark.asyncio
+    async def test_name_filter_survives_max_per_category_cap(self) -> None:
+        # Load-bearing guarantee: filter runs BEFORE the cap, so an explicitly
+        # selected strategy that sorts AFTER the cap index still survives.
+        # If the filter ran after the cap, only names[0] would remain and the
+        # filter on {late} would yield nothing.
+        base, _, _ = await _plan([VULN])
+        names = [s.name for s in base[VULN]]
+        assert len(names) >= 2, 'need >=2 strategies so the cap can drop the late one'
+        late = names[-1]
+
+        filtered, _, _ = await _plan([VULN], max_per_category=1, strategy_names={late})
+        assert [s.name for s in filtered[VULN]] == [late]
+
+    @pytest.mark.asyncio
+    async def test_category_fallback_path_applies_filter(self) -> None:
+        # Unresolved category → fallback branch calls select_applicable_strategies
+        # then _filter_by_method. Patch the lookup so we control the candidate set.
+        from evaluatorq.redteam.adaptive import strategy_planner
+
+        keep = _make_strategy('keep_me', delivery_methods=[DeliveryMethod.CRESCENDO])
+        drop = _make_strategy('drop_me', delivery_methods=[DeliveryMethod.BASE64])
+
+        with patch.object(strategy_planner, 'select_applicable_strategies', return_value=[keep, drop]):
+            result, _, _ = await strategy_planner.plan_strategies_for_categories(
+                agent_context=AgentContext(key='test-agent'),
+                categories=['UNRESOLVABLE_CATEGORY'],
+                llm_client=None,
+                attack_model='test-model',
+                max_turns=5,
+                max_per_category=None,
+                generate_additional_strategies=False,
+                generated_strategy_count=0,
+                strategy_names={'keep_me'},
+            )
+
+        assert [s.name for s in result['UNRESOLVABLE_CATEGORY']] == ['keep_me']
+
+
+# ---------------------------------------------------------------------------
+# 5. Static delivery-method filter — applied inside the dataset loader
+# ---------------------------------------------------------------------------
+
+
+_FIXTURE = Path(__file__).parent / 'fixtures' / 'static_e2e_dataset.json'
+
+
+class TestBridgeDeliveryFilter:
+    """`load_owasp_agentic_dataset`/`_apply_filters` filter static rows by delivery method.
+
+    Static-mode `--delivery-method` flows here (not through the strategy registry),
+    so this is the integration point for the static-path filter requirement.
+    """
+
+    def _dp(self, method: str, category: str = 'ASI01'):
+        from evaluatorq import DataPoint
+
+        return DataPoint(inputs={'delivery_method': method, 'category': category})
+
+    def test_apply_filters_narrows_by_delivery_method(self) -> None:
+        from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import _apply_filters
+
+        dps = [self._dp('base64'), self._dp('crescendo'), self._dp('leetspeak')]
+        kept = _apply_filters(dps, delivery_methods=['crescendo'])
+        assert [dp.inputs['delivery_method'] for dp in kept] == ['crescendo']
+
+    def test_delivery_filter_runs_before_num_samples_cap(self) -> None:
+        # Regression: the cap must apply to the FILTERED set, not slice first.
+        # crescendo row is last; cap=2 would slice it off if filtering ran after.
+        from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import _apply_filters
+
+        dps = [self._dp('base64'), self._dp('base64'), self._dp('crescendo')]
+        kept = _apply_filters(dps, num_samples=2, delivery_methods=['crescendo'])
+        assert [dp.inputs['delivery_method'] for dp in kept] == ['crescendo']
+
+    def test_delivery_match_is_case_insensitive(self) -> None:
+        # delivery_method is a free-form str; tolerate case drift vs enum slugs.
+        from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import _apply_filters
+
+        dps = [self._dp('Base64'), self._dp('CRESCENDO')]
+        kept = _apply_filters(dps, delivery_methods=['base64'])
+        assert [dp.inputs['delivery_method'] for dp in kept] == ['Base64']
+
+    def test_delivery_match_tolerates_space_and_underscore_drift(self) -> None:
+        # Dataset rows spelled with spaces/underscores still match the hyphenated slug.
+        from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import _apply_filters
+
+        dps = [self._dp('Direct Request'), self._dp('direct_request'), self._dp('base64')]
+        kept = _apply_filters(dps, delivery_methods=['direct-request'])
+        assert [dp.inputs['delivery_method'] for dp in kept] == ['Direct Request', 'direct_request']
+
+    def test_empty_delivery_value_never_matches(self) -> None:
+        from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import _apply_filters
+
+        dps = [self._dp(''), self._dp('crescendo')]
+        kept = _apply_filters(dps, delivery_methods=['crescendo'])
+        assert [dp.inputs['delivery_method'] for dp in kept] == ['crescendo']
+
+    def test_load_from_file_applies_delivery_filter(self) -> None:
+        # End-to-end through the public loader against the real e2e fixture
+        # (all 3 rows are 'direct-request').
+        from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import load_owasp_agentic_dataset
+
+        assert _FIXTURE.exists(), 'e2e fixture missing'
+        kept = load_owasp_agentic_dataset(dataset=_FIXTURE, delivery_methods=['direct-request'])
+        assert len(kept) == 3
+        assert load_owasp_agentic_dataset(dataset=_FIXTURE, delivery_methods=['base64']) == []
+        # No filter → all rows load.
+        assert len(load_owasp_agentic_dataset(dataset=_FIXTURE)) == 3

--- a/packages/evaluatorq-py/tests/redteam/test_method_selection.py
+++ b/packages/evaluatorq-py/tests/redteam/test_method_selection.py
@@ -246,9 +246,11 @@ class TestCheckFilterResults:
                 dps, None, {DeliveryMethod.CRESCENDO, DeliveryMethod.BASE64}
             )
         )
-        assert any("Unmatched delivery method(s)" in m and "base64" in m for m in msgs)
-        # 'crescendo' matched, so it must not be reported as unmatched.
-        assert not any("crescendo" in m for m in msgs if "Unmatched delivery" in m)
+        warning = next((m for m in msgs if "Unmatched delivery method(s)" in m), None)
+        assert warning is not None
+        assert "base64" in warning  # the unmatched method is named
+        # 'crescendo' matched, so it appears in the Present hint, not as unmatched.
+        assert "Present: ['crescendo']" in warning
 
     def test_delivery_method_only_no_warning_when_matched(self) -> None:
         from evaluatorq.redteam.runner import _check_filter_results
@@ -452,6 +454,15 @@ class TestBridgeDeliveryFilter:
         dps = [self._dp('Base64'), self._dp('Direct Request'), self._dp('base64')]
         kept = _apply_filters(dps, delivery_methods=['base64'])
         assert [dp.inputs['delivery_method'] for dp in kept] == ['base64']
+
+    def test_open_set_custom_method_is_filterable(self) -> None:
+        # A non-enum (custom) delivery method present in a dataset can still be
+        # selected — the open-set promise, exercised through the loader filter.
+        from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import _apply_filters
+
+        dps = [self._dp('my-custom-method'), self._dp('crescendo')]
+        kept = _apply_filters(dps, delivery_methods=['my-custom-method'])
+        assert [dp.inputs['delivery_method'] for dp in kept] == ['my-custom-method']
 
     def test_empty_delivery_value_never_matches(self) -> None:
         from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import _apply_filters

--- a/packages/evaluatorq-py/tests/redteam/test_method_selection.py
+++ b/packages/evaluatorq-py/tests/redteam/test_method_selection.py
@@ -1,0 +1,146 @@
+"""Tests for strategy-name / delivery-method selection in red_team().
+
+Covers the predicate behavior in `_filter_by_method` directly, plus runner-level
+warning behavior for unknown names and empty intersections.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from evaluatorq.redteam.adaptive.strategy_registry import (
+    VULNERABILITY_STRATEGY_REGISTRY,
+    _filter_by_method,
+)
+from evaluatorq.redteam.contracts import (
+    AttackStrategy,
+    AttackTechnique,
+    DeliveryMethod,
+    Severity,
+    TurnType,
+)
+
+
+def _make_strategy(
+    name: str,
+    *,
+    delivery_methods: list[DeliveryMethod],
+    technique: AttackTechnique = AttackTechnique.DIRECT_INJECTION,
+    turn_type: TurnType = TurnType.SINGLE,
+    category: str = "ASI01",
+) -> AttackStrategy:
+    return AttackStrategy(
+        category=category,
+        name=name,
+        description="test",
+        attack_technique=technique,
+        delivery_methods=delivery_methods,
+        turn_type=turn_type,
+        severity=Severity.MEDIUM,
+        objective_template="x",
+    )
+
+
+@pytest.fixture
+def sample_strategies() -> list[AttackStrategy]:
+    return [
+        _make_strategy("alpha", delivery_methods=[DeliveryMethod.CRESCENDO]),
+        _make_strategy("beta", delivery_methods=[DeliveryMethod.BASE64, DeliveryMethod.LEETSPEAK]),
+        _make_strategy("gamma", delivery_methods=[DeliveryMethod.MULTILINGUAL]),
+        _make_strategy("alpha", delivery_methods=[DeliveryMethod.BASE64], category="LLM01"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. Predicate behavior
+# ---------------------------------------------------------------------------
+
+
+class TestFilterByMethod:
+    """Pure predicate behavior — no runner, no planner."""
+
+    def test_no_filters_returns_all(self, sample_strategies: list[AttackStrategy]) -> None:
+        kept = _filter_by_method(sample_strategies, names=None, delivery_methods=None)
+        assert kept == sample_strategies
+
+    def test_filter_by_strategy_name_narrows_set(self, sample_strategies: list[AttackStrategy]) -> None:
+        kept = _filter_by_method(sample_strategies, names={"beta"}, delivery_methods=None)
+        assert [s.name for s in kept] == ["beta"]
+
+    def test_filter_by_delivery_method_narrows_set(self, sample_strategies: list[AttackStrategy]) -> None:
+        kept = _filter_by_method(
+            sample_strategies, names=None, delivery_methods={DeliveryMethod.CRESCENDO}
+        )
+        assert [s.name for s in kept] == ["alpha"]
+
+    def test_filter_and_semantics_when_both_set(self, sample_strategies: list[AttackStrategy]) -> None:
+        # alpha appears twice (different categories, different delivery methods).
+        # name=alpha + delivery=base64 should keep only the LLM01 variant.
+        kept = _filter_by_method(
+            sample_strategies, names={"alpha"}, delivery_methods={DeliveryMethod.BASE64}
+        )
+        assert len(kept) == 1
+        assert kept[0].category == "LLM01"
+
+    def test_strategy_name_matches_across_categories(self, sample_strategies: list[AttackStrategy]) -> None:
+        # Duplicate names are intentional — both alpha strategies survive.
+        kept = _filter_by_method(sample_strategies, names={"alpha"}, delivery_methods=None)
+        assert {s.category for s in kept} == {"ASI01", "LLM01"}
+
+    def test_delivery_method_overlap_semantics(self, sample_strategies: list[AttackStrategy]) -> None:
+        # beta has [BASE64, LEETSPEAK] — selecting LEETSPEAK keeps it.
+        kept = _filter_by_method(
+            sample_strategies, names=None, delivery_methods={DeliveryMethod.LEETSPEAK}
+        )
+        assert [s.name for s in kept] == ["beta"]
+
+    def test_empty_intersection_returns_empty(self, sample_strategies: list[AttackStrategy]) -> None:
+        kept = _filter_by_method(
+            sample_strategies,
+            names={"nonexistent"},
+            delivery_methods={DeliveryMethod.CRESCENDO},
+        )
+        assert kept == []
+
+    def test_empty_name_set_filters_everything_out(self, sample_strategies: list[AttackStrategy]) -> None:
+        # Explicit empty set means "match nothing", distinct from None.
+        kept = _filter_by_method(sample_strategies, names=set(), delivery_methods=None)
+        assert kept == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Registry-level invariants
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryNameUniqueness:
+    """Regression guard: strategy names are unique across the registry today.
+
+    The filter predicate does not rely on uniqueness — it handles duplicates
+    correctly — but if uniqueness is ever broken, the docstring on
+    ``red_team(strategies=...)`` should be revisited to clarify multi-match
+    semantics to users.
+    """
+
+    def test_no_strategy_name_appears_in_multiple_vulnerabilities(self) -> None:
+        name_to_vulns: dict[str, set[str]] = {}
+        for vuln, strategies in VULNERABILITY_STRATEGY_REGISTRY.items():
+            for strategy in strategies:
+                name_to_vulns.setdefault(strategy.name, set()).add(vuln.value)
+
+        duplicated = {name: vulns for name, vulns in name_to_vulns.items() if len(vulns) > 1}
+        assert not duplicated, (
+            f"Strategy names are no longer unique across the registry: {duplicated}. "
+            "Update the docstring on red_team(strategies=...) to document the multi-match semantics."
+        )
+
+    def test_filter_against_real_registry_finds_each_name(self) -> None:
+        # Sanity: a known registered name yields at least one match through
+        # the real predicate path.
+        all_strategies = [s for strategies in VULNERABILITY_STRATEGY_REGISTRY.values() for s in strategies]
+        sample_name = all_strategies[0].name
+        kept = _filter_by_method(all_strategies, names={sample_name}, delivery_methods=None)
+        assert len(kept) >= 1
+        assert all(s.name == sample_name for s in kept)
+
+

--- a/packages/evaluatorq-py/tests/redteam/test_method_selection.py
+++ b/packages/evaluatorq-py/tests/redteam/test_method_selection.py
@@ -295,18 +295,6 @@ class TestCheckFilterResults:
         )
         assert msgs == []
 
-    def test_case_and_punctuation_drift_no_false_unmatched_warning(self) -> None:
-        # A static row spelled 'Direct Request' (case + space) is kept by the
-        # loader's normalized match, so it must NOT be reported "unmatched" here.
-        from evaluatorq.redteam.runner import _check_filter_results
-
-        msgs = _capture_warnings(
-            lambda: _check_filter_results(
-                _static_dps("Direct Request"), None, {DeliveryMethod.DIRECT_REQUEST}, names_apply=False
-            )
-        )
-        assert msgs == []
-
     def test_mixed_dynamic_and_static_datapoints(self) -> None:
         # The docstring claims the check covers a combined dynamic+static set
         # (hybrid mode). A dynamic strategy provides the name match; a static row
@@ -441,21 +429,29 @@ class TestBridgeDeliveryFilter:
         kept = _apply_filters(dps, num_samples=2, delivery_methods=['crescendo'])
         assert [dp.inputs['delivery_method'] for dp in kept] == ['crescendo']
 
-    def test_delivery_match_is_case_insensitive(self) -> None:
-        # delivery_method is a free-form str; tolerate case drift vs enum slugs.
+    def test_redteam_input_coerces_delivery_method(self) -> None:
+        # Pattern A: known value -> DeliveryMethod enum (usable as-is); unknown -> raw str.
+        from evaluatorq.redteam.contracts import RedTeamInput, Severity, TurnType, VulnerabilityDomain
+
+        base = dict(
+            id='t1', category='ASI01', severity=Severity.MEDIUM,
+            vulnerability_domain=next(iter(VulnerabilityDomain)), turn_type=TurnType.SINGLE, source='test',
+        )
+        known = RedTeamInput(delivery_method='direct-request', **base)
+        assert known.delivery_method is DeliveryMethod.DIRECT_REQUEST
+
+        unknown = RedTeamInput(delivery_method='my-custom-method', **base)
+        assert unknown.delivery_method == 'my-custom-method'
+        assert not isinstance(unknown.delivery_method, DeliveryMethod)
+
+    def test_delivery_match_is_exact(self) -> None:
+        # delivery_method must equal the enum value exactly — no case/punctuation
+        # coercion. A row spelled differently simply does not match.
         from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import _apply_filters
 
-        dps = [self._dp('Base64'), self._dp('CRESCENDO')]
+        dps = [self._dp('Base64'), self._dp('Direct Request'), self._dp('base64')]
         kept = _apply_filters(dps, delivery_methods=['base64'])
-        assert [dp.inputs['delivery_method'] for dp in kept] == ['Base64']
-
-    def test_delivery_match_tolerates_space_and_underscore_drift(self) -> None:
-        # Dataset rows spelled with spaces/underscores still match the hyphenated slug.
-        from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import _apply_filters
-
-        dps = [self._dp('Direct Request'), self._dp('direct_request'), self._dp('base64')]
-        kept = _apply_filters(dps, delivery_methods=['direct-request'])
-        assert [dp.inputs['delivery_method'] for dp in kept] == ['Direct Request', 'direct_request']
+        assert [dp.inputs['delivery_method'] for dp in kept] == ['base64']
 
     def test_empty_delivery_value_never_matches(self) -> None:
         from evaluatorq.redteam.frameworks.owasp.evaluatorq_bridge import _apply_filters


### PR DESCRIPTION
Adds `strategies` and `delivery_methods` selection to `red_team()` and the redteam CLI so runs can be restricted to specific named strategies / delivery methods, not just whole vulnerabilities or categories.

Ticket: https://linear.app/orqai/issue/RES-295/allow-selection-of-attack-methoddelivery-method

Full spec and scope for review posted as the first comment below.