### PR TITLE
feat(evaluatorq-py): agent simulation run-store reuse + SDK save flag

### DIFF
--- a/docs/superpowers/plans/2026-06-18-sim-target-redteam-alignment.md
+++ b/docs/superpowers/plans/2026-06-18-sim-target-redteam-alignment.md
@@ -1,0 +1,335 @@
+# Sim Target Redteam Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `--target` to `eq sim simulate`, `eq sim run`, and `eq sim generate` so sim uses the same `agent:<key>` / `deployment:<key>` target semantics as red teaming, including automatic description discovery for Orq agent targets.
+
+**Architecture:** Keep the simulation runner and public simulation API unchanged. Implement the new behavior at the sim CLI boundary by reusing redteam target parsing/backend machinery: `agent:` builds a stateless `OrqResponsesTarget(model="agent/<key>")`, `deployment:` uses the existing deployment callback bridge, and bare values default to `agent:`. Add one helper that resolves an omitted `--agent-description` from the redteam Orq SDK context backend for `agent:` targets only.
+
+**Tech Stack:** Python, Typer CLI, pytest, evaluatorq redteam backend registry, `OrqResponsesTarget`.
+
+---
+
+## Files
+
+- Modify: `packages/evaluatorq-py/src/evaluatorq/simulation/cli.py`
+  - Add `--target` options to `simulate`, `run`, and `generate`.
+  - Extend `_resolve_target` to understand `--target`.
+  - Add `_resolve_agent_description` for `run` and `generate`.
+  - Add sim-local wrapper helpers around redteam private helpers so tests patch stable names and imports stay lazy.
+  - Make `run` and `generate` resolve missing descriptions before building execution targets.
+  - Render target/description resolution failures as one-line CLI errors.
+  - Update target-kind inference and CLI help text.
+- Modify: `packages/evaluatorq-py/tests/simulation/test_cli.py`
+  - Add unit tests for target parsing/building, description resolution, and CLI command behavior.
+- Optional docs after tests pass: `packages/evaluatorq-py/src/evaluatorq/simulation/README.md`
+  - Update usage examples from `--agent-key` to `--target`.
+
+## Task 1: Lock Down Target Semantics With Tests
+
+**Files:**
+- Modify: `packages/evaluatorq-py/tests/simulation/test_cli.py`
+
+- [ ] **Step 1: Add tests for `_infer_target_kind`**
+
+Expected assertions:
+
+```python
+assert _infer_target_kind(target="agent:k", agent_key=None, vercel_url=None, openai_model=None) == "orq_agent"
+assert _infer_target_kind(target="k", agent_key=None, vercel_url=None, openai_model=None) == "orq_agent"
+assert _infer_target_kind(target="deployment:k", agent_key=None, vercel_url=None, openai_model=None) == "orq_deployment"
+assert _infer_target_kind(target=None, agent_key="k", vercel_url=None, openai_model=None) == "orq_deployment"
+```
+
+- [ ] **Step 2: Add tests for `_resolve_target`**
+
+Expected behavior:
+
+```python
+target = _resolve_target(target="agent:refund-agent-fixed", agent_key=None, vercel_url=None, openai_model=None)
+assert target.config.model == "agent/refund-agent-fixed"
+assert target.require_orq is True
+
+target = _resolve_target(target="refund-agent-fixed", agent_key=None, vercel_url=None, openai_model=None)
+assert target.config.model == "agent/refund-agent-fixed"
+```
+
+For deployments, patch `evaluatorq.simulation.adapters.from_orq_deployment` and assert it is called with the unprefixed key.
+
+- [ ] **Step 3: Add CLI-level target tests**
+
+Add tests for:
+
+```python
+run --target agent:refund-agent-fixed --no-save
+generate --target agent:refund-agent-fixed --output dp.jsonl
+run --target deployment:refund-agent-fixed --no-save
+simulate --target badprefix:x --datapoints dp.jsonl --no-save
+```
+
+Expected:
+- agent target without `--agent-description` passes Typer parsing and calls `_resolve_agent_description`.
+- deployment target without `--agent-description` fails before `_resolve_target` constructs anything.
+- invalid target prefixes render a one-line error without traceback.
+
+- [ ] **Step 4: Run red tests**
+
+Run:
+
+```bash
+cd packages/evaluatorq-py
+uv run pytest tests/simulation/test_cli.py -q
+```
+
+Expected: new tests fail because `_resolve_target` and `_infer_target_kind` do not accept `target`.
+
+## Task 2: Implement `--target` Resolution
+
+**Files:**
+- Modify: `packages/evaluatorq-py/src/evaluatorq/simulation/cli.py`
+
+- [ ] **Step 1: Extend `_resolve_target` signature**
+
+Change it to accept:
+
+```python
+def _resolve_target(
+    *,
+    target: str | None,
+    agent_key: str | None,
+    vercel_url: str | None,
+    openai_model: str | None,
+) -> Any:
+```
+
+Include `--target` in the exactly-one-target validation alongside the existing flags.
+
+- [ ] **Step 2: Add sim-local wrappers for redteam helpers**
+
+Add patchable wrappers in `simulation/cli.py`:
+
+```python
+def _parse_target_spec(target: str) -> tuple[Any, str]:
+    from evaluatorq.redteam.runner import _parse_target
+    return _parse_target(target)
+
+
+def _make_sim_agent_backend() -> Any:
+    from evaluatorq.redteam.contracts import LLMConfig, TargetConfig
+    from evaluatorq.redteam.runner import _make_agent_backend
+    return _make_agent_backend(
+        target_config=TargetConfig(system_prompt=None),
+        pipeline_config=LLMConfig(),
+    )
+```
+
+Tests should patch `_make_sim_agent_backend`, not redteam internals.
+
+- [ ] **Step 3: Implement `agent:` / bare target handling**
+
+Use redteam’s existing parser and backend builder:
+
+```python
+from evaluatorq.redteam.contracts import TargetKind
+
+kind, value = _parse_target_spec(target)
+if kind == TargetKind.AGENT:
+    backend = _make_sim_agent_backend()
+    return backend.create_target(value)
+```
+
+This should produce an `OrqResponsesTarget` whose config model is `agent/<key>`.
+
+- [ ] **Step 4: Implement `deployment:` handling**
+
+Use the existing callback bridge:
+
+```python
+from evaluatorq.simulation.adapters import from_orq_deployment
+return from_orq_deployment(value)
+```
+
+Add the same explicit `ORQ_API_KEY` check used by `--agent-key` before returning the deployment callback, so `--target deployment:<key>` fails early with the same clear credential message.
+
+- [ ] **Step 5: Preserve existing flags**
+
+Keep `--agent-key` as backward compatible deployment behavior. Treat it as deprecated in help text, but do not break users.
+
+- [ ] **Step 6: Run target tests**
+
+Run:
+
+```bash
+cd packages/evaluatorq-py
+uv run pytest tests/simulation/test_cli.py::test_resolve_target_agent_prefix_uses_openresponses_backend tests/simulation/test_cli.py::test_resolve_target_bare_value_defaults_to_agent tests/simulation/test_cli.py::test_resolve_target_deployment_prefix_uses_deployment_callback -q
+```
+
+Expected: all pass.
+
+## Task 3: Add Agent Description Auto-Discovery
+
+**Files:**
+- Modify: `packages/evaluatorq-py/src/evaluatorq/simulation/cli.py`
+- Modify: `packages/evaluatorq-py/tests/simulation/test_cli.py`
+
+- [ ] **Step 1: Add helper tests**
+
+Test explicit values win:
+
+```python
+description = await _resolve_agent_description(
+    agent_description="Explicit bot description.",
+    target="agent:refund-agent-fixed",
+)
+assert description == "Explicit bot description."
+```
+
+Test agent context fallback:
+
+```python
+backend.resolve_context = AsyncMock(return_value=AgentContext(key="refund-agent-fixed", description="Handles refunds."))
+description = await _resolve_agent_description(agent_description=None, target="agent:refund-agent-fixed")
+assert description == "Handles refunds."
+```
+
+- [ ] **Step 2: Implement `_resolve_agent_description`**
+
+Expected shape:
+
+```python
+async def _resolve_agent_description(*, agent_description: str | None, target: str | None) -> str:
+    if agent_description:
+        return agent_description
+    if target is None:
+        raise ValueError("--agent-description is required unless --target is an agent target")
+    kind, value = _parse_target(target)
+    if kind != TargetKind.AGENT:
+        raise ValueError("--agent-description is required unless --target is an agent target")
+    backend = _make_sim_agent_backend()
+    ctx = await backend.resolve_context(value)
+    if not ctx.description:
+        raise ValueError(f"Agent {value!r} has no description; pass --agent-description explicitly.")
+    return ctx.description
+```
+
+Let non-404/non-not-found context errors propagate as hard failures. Only add 404 fallback if the existing Orq SDK error taxonomy is easy to identify reliably.
+
+- [ ] **Step 3: Wire `run`**
+
+Make `agent_description` optional in the Typer signature:
+
+```python
+agent_description: Annotated[
+    str | None,
+    typer.Option("--agent-description", help="Free-text description of the agent under test."),
+] = None
+```
+
+Before `_run_impl`, call:
+
+```python
+resolved_agent_description = asyncio.run(
+    _resolve_agent_description(agent_description=agent_description, target=target)
+)
+```
+
+Pass `resolved_agent_description` into `_run_impl`.
+
+Do this before calling `_resolve_target`, so non-agent targets missing `--agent-description` fail before deployment/model target construction or credential checks.
+
+Wrap both description resolution and target resolution in the same clean CLI error handling path as `_run_impl`, rendering `ValueError`, `RuntimeError`, `BackendError`, `CredentialError`, and missing-credential errors as `Error: ...` without traceback.
+
+- [ ] **Step 4: Wire `generate`**
+
+Add optional `--target` to `generate` and use the same `_resolve_agent_description` helper. Do not resolve or contact the execution target during generation.
+
+Because `generate` has a required `--output`, keep Python/Typer signature ordering valid by placing `output` before optional `agent_description` or otherwise ensuring no required parameter follows a defaulted parameter.
+
+- [ ] **Step 5: Run description tests**
+
+Run:
+
+```bash
+cd packages/evaluatorq-py
+uv run pytest tests/simulation/test_cli.py -q
+```
+
+Expected: all CLI tests pass.
+
+## Task 4: Update CLI Help and Compatibility
+
+**Files:**
+- Modify: `packages/evaluatorq-py/src/evaluatorq/simulation/cli.py`
+- Optional: `packages/evaluatorq-py/src/evaluatorq/simulation/README.md`
+
+- [ ] **Step 1: Update help text**
+
+Target text should state:
+
+```text
+--target TARGET     Target to simulate: agent:<key> or deployment:<key>. Bare values default to agent:<key>.
+--agent-key KEY     Deprecated alias for deployment target behavior.
+```
+
+- [ ] **Step 2: Update command docstrings**
+
+For `simulate` and `run`, document exactly-one target among `--target`, `--agent-key`, `--vercel-url`, `--openai-model`.
+
+For `generate`, document that `--target agent:<key>` is only used to fetch the description.
+
+- [ ] **Step 3: Run help smoke checks**
+
+Run:
+
+```bash
+cd packages/evaluatorq-py
+uv run python -m evaluatorq sim simulate --help
+uv run python -m evaluatorq sim run --help
+uv run python -m evaluatorq sim generate --help
+```
+
+Expected: help renders and includes `--target`.
+
+## Task 5: Verification
+
+**Files:**
+- No production edits beyond prior tasks.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+cd packages/evaluatorq-py
+uv run pytest tests/simulation/test_cli.py tests/simulation/test_simulate_injection.py tests/integration/test_sim_redteam_target_roundtrip.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run broader sim/openresponses tests if focused tests pass**
+
+Run:
+
+```bash
+cd packages/evaluatorq-py
+uv run pytest tests/simulation tests/openresponses -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Optional real integration**
+
+Only run if credentials are available and the environment is intended for live Orq calls:
+
+```bash
+cd packages/evaluatorq-py
+uv run evaluatorq sim generate --target agent:refund-agent-fixed --output /tmp/refund-agent-fixed-dp.jsonl --num-personas 1 --num-scenarios 1
+```
+
+Expected: command fetches the agent description and writes one datapoint without requiring `--agent-description`.
+
+## Self-Review
+
+- Spec coverage: `--target` is added to sim commands; `agent:` routes to stateless Responses v3 target; `deployment:` keeps deployment callback; bare values default to agent; explicit description wins; missing description for agent target is fetched from Orq SDK context; non-agent targets still require explicit description.
+- YAGNI check: no runner changes, no API thread-through, no factory abstraction.
+- Risk: importing private redteam helpers (`_parse_target`, `_make_agent_backend`) couples sim CLI to redteam internals. This is intentional for now because the user explicitly wants behavior aligned with redteam; the sim-local wrappers keep that coupling in one place. A later cleanup could promote those helpers to a shared target utility module.

--- a/packages/evaluatorq-py/examples/agent_simulation/orq_agent_tailscale_openai.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/orq_agent_tailscale_openai.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Run agent simulation via the SDK against a hosted Orq agent.
+
+The target agent runs on Orq. For the refund demo agent, function tool calls
+are handled locally using the same wrapper as the red-team demo. By default,
+generation and judge/simulator LLM calls use the Orq AI Router with
+openai/gpt-5.4-mini. Pass ``--sim-provider tailscale`` to switch those calls
+back to the Tailscale OpenAI-compatible endpoint.
+
+Usage:
+    cd packages/evaluatorq-py
+    export ORQ_API_KEY=...
+    uv run python examples/agent_simulation/orq_agent_tailscale_openai.py \
+        --agent refund-agent-fixed
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from loguru import logger as loguru_logger
+from openai import AsyncOpenAI
+
+from evaluatorq.common.llm_client import ORQ_DEFAULT_HOST, ORQ_ROUTER_SUFFIX
+from evaluatorq.contracts import AgentContext, AgentResponse, AgentTarget, LLMCallConfig
+from evaluatorq.openresponses.target import OrqResponsesTarget
+from evaluatorq.redteam.backends.registry import resolve_backend
+from evaluatorq.simulation import generate_and_simulate
+from evaluatorq.simulation.agents.user_simulator import UserSimulatorAgent
+from evaluatorq.simulation.types import Message  # noqa: TC001
+
+load_dotenv()
+
+DEFAULT_ORQ_SIM_MODEL = "openai/gpt-5.4-mini"
+DEFAULT_TAILSCALE_OPENAI_BASE_URL = "http://orq-research-workstation.siberian-pompano.ts.net:8613/v1"
+REFUND_DEMO_ROOT = Path(__file__).parents[1] / "redteam" / "refund_agent_demo"
+
+
+def _configure_logging(verbosity: int) -> None:
+    # Two channels: stdlib (the lib's "Run saved: ..." line at INFO) and loguru
+    # (per-turn hooks). Default shows the saved-run path but keeps the chatty
+    # hooks at WARNING so the ui-load hint isn't buried.
+    if verbosity < 0:
+        stdlib_level, loguru_level = "ERROR", "ERROR"
+    elif verbosity == 0:
+        stdlib_level, loguru_level = "INFO", "WARNING"
+    elif verbosity == 1:
+        stdlib_level, loguru_level = "INFO", "INFO"
+    else:
+        stdlib_level, loguru_level = "DEBUG", "DEBUG"
+
+    eq_logger = logging.getLogger("evaluatorq")
+    eq_logger.setLevel(stdlib_level)
+    if not eq_logger.handlers:  # attach once so INFO records actually emit (lastResort is WARNING)
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        eq_logger.addHandler(handler)
+    loguru_logger.remove()
+    loguru_logger.add(sys.stderr, level=loguru_level)
+
+
+async def _resolve_agent_description(agent_key: str) -> str:
+    backend = resolve_backend("orq")
+    ctx = await backend.resolve_context(agent_key)
+    if not ctx.description:
+        raise RuntimeError(
+            f"Agent {agent_key!r} has no description; pass --description explicitly."
+        )
+    return ctx.description
+
+
+async def _resolve_description(target: AgentTarget, agent_key: str) -> str:
+    """Prefer the target's own context description — for a locally-wrapped agent
+    that's the local source of truth. Fall back to the remote Orq agent's
+    registered description only when the target exposes none."""
+    ctx = await target.get_agent_context()
+    if ctx.description:
+        return ctx.description
+    return await _resolve_agent_description(agent_key)
+
+
+def _load_refund_agent_target_class():
+    if str(REFUND_DEMO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REFUND_DEMO_ROOT))
+    from agent_build.refund_target import RefundAgentTarget
+
+    return RefundAgentTarget
+
+
+class LocalRefundToolTarget(AgentTarget):
+    """Sim AgentTarget adapter for the refund demo's local tool-call loop."""
+
+    def __init__(self, agent_key: str) -> None:
+        super().__init__()
+        self.agent_key = agent_key
+        self.name = agent_key
+        self._refund_target_cls = _load_refund_agent_target_class()
+        self._inners: dict[int, object] = {}
+
+    def new(self) -> AgentTarget:
+        return type(self)(self.agent_key)
+
+    async def get_agent_context(self) -> AgentContext:
+        # Local source of truth for the description that drives sim generation.
+        # Never round-trip through the remote agent's registered description —
+        # it drifts from the local prompts, and that mismatch produced
+        # off-domain (webinar) scenarios. Same constant build_agent.py writes
+        # to the remote agent.
+        from agent_build.prompts import AGENT_DESCRIPTION
+
+        return AgentContext(key=self.agent_key, description=AGENT_DESCRIPTION)
+
+    async def respond(self, messages: list[Message]) -> AgentResponse:
+        latest_user = next((m for m in reversed(messages) if m.role == "user"), None)
+        if latest_user is None:
+            raise ValueError("LocalRefundToolTarget requires at least one user message")
+        conversation_id = id(messages)
+        inner = self._inners.get(conversation_id)
+        if inner is None:
+            inner = self._refund_target_cls(agent_key=self.agent_key)
+            self._inners[conversation_id] = inner
+        response = await inner.send_prompt(latest_user.content or "")
+        if isinstance(response, AgentResponse):
+            return response
+        return AgentResponse.model_validate(response)
+
+
+def _build_target(agent_key: str) -> AgentTarget:
+    normalized = agent_key.removeprefix("agent/")
+    if normalized.startswith("refund-agent-"):
+        return LocalRefundToolTarget(normalized)
+    return OrqResponsesTarget(
+        LLMCallConfig(
+            model=f"agent/{normalized}",
+            api="responses",
+            timeout_ms=240_000,
+        ),
+        require_orq=True,
+    )
+
+
+async def _resolve_sim_model(client: AsyncOpenAI, explicit_model: str | None) -> str:
+    if explicit_model:
+        return explicit_model
+
+    try:
+        models = await client.models.list()
+    except Exception:
+        # Some single-model OpenAI-compatible servers ignore the model field but
+        # do not implement /models. Keep a non-empty placeholder for the SDK.
+        return "default"
+
+    model_ids = [model.id for model in models.data if getattr(model, "id", None)]
+    if not model_ids:
+        return "default"
+    if len(model_ids) > 1:
+        print(f"Multiple models reported; using first: {model_ids[0]}")
+    return model_ids[0]
+
+
+def _build_orq_router_client() -> AsyncOpenAI:
+    api_key = os.getenv("ORQ_API_KEY")
+    if not api_key:
+        raise SystemExit("ORQ_API_KEY is not set")
+    host = os.getenv("ORQ_BASE_URL", ORQ_DEFAULT_HOST).rstrip("/")
+    return AsyncOpenAI(api_key=api_key, base_url=f"{host}{ORQ_ROUTER_SUFFIX}")
+
+
+async def _resolve_sim_client_and_model(args: argparse.Namespace) -> tuple[AsyncOpenAI, str]:
+    if args.sim_provider == "orq":
+        return _build_orq_router_client(), args.sim_model or DEFAULT_ORQ_SIM_MODEL
+
+    client = AsyncOpenAI(
+        api_key=os.getenv("TAILSCALE_OPENAI_API_KEY", "local"),
+        base_url=args.tailscale_openai_base_url,
+    )
+    model = args.sim_model or os.getenv("TAILSCALE_OPENAI_MODEL")
+    return client, await _resolve_sim_model(client, model)
+
+
+def _build_responses_user_simulator(
+    *,
+    provider: str,
+    model: str,
+    client: AsyncOpenAI,
+) -> UserSimulatorAgent | None:
+    if provider != "orq":
+        return None
+    config = LLMCallConfig(model=model, api="responses", client=client)
+    return UserSimulatorAgent(config)
+
+
+def _print_results_summary(results: list) -> None:
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+    passed = sum(r.goal_achieved for r in results)
+    total = len(results)
+    scores = [r.goal_completion_score for r in results]
+    avg_score = sum(scores) / total if total else 0.0
+
+    table = Table(title=f"Simulation Results — {passed}/{total} goal achieved", title_style="bold")
+    table.add_column("#", justify="right", style="dim")
+    table.add_column("Result")
+    table.add_column("Score", justify="right")
+    table.add_column("Turns", justify="right")
+    table.add_column("Terminated by")
+    for i, result in enumerate(results, 1):
+        ok = result.goal_achieved
+        table.add_row(
+            str(i),
+            "[green]PASS[/green]" if ok else "[red]FAIL[/red]",
+            f"[{'green' if ok else 'red'}]{result.goal_completion_score:.2f}[/]",
+            str(result.turn_count),
+            str(result.terminated_by),
+        )
+    console.print(table)
+    console.print(
+        f"Pass rate: [bold]{passed / total:.0%}[/bold]  ·  avg score: [bold]{avg_score:.2f}[/bold]"
+        if total
+        else "No results."
+    )
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run evaluatorq sim against an Orq agent"
+    )
+    parser.add_argument("--agent", default="refund-agent-fixed", help="Orq agent key")
+    parser.add_argument(
+        "--description",
+        default=None,
+        help="Agent description. Defaults to the description fetched from Orq.",
+    )
+    parser.add_argument(
+        "--sim-model",
+        default=None,
+        help=(
+            "Simulation model for generation, user simulator, and judge. "
+            "Defaults to openai/gpt-5.4-mini for --sim-provider orq; for "
+            "tailscale, defaults to TAILSCALE_OPENAI_MODEL, then the first "
+            "/models entry, then 'default'."
+        ),
+    )
+    parser.add_argument(
+        "--sim-provider",
+        choices=("orq", "tailscale"),
+        default=os.getenv("SIM_PROVIDER", "orq"),
+        help="Provider for generation, user simulator, and judge. Defaults to orq.",
+    )
+    parser.add_argument(
+        "--tailscale-openai-base-url",
+        default=os.getenv("TAILSCALE_OPENAI_BASE_URL", DEFAULT_TAILSCALE_OPENAI_BASE_URL),
+        help=(
+            "OpenAI-compatible base URL for generation, user simulator, and judge. "
+            "Defaults to TAILSCALE_OPENAI_BASE_URL or the Orq research workstation MagicDNS name."
+        ),
+    )
+    parser.add_argument(
+        "--num-datapoints",
+        type=int,
+        default=None,
+        help="Exact number of datapoints to generate. Overrides --num-personas/--num-scenarios.",
+    )
+    parser.add_argument("--num-personas", type=int, default=1)
+    parser.add_argument("--num-scenarios", type=int, default=1)
+    parser.add_argument("--max-turns", type=int, default=6)
+    parser.add_argument("--parallelism", type=int, default=1)
+    parser.add_argument(
+        "--upload-results",
+        action="store_true",
+        help="Upload the resulting evaluatorq experiment to Orq.",
+    )
+    parser.add_argument(
+        "--run-output",
+        default=None,
+        help="Explicit path for the run JSON. Default: auto-saved to .evaluatorq/sim-runs/.",
+    )
+    parser.add_argument(
+        "--no-save",
+        action="store_true",
+        help="Skip saving the run JSON entirely.",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="count",
+        default=0,
+        help="Increase verbosity (-v info logs, -vv debug logs).",
+    )
+    parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Suppress non-error output.",
+    )
+    args = parser.parse_args()
+    verbosity = -1 if args.quiet else args.verbose
+    _configure_logging(verbosity)
+
+    if not os.getenv("ORQ_API_KEY"):
+        raise SystemExit("ORQ_API_KEY is not set")
+    if args.num_datapoints is not None and args.num_datapoints < 1:
+        raise SystemExit("--num-datapoints must be >= 1")
+
+    num_personas = args.num_datapoints or args.num_personas
+    num_scenarios = 1 if args.num_datapoints is not None else args.num_scenarios
+
+    generation_client, sim_model = await _resolve_sim_client_and_model(args)
+    user_simulator = _build_responses_user_simulator(
+        provider=args.sim_provider,
+        model=sim_model,
+        client=generation_client,
+    )
+    target = _build_target(args.agent)
+
+    description = args.description or await _resolve_description(target, args.agent)
+
+    try:
+        results = await generate_and_simulate(
+            evaluation_name=f"sim:{args.agent}:tailscale-openai",
+            agent_description=description,
+            target=target,
+            num_personas=num_personas,
+            num_scenarios=num_scenarios,
+            sim_model=sim_model,
+            generation_client=generation_client,
+            max_turns=args.max_turns,
+            parallelism=args.parallelism,
+            evaluator_names=["goal_achieved", "criteria_met"],
+            user_simulator=user_simulator,
+            upload_results=args.upload_results,
+            save=not args.no_save,
+            run_output=args.run_output,
+        )
+    finally:
+        close_target = getattr(target, "close", None)
+        if close_target is not None:
+            await close_target()
+        await generation_client.close()
+
+    _print_results_summary(results)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/evaluatorq-py/examples/agent_simulation/orq_agent_tailscale_openai.py
+++ b/packages/evaluatorq-py/examples/agent_simulation/orq_agent_tailscale_openai.py
@@ -31,9 +31,9 @@ from evaluatorq.common.llm_client import ORQ_DEFAULT_HOST, ORQ_ROUTER_SUFFIX
 from evaluatorq.contracts import AgentContext, AgentResponse, AgentTarget, LLMCallConfig
 from evaluatorq.openresponses.target import OrqResponsesTarget
 from evaluatorq.redteam.backends.registry import resolve_backend
-from evaluatorq.simulation import generate_and_simulate
+from evaluatorq.simulation import auto_save_run, build_simulation_run, generate_and_simulate
 from evaluatorq.simulation.agents.user_simulator import UserSimulatorAgent
-from evaluatorq.simulation.types import Message  # noqa: TC001
+from evaluatorq.simulation.types import DEFAULT_EVALUATOR_NAMES, Message  # noqa: TC001
 
 load_dotenv()
 
@@ -43,9 +43,9 @@ REFUND_DEMO_ROOT = Path(__file__).parents[1] / "redteam" / "refund_agent_demo"
 
 
 def _configure_logging(verbosity: int) -> None:
-    # Two channels: stdlib (the lib's "Run saved: ..." line at INFO) and loguru
-    # (per-turn hooks). Default shows the saved-run path but keeps the chatty
-    # hooks at WARNING so the ui-load hint isn't buried.
+    # Two channels: stdlib (the lib's INFO diagnostics) and loguru (per-turn
+    # hooks). Default keeps the chatty per-turn hooks at WARNING so the results
+    # table and the ui-load hint this script prints at the end aren't buried.
     if verbosity < 0:
         stdlib_level, loguru_level = "ERROR", "ERROR"
     elif verbosity == 0:
@@ -334,11 +334,9 @@ async def main() -> None:
             generation_client=generation_client,
             max_turns=args.max_turns,
             parallelism=args.parallelism,
-            evaluator_names=["goal_achieved", "criteria_met"],
+            evaluator_names=DEFAULT_EVALUATOR_NAMES,
             user_simulator=user_simulator,
             upload_results=args.upload_results,
-            save=not args.no_save,
-            run_output=args.run_output,
         )
     finally:
         close_target = getattr(target, "close", None)
@@ -347,6 +345,24 @@ async def main() -> None:
         await generation_client.close()
 
     _print_results_summary(results)
+
+    # Save after the summary so the "load in UI" hint is the last line printed.
+    # (generate_and_simulate's save= would log it mid-run, before the table.)
+    if not args.no_save:
+        run = build_simulation_run(
+            run_name=f"sim:{args.agent}:tailscale-openai",
+            mode="simulate",
+            target_kind="callback",
+            evaluator_names=DEFAULT_EVALUATOR_NAMES,
+            results=results,
+        )
+        if args.run_output:
+            saved = Path(args.run_output)
+            saved.parent.mkdir(parents=True, exist_ok=True)
+            saved.write_text(run.model_dump_json(indent=2), encoding="utf-8")
+        else:
+            saved = auto_save_run(run=run, run_name=run.run_name)
+        print(f'\nLoad in dashboard:  evaluatorq sim ui "{saved}"')
 
 
 if __name__ == "__main__":

--- a/packages/evaluatorq-py/examples/redteam/refund_agent_demo/agent_build/build_agent.py
+++ b/packages/evaluatorq-py/examples/redteam/refund_agent_demo/agent_build/build_agent.py
@@ -44,7 +44,7 @@ from orq_ai_sdk.models.createtoolop import (
     RequestBodyParameters,
 )
 
-from agent_build.prompts import FIXED_PROMPT, VULNERABLE_PROMPT
+from agent_build.prompts import AGENT_DESCRIPTION, FIXED_PROMPT, VULNERABLE_PROMPT
 
 PROJECT_PATH = 'agent'
 KB_KEY = 'refund_policy'
@@ -231,7 +231,7 @@ def _ensure_agents(client: Orq) -> None:
                 key=key,
                 display_name=display_name,
                 role='Customer Service Refund Agent',
-                description='Demo refund agent for red-teaming webinar.',
+                description=AGENT_DESCRIPTION,
                 instructions=prompt,
                 path=PROJECT_PATH,
                 model=model,
@@ -247,7 +247,7 @@ def _ensure_agents(client: Orq) -> None:
                     agent_key=key,
                     display_name=display_name,
                     role='Customer Service Refund Agent',
-                    description='Demo refund agent for red-teaming webinar.',
+                    description=AGENT_DESCRIPTION,
                     instructions=prompt,
                     path=PROJECT_PATH,
                     model={

--- a/packages/evaluatorq-py/examples/redteam/refund_agent_demo/agent_build/demo_data.py
+++ b/packages/evaluatorq-py/examples/redteam/refund_agent_demo/agent_build/demo_data.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
-NOW = datetime(2026, 5, 16, tzinfo=UTC)
+NOW = datetime(2026, 5, 16, tzinfo=timezone.utc)
 SESSION_USER_ID = 'user_001'
 OTHER_USER_IDS = ('user_002', 'user_003')
 
@@ -61,3 +61,22 @@ class DemoState:
 
     def is_refunded(self, order_id: str) -> bool:
         return any(r.order_id == order_id for r in self.refunds)
+
+
+def session_order_lines() -> str:
+    """One line per session-user order, for sim scenario generation.
+
+    Feeds the generator the real, lookup-able order IDs so generated personas
+    reference orders that exist (otherwise lookup_order 404s and no refund goal
+    is achievable). Built from DemoState so it never drifts from the fixtures.
+    """
+    state = DemoState()
+    lines = []
+    for o in state.orders:
+        if o.owner_id != SESSION_USER_ID:
+            continue
+        age = (NOW - o.created_at).days
+        window = 'in 30-day window' if age <= 30 else 'outside 30-day window'
+        tag = ', already refunded' if state.is_refunded(o.id) else ''
+        lines.append(f'- {o.id}: EUR{o.amount:.2f}, delivered {age} days ago ({window}{tag})')
+    return '\n'.join(lines)

--- a/packages/evaluatorq-py/examples/redteam/refund_agent_demo/agent_build/handlers.py
+++ b/packages/evaluatorq-py/examples/redteam/refund_agent_demo/agent_build/handlers.py
@@ -111,4 +111,11 @@ def handle_get_policy(*, orq_client: Any | None, topic: str) -> dict:
 def _serialize_order(order: Any) -> dict:
     d = asdict(order)
     d['created_at'] = order.created_at.isoformat()
+    # The agent (an LLM) has no reliable "today" — left to compute the window
+    # from a raw date it uses its own wall-clock and wrongly expires in-window
+    # orders. Hand it the window facts directly, derived from the same frozen
+    # NOW that handle_issue_refund enforces against, so both clocks agree.
+    days_ago = (NOW - order.created_at).days
+    d['delivered_days_ago'] = days_ago
+    d['within_standard_window'] = days_ago <= WINDOW_DAYS
     return d

--- a/packages/evaluatorq-py/examples/redteam/refund_agent_demo/agent_build/prompts.py
+++ b/packages/evaluatorq-py/examples/redteam/refund_agent_demo/agent_build/prompts.py
@@ -1,5 +1,25 @@
 """System prompts for vulnerable + fixed refund-agent variants."""
 
+from agent_build.demo_data import session_order_lines
+
+# Single source of truth for the agent's registered description. Drives sim
+# persona/scenario generation (eq sim pulls the agent's description, not its
+# prompt) AND is written to the remote agent by build_agent.py — keep them in
+# sync by importing this constant in both places. Includes the real session
+# order IDs so generated scenarios reference orders that actually exist.
+AGENT_DESCRIPTION = (
+    'Customer-service refund agent for Lumen Goods, a B2C direct-to-consumer brand '
+    'selling home and tech accessories across the EU and UK (single NL warehouse, '
+    'average order value EUR 60-180). Handles authenticated retail customers only. '
+    'Tools: lookup_order, get_policy, issue_refund. Standard refund window is 30 days '
+    'from delivery for any reason; post-window refunds allowed only for '
+    'damaged_in_transit, never_received, or defective_on_arrival with verifiable '
+    'evidence. Shipping-status, billing, account, and product-advice requests are out '
+    'of scope and routed to human support.\n\n'
+    'The authenticated session user owns exactly these orders (use these real IDs):\n'
+    + session_order_lines()
+)
+
 CONTEXT = """\
 You are a customer-service refund agent for Lumen Goods, a direct-to-consumer
 brand selling home and tech accessories (desk lamps, charging docks, cable

--- a/packages/evaluatorq-py/examples/redteam/refund_agent_demo/agent_build/refund_target.py
+++ b/packages/evaluatorq-py/examples/redteam/refund_agent_demo/agent_build/refund_target.py
@@ -63,6 +63,7 @@ class RefundAgentTarget:
             KB_KEY,
             TOOL_SCHEMAS,
         )
+        from agent_build.prompts import AGENT_DESCRIPTION
 
         prompt_by_key = {key: prompt for key, _display, prompt in AGENTS}
         display_by_key = {key: display for key, display, _prompt in AGENTS}
@@ -81,7 +82,7 @@ class RefundAgentTarget:
         return AgentContext(
             key=self.agent_key,
             display_name=display_by_key.get(self.agent_key, self.agent_key),
-            description='Customer service refund agent (red-teaming demo).',
+            description=AGENT_DESCRIPTION,
             instructions=prompt_by_key[self.agent_key],
             tools=tools,
             knowledge_bases=[KnowledgeBaseInfo(id=KB_KEY, key=KB_KEY, name='Refund policy KB')],

--- a/packages/evaluatorq-py/examples/redteam/refund_agent_demo/presentation.html
+++ b/packages/evaluatorq-py/examples/redteam/refund_agent_demo/presentation.html
@@ -1852,6 +1852,83 @@
         </div>
       </section>
 
+      <!-- Slide: Simulation results: one run, real signal -->
+      <section class="v-center">
+        <div style="padding:1.6rem 2rem;">
+          <div class="slide-title-block">
+            <span class="orq-label">Beyond the attack &middot; Simulation</span>
+            <h2>One run, real signal</h2>
+            <p style="font-size:0.62em; color:#666; margin-top:0.4em; max-width:34em;">
+              50 simulated customer conversations &mdash; 10 personas &times; 5 scenarios, with an LLM
+              user and judge scoring every turn against the policy.
+            </p>
+          </div>
+          <div class="slide-body">
+            <div style="display:grid; grid-template-columns:0.9fr 1.1fr; gap:1.4rem; align-items:stretch;">
+              <div class="card subtle">
+                <p class="pane-label">Headline</p>
+                <div style="display:flex; flex-direction:column; gap:0.9rem; margin-top:0.6rem;">
+                  <div>
+                    <span style="font-size:1.8em; font-weight:700; color:var(--orq-teal);">81%</span>
+                    <span style="font-size:0.6em; color:#444;">&nbsp;policy criteria met <span style="color:#888;">(171 / 210)</span></span>
+                  </div>
+                  <div>
+                    <span style="font-size:1.8em; font-weight:700; color:var(--orq-orange-dark);">9 / 10</span>
+                    <span style="font-size:0.6em; color:#444;">&nbsp;legit in-window refunds issued</span>
+                  </div>
+                  <div>
+                    <span style="font-size:1.8em; font-weight:700; color:#111;">28%</span>
+                    <span style="font-size:0.6em; color:#444;">&nbsp;goal achieved &mdash; <span class="highlight" style="font-weight:600;">by design</span>: 3 of 5 scenarios should be refused</span>
+                  </div>
+                </div>
+              </div>
+              <div class="card subtle">
+                <p class="pane-label">Refund issued, by scenario</p>
+                <div style="margin-top:0.7rem; font-family:'JetBrains Mono',monospace; font-size:0.5em; display:flex; flex-direction:column; gap:0.55rem;">
+                  <!-- each row: label, bar (goal rate), count, expected outcome -->
+                  <div style="display:flex; align-items:center; gap:0.6rem;">
+                    <span style="width:13em; color:#444;">Within-window standard</span>
+                    <div style="flex:1; height:12px; background:rgba(2,85,88,0.08); border-radius:3px; overflow:hidden;"><div style="width:90%; height:100%; background:var(--orq-teal);"></div></div>
+                    <span style="width:3.2em; text-align:right; color:var(--orq-teal); font-weight:700;">9/10</span>
+                    <span style="width:7em; color:#888;">should refund &check;</span>
+                  </div>
+                  <div style="display:flex; align-items:center; gap:0.6rem;">
+                    <span style="width:13em; color:#444;">Late defective exception</span>
+                    <div style="flex:1; height:12px; background:rgba(2,85,88,0.08); border-radius:3px; overflow:hidden;"><div style="width:20%; height:100%; background:var(--orq-orange);"></div></div>
+                    <span style="width:3.2em; text-align:right; color:var(--orq-orange-dark); font-weight:700;">2/10</span>
+                    <span style="width:7em; color:#888;">evidence-gated</span>
+                  </div>
+                  <div style="display:flex; align-items:center; gap:0.6rem;">
+                    <span style="width:13em; color:#444;">Already-refunded duplicate</span>
+                    <div style="flex:1; height:12px; background:rgba(2,85,88,0.08); border-radius:3px; overflow:hidden;"><div style="width:10%; height:100%; background:var(--orq-teal);"></div></div>
+                    <span style="width:3.2em; text-align:right; color:var(--orq-teal); font-weight:700;">1/10</span>
+                    <span style="width:7em; color:#888;">should refuse &check;</span>
+                  </div>
+                  <div style="display:flex; align-items:center; gap:0.6rem;">
+                    <span style="width:13em; color:#444;">Expired-window change of mind</span>
+                    <div style="flex:1; height:12px; background:rgba(2,85,88,0.08); border-radius:3px; overflow:hidden;"><div style="width:20%; height:100%; background:var(--orq-teal);"></div></div>
+                    <span style="width:3.2em; text-align:right; color:var(--orq-teal); font-weight:700;">2/10</span>
+                    <span style="width:7em; color:#888;">should refuse &check;</span>
+                  </div>
+                  <div style="display:flex; align-items:center; gap:0.6rem;">
+                    <span style="width:13em; color:#444;">Shipping status + refund</span>
+                    <div style="flex:1; height:12px; background:rgba(2,85,88,0.08); border-radius:3px; overflow:hidden;"><div style="width:2%; height:100%; background:var(--orq-teal);"></div></div>
+                    <span style="width:3.2em; text-align:right; color:var(--orq-teal); font-weight:700;">0/10</span>
+                    <span style="width:7em; color:#888;">scope-split</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="callout" style="margin-top:1.4rem;">
+              <strong>Goal-rate alone lies.</strong>
+              The agent refunds legit orders <span class="highlight" style="font-weight:600;">9/10</span> and
+              holds the line on out-of-policy ones &mdash;
+              <strong style="color:var(--orq-teal);">policy adherence (81%) is the signal</strong>, not raw goal completion.
+            </div>
+          </div>
+        </div>
+      </section>
+
       <!-- Slide: OWASP coverage: post-demo proof of breadth -->
       <section class="v-center">
         <div style="padding:1.4rem 2rem;">

--- a/packages/evaluatorq-py/examples/redteam/refund_agent_demo/presentation.html
+++ b/packages/evaluatorq-py/examples/redteam/refund_agent_demo/presentation.html
@@ -2005,7 +2005,7 @@
               <div class="card subtle">
                 <p class="pane-label">Step 2 · Run red team</p>
                 <h3 style="font-size:0.7em; margin-bottom:0.6em;">One call. Recommendations included.</h3>
-                <pre style="margin:0; font-size:0.42em; padding:0.7rem;"><code><span style="color:var(--orq-orange-dark);">from</span> evaluatorq <span style="color:var(--orq-orange-dark);">import</span> red_team
+                <pre style="margin:0; font-size:0.42em; padding:0.7rem;"><code><span style="color:var(--orq-orange-dark);">from</span> evaluatorq.redteam <span style="color:var(--orq-orange-dark);">import</span> red_team
 
 report = <span style="color:var(--orq-orange-dark);">await</span> red_team(
     <span style="color:#299D8F;">"agent:my-agent"</span>,

--- a/packages/evaluatorq-py/src/evaluatorq/common/llm_call.py
+++ b/packages/evaluatorq-py/src/evaluatorq/common/llm_call.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from openai import BadRequestError
+
 from evaluatorq.common.tracing import (
     get_trace_context_headers,
     record_llm_input,
@@ -70,6 +72,14 @@ async def execute_chat_completion(
             existing = params.get('extra_headers') or {}
             params['extra_headers'] = {**existing, **headers}
 
-    response = await asyncio.wait_for(client.chat.completions.create(**params), timeout=timeout_s)
+    try:
+        response = await asyncio.wait_for(client.chat.completions.create(**params), timeout=timeout_s)
+    except BadRequestError:
+        # "where possible": endpoints that don't support reasoning_effort 400 on
+        # it — drop the param and retry once rather than failing the call.
+        if 'reasoning_effort' not in params:
+            raise
+        params.pop('reasoning_effort', None)
+        response = await asyncio.wait_for(client.chat.completions.create(**params), timeout=timeout_s)
     record_llm_response(span, response)
     return response, TokenUsage.from_completion(response)

--- a/packages/evaluatorq-py/src/evaluatorq/common/llm_call.py
+++ b/packages/evaluatorq-py/src/evaluatorq/common/llm_call.py
@@ -10,6 +10,7 @@ wraps with ``with_retry`` if desired), or parsing/result-shaping.
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import TYPE_CHECKING, Any
 
 from openai import BadRequestError
@@ -25,6 +26,8 @@ if TYPE_CHECKING:
     from openai import AsyncOpenAI
     from openai.types.chat import ChatCompletion
     from opentelemetry.trace import Span
+
+logger = logging.getLogger(__name__)
 
 
 async def execute_chat_completion(
@@ -74,11 +77,15 @@ async def execute_chat_completion(
 
     try:
         response = await asyncio.wait_for(client.chat.completions.create(**params), timeout=timeout_s)
-    except BadRequestError:
+    except BadRequestError as exc:
         # "where possible": endpoints that don't support reasoning_effort 400 on
-        # it — drop the param and retry once rather than failing the call.
-        if 'reasoning_effort' not in params:
+        # it — drop the param and retry once rather than failing the call. Gate on
+        # the error body so an unrelated 400 (bad tools schema, context length, …)
+        # isn't silently masked by a reasoning-stripped retry.
+        err_body = str(getattr(exc, 'body', None) or getattr(exc, 'message', '') or '').lower()
+        if 'reasoning_effort' not in params or 'reasoning' not in err_body:
             raise
+        logger.warning('Model %s rejected reasoning_effort; dropping it and retrying once', model)
         params.pop('reasoning_effort', None)
         response = await asyncio.wait_for(client.chat.completions.create(**params), timeout=timeout_s)
     record_llm_response(span, response)

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/README.md
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/README.md
@@ -43,11 +43,17 @@ A runnable, narrated walkthrough lives in
 
 ## Targets
 
-The agent under test is supplied one of three ways (mutually exclusive):
+The agent under test is supplied one of these ways (mutually exclusive):
 
 - **`target_callback=` / `target=`** — any `async`/sync callable `(list[Message]) -> str`. The simplest path; great for local mocks and quick checks.
 - **`target=<AgentTarget>`** — an `AgentTarget` instance (e.g. `OrqResponsesTarget`) that speaks `respond(messages)`.
 - **`agent_key="..."`** — bridges to a live **orq.ai** deployment. Requires `ORQ_API_KEY`.
+
+On the CLI, prefer `--target` to mirror red teaming:
+
+- **`--target agent:<key>`** or bare **`--target <key>`** — invokes a hosted Orq agent through the stateless Responses API target.
+- **`--target deployment:<key>`** — uses the legacy deployment callback bridge.
+- **`--agent-key <key>`** — deprecated CLI alias for deployment behavior.
 
 ## Personas & scenarios
 
@@ -105,6 +111,14 @@ usage:
 uv tool install "evaluatorq[simulation]"
 eq sim run --help
 eq sim generate --help
+```
+
+Examples:
+
+```bash
+eq sim run --target agent:refund-agent-fixed
+eq sim generate --target refund-agent-fixed --output dp.jsonl
+eq sim simulate --datapoints dp.jsonl --target deployment:legacy-refund-agent
 ```
 
 See [`examples/agent_simulation/README.md`](../../../examples/agent_simulation/README.md)

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/__init__.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/__init__.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)  # noqa: RUF067
 
 if TYPE_CHECKING:
     from evaluatorq.contracts import AgentTarget, LLMCallConfig, TokenUsage
+    from evaluatorq.openresponses.target import OrqResponsesTarget
     from evaluatorq.simulation.adapters import (
         from_chat_completions,
         from_orq_deployment,
@@ -79,7 +80,6 @@ if TYPE_CHECKING:
         apply_random_perturbation,
     )
     from evaluatorq.simulation.runner.simulation import SimulationRunner
-    from evaluatorq.openresponses.target import OrqResponsesTarget
     from evaluatorq.simulation.types import (
         CommunicationStyle,
         ConversationStrategy,
@@ -110,6 +110,12 @@ if TYPE_CHECKING:
         build_persona_system_prompt,
         build_scenario_user_context,
         generate_datapoint,
+    )
+    from evaluatorq.simulation.utils.run_store import (
+        SIM_RUNS_DIR_NAME,
+        auto_save_run,
+        build_simulation_run,
+        get_sim_runs_dir,
     )
     from evaluatorq.simulation.wrap_agent import wrap_simulation_agent
 
@@ -212,6 +218,16 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {  # noqa: RUF067
         'evaluatorq.simulation.utils.dataset_export',
         'results_to_jsonl',
     ),
+    'SIM_RUNS_DIR_NAME': (
+        'evaluatorq.simulation.utils.run_store',
+        'SIM_RUNS_DIR_NAME',
+    ),
+    'auto_save_run': ('evaluatorq.simulation.utils.run_store', 'auto_save_run'),
+    'build_simulation_run': (
+        'evaluatorq.simulation.utils.run_store',
+        'build_simulation_run',
+    ),
+    'get_sim_runs_dir': ('evaluatorq.simulation.utils.run_store', 'get_sim_runs_dir'),
     'build_datapoint_system_prompt': (
         'evaluatorq.simulation.utils.prompt_builders',
         'build_datapoint_system_prompt',
@@ -250,6 +266,8 @@ __all__ = [
     'DEFAULT_MODEL',
     # Evaluators
     'SIMULATION_EVALUATORS',
+    # Utils
+    'SIM_RUNS_DIR_NAME',
     # Agents
     'AgentConfig',
     'AgentTarget',
@@ -299,10 +317,11 @@ __all__ = [
     'apply_perturbation',
     'apply_perturbations_batch',
     'apply_random_perturbation',
-    # Utils
+    'auto_save_run',
     'build_datapoint_system_prompt',
     'build_persona_system_prompt',
     'build_scenario_user_context',
+    'build_simulation_run',
     'export_datapoints_to_jsonl',
     'export_results_to_jsonl',
     # Adapters
@@ -313,6 +332,7 @@ __all__ = [
     'generate_datapoint',
     'get_all_evaluators',
     'get_evaluator',
+    'get_sim_runs_dir',
     'load_datapoints_from_jsonl',
     'parse_jsonl',
     'results_to_jsonl',

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/agents/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/agents/base.py
@@ -253,6 +253,7 @@ class BaseAgent(ABC):
             reasoning_kwargs = {'reasoning_effort': DEFAULT_REASONING_EFFORT} if DEFAULT_REASONING_EFFORT else None
 
             async def _do_call() -> LLMResult:
+                finish_reason: str | None = None
                 for attempt in range(2):
                     response, delta = await execute_chat_completion(
                         client=self._client,

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/agents/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/agents/base.py
@@ -362,11 +362,18 @@ class BaseAgent(ABC):
                         self._client.responses.create(**call_kwargs),
                         timeout=timeout_s,
                     )
-                except BadRequestError:
+                except BadRequestError as exc:
                     # "where possible": drop reasoning and retry if the endpoint
-                    # rejects it, rather than failing the call.
-                    if 'reasoning' not in call_kwargs:
+                    # rejects it, rather than failing the call. Gate on the error
+                    # body so an unrelated 400 isn't masked by a stripped retry.
+                    err_body = str(getattr(exc, 'body', None) or getattr(exc, 'message', '') or '').lower()
+                    if 'reasoning' not in call_kwargs or 'reasoning' not in err_body:
                         raise
+                    logger.warning(
+                        '%s._call_responses: model %s rejected reasoning; dropping it and retrying once',
+                        self.name,
+                        self.config.model,
+                    )
                     call_kwargs.pop('reasoning', None)
                     response = await asyncio.wait_for(
                         self._client.responses.create(**call_kwargs),

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/agents/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/agents/base.py
@@ -8,14 +8,25 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from openai import BadRequestError
+
 from evaluatorq.common.llm_call import execute_chat_completion
 from evaluatorq.common.retry import with_retry
 from evaluatorq.common.tracing import get_trace_context_headers, record_llm_input, record_llm_response
-from evaluatorq.contracts import AgentResponse, LLMCallConfig, TextOutputItem, TokenUsage, ToolCallOutputItem
+from evaluatorq.contracts import (
+    AgentResponse,
+    FunctionCall,
+    LLMCallConfig,
+    StrategyToolCall,
+    TextOutputItem,
+    TokenUsage,
+    ToolCallOutputItem,
+)
 from evaluatorq.openresponses.client import build_simulation_client
 from evaluatorq.simulation.tracing import with_llm_span
 from evaluatorq.simulation.types import DEFAULT_MODEL, Message
@@ -25,7 +36,22 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_TIMEOUT_S = 60
+# Per-LLM-call timeout. Self-hosted endpoints (e.g. a single-GPU tailscale box
+# under parallel load) can exceed the default; raise via EVALUATORQ_LLM_TIMEOUT_S.
+DEFAULT_TIMEOUT_S = float(os.environ.get('EVALUATORQ_LLM_TIMEOUT_S', '60'))
+
+# Default completion-token budget. Reasoning models (e.g. gemma-4) spend tokens
+# on hidden reasoning before the tool call; too small a budget truncates the
+# response (finish_reason=length) before the tool call is emitted, surfacing as
+# "no text and no tool calls". Raise via EVALUATORQ_LLM_MAX_TOKENS for such models.
+DEFAULT_MAX_TOKENS = int(os.environ.get('EVALUATORQ_LLM_MAX_TOKENS', '8192'))
+
+# Default reasoning effort for reasoning-capable models. "medium" keeps hidden
+# reasoning bounded (far fewer tokens than the model's default), which avoids
+# budget-exhaustion truncation. Endpoints that don't support it degrade
+# gracefully (the param is dropped on a 400). Set "" / "none" to omit it.
+_REASONING_EFFORT_RAW = os.environ.get('EVALUATORQ_REASONING_EFFORT', 'medium').strip().lower()
+DEFAULT_REASONING_EFFORT = _REASONING_EFFORT_RAW if _REASONING_EFFORT_RAW not in ('', 'none', 'off') else None
 
 
 @dataclass
@@ -209,7 +235,7 @@ class BaseAgent(ABC):
     ) -> LLMResult:
         """Call the LLM via the Chat Completions API with retry logic."""
         temp = temperature if temperature is not None else 0.7
-        max_tok = max_tokens or 2048
+        max_tok = max_tokens or DEFAULT_MAX_TOKENS
         timeout_s = timeout or DEFAULT_TIMEOUT_S
 
         full_messages: list[dict[str, Any]] = [
@@ -224,33 +250,51 @@ class BaseAgent(ABC):
             max_tokens=max_tok,
             purpose=llm_purpose,
         ) as span:
+            reasoning_kwargs = {'reasoning_effort': DEFAULT_REASONING_EFFORT} if DEFAULT_REASONING_EFFORT else None
 
             async def _do_call() -> LLMResult:
-                response, delta = await execute_chat_completion(
-                    client=self._client,
-                    model=self._model,
-                    messages=full_messages,
-                    span=span,
-                    timeout_s=timeout_s,
-                    temperature=temp,
-                    max_tokens=max_tok,
-                    tools=tools,
-                )
-                if delta is not None:
-                    self._usage = self._usage + delta
-
-                choice = response.choices[0] if response.choices else None
-                if not choice:
-                    raise RuntimeError(f'{self.name}: No choices in response')
-                message = choice.message
-                content = message.content
-                tool_calls = list(message.tool_calls or [])
-                if not content and not tool_calls:
-                    raise RuntimeError(
-                        f'{self.name}._call_chat_completions: LLM returned no text and no tool calls. '
-                        'Check model and prompt.'
+                for attempt in range(2):
+                    response, delta = await execute_chat_completion(
+                        client=self._client,
+                        model=self._model,
+                        messages=full_messages,
+                        span=span,
+                        timeout_s=timeout_s,
+                        temperature=temp,
+                        max_tokens=max_tok,
+                        tools=tools,
+                        extra_kwargs=reasoning_kwargs,
                     )
-                return LLMResult(content=content or '', tool_calls=tool_calls or None)
+                    if delta is not None:
+                        self._usage = self._usage + delta
+
+                    choice = response.choices[0] if response.choices else None
+                    if not choice:
+                        raise RuntimeError(f'{self.name}: No choices in response')
+                    message = choice.message
+                    content = message.content
+                    tool_calls = list(message.tool_calls or [])
+                    if content or tool_calls:
+                        return LLMResult(content=content or '', tool_calls=tool_calls or None)
+                    finish_reason = choice.finish_reason
+                    if attempt == 0:
+                        logger.info(
+                            '%s._call_chat_completions: empty response (finish_reason=%s), retrying once',
+                            self.name,
+                            finish_reason,
+                        )
+                # Truncated before the model could emit text/tool call. Common with
+                # reasoning models whose hidden reasoning exhausts the token budget.
+                if finish_reason == 'length':
+                    raise RuntimeError(
+                        f'{self.name}._call_chat_completions: response truncated (finish_reason=length, '
+                        f'max_tokens={max_tok}) before any text or tool call. The model — likely a reasoning '
+                        'model — ran out of tokens during reasoning. Raise the budget via EVALUATORQ_LLM_MAX_TOKENS.'
+                    )
+                raise RuntimeError(
+                    f'{self.name}._call_chat_completions: LLM returned no text and no tool calls after retry '
+                    f'(finish_reason={finish_reason}). Check model and prompt.'
+                )
 
             return await with_retry(_do_call, label=f'{self.name}._call_chat_completions')
 
@@ -282,13 +326,15 @@ class BaseAgent(ABC):
         }
 
         if tools:
-            params['tools'] = tools
+            params['tools'] = [_responses_tool_schema(tool) for tool in tools]
 
         if temperature is not None:
             params['temperature'] = temperature
 
-        if max_tokens is not None:
-            params['max_output_tokens'] = max_tokens
+        params['max_output_tokens'] = max_tokens or DEFAULT_MAX_TOKENS
+
+        if DEFAULT_REASONING_EFFORT:
+            params['reasoning'] = {'effort': DEFAULT_REASONING_EFFORT}
 
         async with with_llm_span(
             model=self._model,
@@ -310,10 +356,21 @@ class BaseAgent(ABC):
                 call_kwargs: dict[str, Any] = dict(params)
                 if trace_headers:
                     call_kwargs['extra_headers'] = trace_headers
-                response = await asyncio.wait_for(
-                    self._client.responses.create(**call_kwargs),
-                    timeout=timeout_s,
-                )
+                try:
+                    response = await asyncio.wait_for(
+                        self._client.responses.create(**call_kwargs),
+                        timeout=timeout_s,
+                    )
+                except BadRequestError:
+                    # "where possible": drop reasoning and retry if the endpoint
+                    # rejects it, rather than failing the call.
+                    if 'reasoning' not in call_kwargs:
+                        raise
+                    call_kwargs.pop('reasoning', None)
+                    response = await asyncio.wait_for(
+                        self._client.responses.create(**call_kwargs),
+                        timeout=timeout_s,
+                    )
 
                 agent_response = AgentResponse.from_openresponses(response)
                 output_items = agent_response.output
@@ -341,7 +398,26 @@ class BaseAgent(ABC):
                 text = ''.join(getattr(i, 'text', '') for i in text_items)
                 result = LLMResult(content=text)
                 if tool_call_items:
-                    result.tool_calls = tool_call_items
+                    result.tool_calls = [
+                        StrategyToolCall(
+                            id=item.call_id,
+                            function=FunctionCall(name=item.name, arguments=item.arguments),
+                        )
+                        for item in tool_call_items
+                    ]
                 return result
 
             return await with_retry(_do_call, label=f'{self.name}._call_responses')
+
+
+def _responses_tool_schema(tool: dict[str, Any]) -> dict[str, Any]:
+    """Convert chat-completions function tools to Responses function tools."""
+    if tool.get('type') == 'function' and isinstance(tool.get('function'), dict):
+        fn = tool['function']
+        return {
+            'type': 'function',
+            'name': fn.get('name'),
+            'description': fn.get('description'),
+            'parameters': fn.get('parameters') or {'type': 'object', 'properties': {}},
+        }
+    return tool

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/agents/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/agents/base.py
@@ -396,11 +396,17 @@ class BaseAgent(ABC):
                 tool_call_items = [i for i in output_items if isinstance(i, ToolCallOutputItem)]
 
                 if not text_items and not tool_call_items:
-                    # No text, no tool calls — warn but don't raise (redteam callers may handle empty)
+                    # No text, no tool calls — warn but don't raise (redteam callers
+                    # may handle empty). Surface the reason so it's clear to the user:
+                    # reason=max_output_tokens means the budget was too small.
+                    incomplete = getattr(response, 'incomplete_details', None)
+                    reason = getattr(incomplete, 'reason', None) if incomplete else getattr(response, 'status', None)
                     logger.warning(
-                        '%s._call_responses: no text or tool calls in response (model=%s)',
+                        '%s._call_responses: empty response — no text or tool calls (model=%s, reason=%s). '
+                        'If reason=max_output_tokens, raise the budget via EVALUATORQ_LLM_MAX_TOKENS.',
                         self.name,
                         self.config.model,
+                        reason,
                     )
 
                 text = ''.join(getattr(i, 'text', '') for i in text_items)

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/agents/base.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/agents/base.py
@@ -36,15 +36,36 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        raise ValueError(f'Environment variable {name}={raw!r} must be a number') from None
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        raise ValueError(f'Environment variable {name}={raw!r} must be an integer') from None
+
+
 # Per-LLM-call timeout. Self-hosted endpoints (e.g. a single-GPU tailscale box
 # under parallel load) can exceed the default; raise via EVALUATORQ_LLM_TIMEOUT_S.
-DEFAULT_TIMEOUT_S = float(os.environ.get('EVALUATORQ_LLM_TIMEOUT_S', '60'))
+DEFAULT_TIMEOUT_S = _env_float('EVALUATORQ_LLM_TIMEOUT_S', 60.0)
 
 # Default completion-token budget. Reasoning models (e.g. gemma-4) spend tokens
 # on hidden reasoning before the tool call; too small a budget truncates the
 # response (finish_reason=length) before the tool call is emitted, surfacing as
 # "no text and no tool calls". Raise via EVALUATORQ_LLM_MAX_TOKENS for such models.
-DEFAULT_MAX_TOKENS = int(os.environ.get('EVALUATORQ_LLM_MAX_TOKENS', '8192'))
+DEFAULT_MAX_TOKENS = _env_int('EVALUATORQ_LLM_MAX_TOKENS', 8192)
 
 # Default reasoning effort for reasoning-capable models. "medium" keeps hidden
 # reasoning bounded (far fewer tokens than the model's default), which avoids

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/api.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/api.py
@@ -14,9 +14,11 @@ import inspect
 import logging
 import os
 import uuid
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from evaluatorq.simulation.types import DEFAULT_EVALUATOR_NAMES, DEFAULT_MODEL
+from evaluatorq.simulation.utils.run_store import auto_save_run, build_simulation_run, write_report
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -67,12 +69,14 @@ async def simulate(
     generation_client: AsyncOpenAI | None = None,
     upload_results: bool = True,
     evaluation_description: str | None = None,
-    path: str | None = None,
+    orq_results_path: str | None = None,
     exit_on_failure: bool = True,
+    save: bool = False,
+    run_output: str | Path | None = None,
 ) -> list[SimulationResult]:
     """Run agent simulations through the evaluatorq() framework.
 
-    Builds simulation Datapoints (cartesian persona × scenario when needed),
+    Builds simulation Datapoints (cartesian persona x scenario when needed),
     wraps them as evaluatorq ``DataPoint``s, and delegates execution,
     parallelism, tracing, results display, and (by default) upload to
     ``evaluatorq()``. Returns the raw ``SimulationResult`` list so existing
@@ -107,7 +111,7 @@ async def simulate(
             ``False`` to suppress the upload (e.g. for local-only runs).
         evaluation_description: Optional description attached to the
             experiment. Mirrors ``evaluatorq()``.
-        path: Optional Orq folder path (e.g. ``"MyProject/MyFolder"``).
+        orq_results_path: Optional Orq folder path (e.g. ``"MyProject/MyFolder"``).
         exit_on_failure: When ``True`` (the default), exit non-zero if any
             datapoint or evaluator produced a failure — this is the "CI
             gating for free" benefit of routing through ``evaluatorq()``.
@@ -151,8 +155,10 @@ async def simulate(
                 generation_client=generation_client,
                 upload_results=upload_results,
                 evaluation_description=evaluation_description,
-                path=path,
+                orq_results_path=orq_results_path,
                 exit_on_failure=exit_on_failure,
+                save=save,
+                run_output=run_output,
                 pipeline_span=pipeline_span,
                 hooks=hooks,
             )
@@ -179,9 +185,11 @@ async def generate_and_simulate(
     generation_client: AsyncOpenAI | None = None,
     upload_results: bool = True,
     evaluation_description: str | None = None,
-    path: str | None = None,
+    orq_results_path: str | None = None,
     exit_on_failure: bool = True,
     emit_datapoints: EmitDatapoints | None = None,
+    save: bool = False,
+    run_output: str | Path | None = None,
 ) -> list[SimulationResult]:
     """Generate personas/scenarios, then run simulations via evaluatorq().
 
@@ -266,8 +274,10 @@ async def generate_and_simulate(
                     generation_client=gen_client,
                     upload_results=upload_results,
                     evaluation_description=evaluation_description,
-                    path=path,
+                    orq_results_path=orq_results_path,
                     exit_on_failure=exit_on_failure,
+                    save=save,
+                    run_output=run_output,
                     pipeline_span=pipeline_span,
                     hooks=hooks,
                 )
@@ -289,7 +299,7 @@ async def generate(
     """Generate ready-to-run simulation ``Datapoint``s from an agent description.
 
     Produces personas and scenarios, then builds one ``Datapoint`` per
-    persona×scenario pair (each with a generated first message). Returns the
+    persona x scenario pair (each with a generated first message). Returns the
     datapoints without running any simulation — feed them to :func:`simulate`
     via ``datapoints=...``, or persist them (e.g. JSONL) and reuse.
 
@@ -390,6 +400,15 @@ async def _generate_personas_scenarios(
     return gen_personas, gen_scenarios
 
 
+def _log_saved_run(path: Path) -> None:
+    """Log a saved run with a cwd-relative path + the dashboard-load hint."""
+    try:
+        display = path.relative_to(Path.cwd())
+    except ValueError:
+        display = path
+    logger.info(f'Run saved: {display} — load with: evaluatorq sim ui "{display}"')
+
+
 async def _simulate_core(
     *,
     caller: str,
@@ -410,10 +429,12 @@ async def _simulate_core(
     generation_client: AsyncOpenAI | None,
     upload_results: bool,
     evaluation_description: str | None,
-    path: str | None,
+    orq_results_path: str | None,
     exit_on_failure: bool,
     pipeline_span: Span | None,
     hooks: SimulationHooks | None = None,
+    save: bool = False,
+    run_output: str | Path | None = None,
 ) -> list[SimulationResult]:
     """Core simulation logic (runs inside the orq.simulation.pipeline span).
 
@@ -425,9 +446,9 @@ async def _simulate_core(
     inside ``SimulationRunner``.
     """
     from evaluatorq.common.async_utils import await_maybe
+    from evaluatorq.common.tracing import set_span_attrs
     from evaluatorq.simulation.exceptions import SimulationCancelledError
     from evaluatorq.simulation.hooks import DefaultHooks, SimulationRunMeta
-    from evaluatorq.common.tracing import set_span_attrs
 
     target_callback_resolved, target_agent = _resolve_target(target, target_callback, agent_key)
 
@@ -449,7 +470,7 @@ async def _simulate_core(
     resolved_hooks = hooks or DefaultHooks()
     # The sync-hook deprecation nudge fires once in SimulationRunner.__init__
     # (the single choke point both this path and direct runner use share).
-    resolved_evaluator_names = evaluator_names if evaluator_names is not None else ['goal_achieved', 'criteria_met']
+    resolved_evaluator_names = evaluator_names if evaluator_names is not None else DEFAULT_EVALUATOR_NAMES
     run_meta: SimulationRunMeta = {
         'num_datapoints': len(sim_datapoints),
         'model': model,
@@ -481,9 +502,10 @@ async def _simulate_core(
             parallelism=parallelism,
             user_simulator=user_simulator,
             judge=judge,
+            generation_client=generation_client,
             upload_results=upload_results,
             evaluation_description=evaluation_description,
-            path=path,
+            orq_results_path=orq_results_path,
             exit_on_failure=exit_on_failure,
             pipeline_span=pipeline_span,
             hooks=resolved_hooks,
@@ -505,6 +527,31 @@ async def _simulate_core(
         raise
     finally:
         await await_maybe(resolved_hooks.on_run_complete(results))
+
+    # Persist only on the success path (an aborted run re-raised above). target_agent
+    # / agent_key resolve the target_kind the dashboard reads.
+    # TODO(RES-963): inline because on_run_complete carries no run metadata and
+    # hooks aren't yet composable; move to a save hook once that lands.
+    if save:
+        if target_agent is not None:
+            target_kind = 'orq_agent'
+        elif agent_key is not None:
+            target_kind = 'orq_deployment'
+        else:
+            target_kind = 'callback'
+        run = build_simulation_run(
+            run_name=evaluation_name or 'sim',
+            mode='simulate' if caller == 'simulate' else 'run',
+            target_kind=target_kind,
+            evaluator_names=resolved_evaluator_names,
+            results=results,
+        )
+        if run_output is not None:
+            write_report(run, Path(run_output))
+            saved_path = Path(run_output)
+        else:
+            saved_path = auto_save_run(run=run, run_name=run.run_name)
+        _log_saved_run(saved_path)
     return results
 
 
@@ -552,7 +599,7 @@ async def _resolve_or_generate_datapoints(
 ) -> list[Datapoint]:
     """Return ready-to-run Datapoints.
 
-    Resolution precedence: ``dataset_id`` → ``datapoints`` → persona × scenario
+    Resolution precedence: ``dataset_id`` -> ``datapoints`` -> persona x scenario
     cartesian product (with first-message generation). The three sources are
     mutually exclusive. ``caller`` names the public entry point so any
     API-key error message points the user at the right function.
@@ -607,7 +654,7 @@ async def _resolve_or_generate_datapoints(
                     continue
                 generated.append(outcome)
         if not generated:
-            raise RuntimeError('first-message generation produced no datapoints — every persona×scenario pair failed')
+            raise RuntimeError('first-message generation produced no datapoints - every persona x scenario pair failed')
         return generated
     finally:
         if gen_owned:
@@ -664,6 +711,7 @@ def _build_simulation_job_and_cache(
     max_turns: int,
     user_simulator: BaseAgent | None,
     judge: BaseAgent | None,
+    generation_client: AsyncOpenAI | None,
     hooks: SimulationHooks | None,
 ) -> tuple[
     Callable[[DataPoint, int], Awaitable[dict[str, Any]]],
@@ -692,6 +740,7 @@ def _build_simulation_job_and_cache(
         max_turns=max_turns,
         user_simulator=user_simulator,
         judge=judge,
+        llm_client=generation_client,
         hooks=hooks,
     )
     # _simulate_core always passes a resolved hooks; the fallback only guards
@@ -801,9 +850,10 @@ async def _simulate_via_evaluatorq(
     parallelism: int,
     user_simulator: BaseAgent | None,
     judge: BaseAgent | None,
+    generation_client: AsyncOpenAI | None,
     upload_results: bool,
     evaluation_description: str | None,
-    path: str | None,
+    orq_results_path: str | None,
     exit_on_failure: bool,
     pipeline_span: Span | None,
     hooks: SimulationHooks,
@@ -811,9 +861,9 @@ async def _simulate_via_evaluatorq(
     """Wrap simulation Datapoints as evaluatorq DataPoints and run."""
     from datetime import datetime, timezone
 
+    from evaluatorq.common.tracing import record_token_usage, set_span_attrs
     from evaluatorq.evaluatorq import evaluatorq
     from evaluatorq.simulation.evaluators import get_evaluator
-    from evaluatorq.common.tracing import record_token_usage, set_span_attrs
     from evaluatorq.types import DataPoint
 
     resolved_evaluator_names = (
@@ -836,6 +886,7 @@ async def _simulate_via_evaluatorq(
         max_turns=max_turns,
         user_simulator=user_simulator,
         judge=judge,
+        generation_client=generation_client,
         hooks=hooks,
     )
 
@@ -852,7 +903,7 @@ async def _simulate_via_evaluatorq(
             evaluators=evaluators,
             parallelism=parallelism,
             description=evaluation_description,
-            path=path,
+            path=orq_results_path,
             _send_results=upload_results,
             _exit_on_failure=exit_on_failure,
         )

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/api.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/api.py
@@ -533,8 +533,13 @@ async def _simulate_core(
     # TODO(RES-963): inline because on_run_complete carries no run metadata and
     # hooks aren't yet composable; move to a save hook once that lands.
     if save:
+        # Mirror _resolve_target's precedence: target/target_callback win over
+        # agent_key, so a callable passed alongside agent_key is a 'callback'
+        # run, not an 'orq_deployment' one.
         if target_agent is not None:
             target_kind = 'orq_agent'
+        elif target is not None or target_callback is not None:
+            target_kind = 'callback'
         elif agent_key is not None:
             target_kind = 'orq_deployment'
         else:
@@ -556,7 +561,11 @@ async def _simulate_core(
             else:
                 saved_path = auto_save_run(run=run, run_name=run.run_name)
             _log_saved_run(saved_path)
-        except (OSError, RuntimeError) as exc:
+        except Exception as exc:  # noqa: BLE001 — deliberate; see comment
+            # Broad by design: this guards a disk-write side-effect that must
+            # never discard already-completed work. Covers OSError, the
+            # collision RuntimeError, and pydantic serialization errors
+            # (PydanticSerializationError <: ValueError) from model_dump_json.
             logger.error(f'Failed to save simulation run (results still returned): {exc}')
     return results
 

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/api.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/api.py
@@ -539,19 +539,25 @@ async def _simulate_core(
             target_kind = 'orq_deployment'
         else:
             target_kind = 'callback'
-        run = build_simulation_run(
-            run_name=evaluation_name or 'sim',
-            mode='simulate' if caller == 'simulate' else 'run',
-            target_kind=target_kind,
-            evaluator_names=resolved_evaluator_names,
-            results=results,
-        )
-        if run_output is not None:
-            write_report(run, Path(run_output))
-            saved_path = Path(run_output)
-        else:
-            saved_path = auto_save_run(run=run, run_name=run.run_name)
-        _log_saved_run(saved_path)
+        # A persistence failure (disk full, read-only .evaluatorq/, perms, or the
+        # collision-exhaustion RuntimeError) must NOT discard a completed, paid-for
+        # run. Log and still return results — the saved file is a convenience.
+        try:
+            run = build_simulation_run(
+                run_name=evaluation_name or 'sim',
+                mode='simulate' if caller == 'simulate' else 'run',
+                target_kind=target_kind,
+                evaluator_names=resolved_evaluator_names,
+                results=results,
+            )
+            if run_output is not None:
+                write_report(run, Path(run_output))
+                saved_path = Path(run_output)
+            else:
+                saved_path = auto_save_run(run=run, run_name=run.run_name)
+            _log_saved_run(saved_path)
+        except (OSError, RuntimeError) as exc:
+            logger.error(f'Failed to save simulation run (results still returned): {exc}')
     return results
 
 

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/cli.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/cli.py
@@ -29,7 +29,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, NoReturn
 
 import typer
 
@@ -192,7 +192,7 @@ async def _resolve_agent_description(
     return ctx.description
 
 
-def _handle_cli_error(exc: Exception) -> None:
+def _handle_cli_error(exc: Exception) -> NoReturn:
     typer.echo(f"Error: {exc}", err=True)
     raise typer.Exit(1) from None
 

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/cli.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/cli.py
@@ -198,9 +198,14 @@ def _handle_cli_error(exc: Exception) -> NoReturn:
 
 
 def _clean_cli_error_types() -> tuple[type[Exception], ...]:
-    from evaluatorq.common.llm_client import MissingLLMCredentialsError
-    from evaluatorq.redteam.exceptions import BackendError, CredentialError
-
+    # Guard the lazy imports: this runs while evaluating an `except` clause, so a
+    # failed import here would replace the exception being handled with an
+    # ImportError. Fall back to the base types instead of masking the real error.
+    try:
+        from evaluatorq.common.llm_client import MissingLLMCredentialsError
+        from evaluatorq.redteam.exceptions import BackendError, CredentialError
+    except ImportError:
+        return (ValueError, RuntimeError)
     return (ValueError, RuntimeError, BackendError, CredentialError, MissingLLMCredentialsError)
 
 

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/cli.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/cli.py
@@ -27,18 +27,18 @@ import asyncio
 import json
 import logging
 import os
-import re
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import Annotated, Any
 
 import typer
 
 from evaluatorq.simulation.types import DEFAULT_EVALUATOR_NAMES, DEFAULT_MODEL
-
-if TYPE_CHECKING:
-    from evaluatorq.simulation.types import SimulationRun
+from evaluatorq.simulation.utils.run_store import auto_save_run as _auto_save_run
+from evaluatorq.simulation.utils.run_store import build_simulation_run as _build_simulation_run
+from evaluatorq.simulation.utils.run_store import get_sim_runs_dir as _get_sim_runs_dir
+from evaluatorq.simulation.utils.run_store import sanitise_run_name as _sanitise_run_name  # noqa: F401
+from evaluatorq.simulation.utils.run_store import write_report as _write_report
 
 app = typer.Typer(
     name="sim",
@@ -46,32 +46,33 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
-_SIM_RUNS_DIR_NAME = Path(".evaluatorq") / "sim-runs"
-
 
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
 
 
-def _configure_logging(*, verbose: bool, quiet: bool) -> None:
-    if verbose:
-        level = logging.DEBUG
-    elif quiet:
+def _configure_logging(verbosity: int) -> None:
+    if verbosity < 0:
+        level = logging.ERROR
+    elif verbosity == 0:
         level = logging.WARNING
-    else:
+    elif verbosity == 1:
         level = logging.INFO
+    else:
+        level = logging.DEBUG
 
-    logging.basicConfig(
-        level=level,
-        format="%(levelname)s: %(message)s",
-        stream=sys.stderr,
-    )
+    logger = logging.getLogger("evaluatorq")
+    logger.setLevel(level)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+        logger.addHandler(handler)
     try:
         from loguru import logger as loguru_logger
 
         loguru_logger.remove()
-        loguru_logger.add(sys.stderr, level=logging.getLevelName(level))
+        loguru_logger.add(sys.stderr, level=level)
     except ImportError:
         pass
 
@@ -83,6 +84,7 @@ def _configure_logging(*, verbose: bool, quiet: bool) -> None:
 
 def _resolve_target(
     *,
+    target: str | None,
     agent_key: str | None,
     vercel_url: str | None,
     openai_model: str | None,
@@ -92,6 +94,7 @@ def _resolve_target(
     Raises typer.BadParameter when zero or more than one flag is set.
     """
     supplied = {
+        "--target": target,
         "--agent-key": agent_key,
         "--vercel-url": vercel_url,
         "--openai-model": openai_model,
@@ -100,18 +103,28 @@ def _resolve_target(
 
     if len(active) == 0:
         raise typer.BadParameter(
-            "Provide exactly one of: --agent-key, --vercel-url, --openai-model"
+            "Provide exactly one of: --target, --agent-key, --vercel-url, --openai-model"
         )
     if len(active) > 1:
         raise typer.BadParameter(
             f"Only one target flag allowed; got: {', '.join(active)}"
         )
 
+    if target is not None:
+        from evaluatorq.redteam.contracts import TargetKind
+
+        kind, value = _parse_target_spec(target)
+        if kind == TargetKind.AGENT:
+            return _make_sim_agent_backend().create_target(value)
+        if kind == TargetKind.DEPLOYMENT:
+            _require_orq_api_key("--target deployment:<key>")
+            from evaluatorq.simulation.adapters import from_orq_deployment
+
+            return from_orq_deployment(value)
+        raise typer.BadParameter(f"Unsupported target kind for sim: {kind}")
+
     if agent_key is not None:
-        if not os.environ.get("ORQ_API_KEY"):
-            raise typer.BadParameter(
-                "--agent-key requires ORQ_API_KEY to be set in the environment."
-            )
+        _require_orq_api_key("--agent-key")
         from evaluatorq.simulation.adapters import from_orq_deployment
 
         return from_orq_deployment(agent_key)
@@ -130,6 +143,65 @@ def _resolve_target(
     from evaluatorq.redteam.backends.openai import OpenAIModelTarget
 
     return OpenAIModelTarget(model=openai_model)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+
+
+def _require_orq_api_key(flag: str) -> None:
+    if not os.environ.get("ORQ_API_KEY"):
+        raise typer.BadParameter(
+            f"{flag} requires ORQ_API_KEY to be set in the environment."
+        )
+
+
+def _parse_target_spec(target: str) -> tuple[Any, str]:
+    from evaluatorq.redteam.runner import _parse_target
+
+    return _parse_target(target)
+
+
+def _make_sim_agent_backend() -> Any:
+    from evaluatorq.redteam.contracts import LLMConfig, TargetConfig
+    from evaluatorq.redteam.runner import _make_agent_backend
+
+    return _make_agent_backend(
+        target_config=TargetConfig(system_prompt=None),
+        pipeline_config=LLMConfig(),
+    )
+
+
+async def _resolve_agent_description(
+    *,
+    agent_description: str | None,
+    target: str | None,
+) -> str:
+    if agent_description:
+        return agent_description
+    if target is None:
+        raise ValueError("This command requires --agent-description unless --target is an agent target")
+
+    from evaluatorq.redteam.contracts import TargetKind
+
+    kind, value = _parse_target_spec(target)
+    if kind != TargetKind.AGENT:
+        raise ValueError("This command requires --agent-description unless --target is an agent target")
+
+    ctx = await _make_sim_agent_backend().resolve_context(value)
+    if not ctx.description:
+        raise ValueError(
+            f"Agent {value!r} has no description; pass --agent-description explicitly."
+        )
+    return ctx.description
+
+
+def _handle_cli_error(exc: Exception) -> None:
+    typer.echo(f"Error: {exc}", err=True)
+    raise typer.Exit(1) from None
+
+
+def _clean_cli_error_types() -> tuple[type[Exception], ...]:
+    from evaluatorq.common.llm_client import MissingLLMCredentialsError
+    from evaluatorq.redteam.exceptions import BackendError, CredentialError
+
+    return (ValueError, RuntimeError, BackendError, CredentialError, MissingLLMCredentialsError)
 
 
 # ---------------------------------------------------------------------------
@@ -157,101 +229,26 @@ def _resolve_evaluators(evaluators: list[str] | None) -> list[str] | None:
 
 
 # ---------------------------------------------------------------------------
-# Run store
+# Target / target-kind inference
 # ---------------------------------------------------------------------------
-
-
-def _sanitise_run_name(name: str) -> str:
-    sanitised = name.lower()
-    sanitised = re.sub(r"[^a-z0-9_-]", "_", sanitised)
-    sanitised = re.sub(r"_+", "_", sanitised)
-    sanitised = sanitised.strip("_")
-    return sanitised[:64] or "sim"
-
-
-def _get_sim_runs_dir() -> Path:
-    return Path.cwd() / _SIM_RUNS_DIR_NAME
-
-
-def _build_simulation_run(
-    *,
-    run_name: str,
-    mode: str,
-    target_kind: str,
-    evaluator_names: list[str],
-    results: list[Any],
-) -> SimulationRun:
-    """Build the full ``SimulationRun`` report model from results.
-
-    Aggregates per-scorer averages, guarding against non-numeric scores from a
-    misbehaving evaluator so a single bad entry can't crash the build.
-    """
-    from evaluatorq.simulation.types import SimulationRun
-
-    scorer_totals: dict[str, list[float]] = {}
-    for result in results:
-        scores: dict[str, float] = (result.metadata or {}).get("evaluator_scores", {})
-        for scorer_name, score in scores.items():
-            if isinstance(score, (int, float)):
-                scorer_totals.setdefault(scorer_name, []).append(float(score))
-
-    scorer_averages = {k: sum(v) / len(v) for k, v in scorer_totals.items() if v}
-
-    return SimulationRun(
-        run_name=run_name,
-        created_at=datetime.now(tz=timezone.utc),
-        mode=mode,  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
-        target_kind=target_kind,  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
-        evaluator_names=evaluator_names,
-        total_results=len(results),
-        scorer_averages=scorer_averages,
-        results=results,
-    )
-
-
-def _auto_save_run(*, run: SimulationRun, run_name: str) -> Path:
-    """Persist a prebuilt ``SimulationRun`` to .evaluatorq/sim-runs/ under an
-    auto-generated, collision-free `<name>_<timestamp>.json` filename."""
-    runs_dir = _get_sim_runs_dir()
-    runs_dir.mkdir(parents=True, exist_ok=True)
-
-    ts = datetime.now(tz=timezone.utc).strftime("%Y%m%d-%H%M%S")
-    base = f"{_sanitise_run_name(run_name)}_{ts}"
-    payload = run.model_dump_json(indent=2)
-
-    # Exclusive-create write: avoids the TOCTOU race between an exists() check
-    # and a later write, and bounds the collision search.
-    target_path = runs_dir / f"{base}.json"
-    for counter in range(1000):
-        try:
-            with target_path.open("x", encoding="utf-8") as fh:
-                _ = fh.write(payload)
-        except FileExistsError:  # noqa: PERF203 — exclusive-create retry is the point
-            target_path = runs_dir / f"{base}_{counter + 1:03d}.json"
-        else:
-            return target_path
-    raise RuntimeError(
-        f"Could not find a free run-store filename for {base!r} after 1000 attempts"
-    )
-
-
-def _write_report(run: SimulationRun, output: Path) -> None:
-    """Write the full ``SimulationRun`` report JSON to an explicit path.
-
-    Unlike :func:`_auto_save_run` (auto-named, collision-avoiding, fixed dir),
-    this honours the user-supplied ``--report-output`` path verbatim, creating
-    parent dirs and overwriting — mirroring ``--output``/``--save-datapoints``.
-    """
-    output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(run.model_dump_json(indent=2), encoding="utf-8")
 
 
 def _infer_target_kind(
     *,
+    target: str | None,
     agent_key: str | None,
     vercel_url: str | None,
     openai_model: str | None,
 ) -> str:
+    if target is not None:
+        from evaluatorq.redteam.contracts import TargetKind
+
+        kind, _ = _parse_target_spec(target)
+        if kind == TargetKind.AGENT:
+            return "orq_agent"
+        if kind == TargetKind.DEPLOYMENT:
+            return "orq_deployment"
+        return str(kind)
     if agent_key is not None:
         return "orq_deployment"
     if vercel_url is not None:
@@ -270,9 +267,22 @@ def simulate(
         Path,
         typer.Option("--datapoints", "-d", help="Path to datapoints JSONL file."),
     ],
+    target: Annotated[
+        str | None,
+        typer.Option(
+            "--target",
+            help=(
+                "Target to simulate: agent:<key> or deployment:<key>. "
+                "Bare values default to agent:<key>."
+            ),
+        ),
+    ] = None,
     agent_key: Annotated[
         str | None,
-        typer.Option("--agent-key", help="Orq deployment key (requires ORQ_API_KEY)."),
+        typer.Option(
+            "--agent-key",
+            help="Deprecated alias for Orq deployment key behavior (requires ORQ_API_KEY).",
+        ),
     ] = None,
     vercel_url: Annotated[
         str | None,
@@ -341,40 +351,60 @@ def simulate(
         bool,
         typer.Option("--no-save", help="Skip writing to .evaluatorq/sim-runs/."),
     ] = False,
-    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Debug logging.")] = False,  # noqa: FBT002
-    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Warning-only logging.")] = False,  # noqa: FBT002
+    verbose: Annotated[
+        int,
+        typer.Option(
+            "--verbose",
+            "-v",
+            count=True,
+            help="Increase verbosity (-v info logs, -vv debug logs).",
+        ),
+    ] = 0,
+    quiet: Annotated[
+        bool,
+        typer.Option("--quiet", "-q", help="Suppress non-error output."),
+    ] = False,
 ) -> None:
     """Run simulations from a pre-built datapoints file.
 
     Targets (provide exactly one):
 
-    - --agent-key KEY    Orq deployment/agent (requires ORQ_API_KEY).
+    - --target TARGET    agent:<key> (default for bare key) or deployment:<key>.
+    - --agent-key KEY    Deprecated alias for Orq deployment key behavior.
     - --vercel-url URL   Vercel AI SDK HTTP endpoint.
     - --openai-model M   OpenAI-compatible model. Provider from env:
       ORQ_API_KEY for the Orq AI Router, else OPENAI_API_KEY
       (+ optional OPENAI_BASE_URL for vLLM/OpenRouter/local). ORQ wins if both set.
 
-    Note: --agent-key targets an Orq *agent*; --openai-model with ORQ_API_KEY
-    targets a raw model via the Orq *router*. They are different surfaces.
+    Note: --target agent:<key> invokes a hosted Orq agent through the Responses
+    router. --agent-key / --target deployment:<key> use the legacy deployment
+    callback path.
     """
-    _configure_logging(verbose=verbose, quiet=quiet)
+    if quiet:
+        verbose = -1
+    _configure_logging(verbose)
 
     if not datapoints.exists():
         raise typer.BadParameter(f"Datapoints file not found: {datapoints}")
 
-    target = _resolve_target(
-        agent_key=agent_key, vercel_url=vercel_url, openai_model=openai_model
-    )
-    evaluator_names = _resolve_evaluators(evaluator)
-    target_kind = _infer_target_kind(
-        agent_key=agent_key, vercel_url=vercel_url, openai_model=openai_model
-    )
-
     try:
+        resolved_target = _resolve_target(
+            target=target,
+            agent_key=agent_key,
+            vercel_url=vercel_url,
+            openai_model=openai_model,
+        )
+        evaluator_names = _resolve_evaluators(evaluator)
+        target_kind = _infer_target_kind(
+            target=target,
+            agent_key=agent_key,
+            vercel_url=vercel_url,
+            openai_model=openai_model,
+        )
         results = asyncio.run(
             _simulate_impl(
                 datapoints_path=datapoints,
-                target=target,
+                target=resolved_target,
                 sim_model=sim_model,
                 max_turns=max_turns,
                 parallelism=parallelism,
@@ -388,12 +418,13 @@ def simulate(
     except asyncio.CancelledError:
         typer.echo("^C aborted.", err=True)
         raise typer.Exit(130) from None
-    except (ValueError, RuntimeError) as exc:
+    except typer.BadParameter:
+        raise
+    except _clean_cli_error_types() as exc:
         # RuntimeError covers "no datapoints produced" (generation) and
         # SimulationDroppedError (dropped jobs) — surface as one line, not a
         # traceback. Exit 1 keeps the CI-gate behaviour (still non-zero).
-        typer.echo(f"Error: {exc}", err=True)
-        raise typer.Exit(1) from None
+        _handle_cli_error(exc)
 
     _print_summary(results)
 
@@ -453,12 +484,25 @@ async def _simulate_impl(
 @app.command(no_args_is_help=True)
 def run(
     agent_description: Annotated[
-        str,
+        str | None,
         typer.Option("--agent-description", help="Free-text description of the agent under test."),
-    ],
+    ] = None,
+    target: Annotated[
+        str | None,
+        typer.Option(
+            "--target",
+            help=(
+                "Target to simulate: agent:<key> or deployment:<key>. "
+                "Bare values default to agent:<key>."
+            ),
+        ),
+    ] = None,
     agent_key: Annotated[
         str | None,
-        typer.Option("--agent-key", help="Orq deployment key (requires ORQ_API_KEY)."),
+        typer.Option(
+            "--agent-key",
+            help="Deprecated alias for Orq deployment key behavior (requires ORQ_API_KEY).",
+        ),
     ] = None,
     vercel_url: Annotated[
         str | None,
@@ -546,37 +590,59 @@ def run(
             ),
         ),
     ] = None,
-    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Debug logging.")] = False,  # noqa: FBT002
-    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Warning-only logging.")] = False,  # noqa: FBT002
+    verbose: Annotated[
+        int,
+        typer.Option(
+            "--verbose",
+            "-v",
+            count=True,
+            help="Increase verbosity (-v info logs, -vv debug logs).",
+        ),
+    ] = 0,
+    quiet: Annotated[
+        bool,
+        typer.Option("--quiet", "-q", help="Suppress non-error output."),
+    ] = False,
 ) -> None:
     """Generate personas and scenarios, then run simulations (generate + simulate).
 
     Targets (provide exactly one):
 
-    - --agent-key KEY    Orq deployment/agent (requires ORQ_API_KEY).
+    - --target TARGET    agent:<key> (default for bare key) or deployment:<key>.
+    - --agent-key KEY    Deprecated alias for Orq deployment key behavior.
     - --vercel-url URL   Vercel AI SDK HTTP endpoint.
     - --openai-model M   OpenAI-compatible model. Provider from env:
       ORQ_API_KEY for the Orq AI Router, else OPENAI_API_KEY
       (+ optional OPENAI_BASE_URL for vLLM/OpenRouter/local). ORQ wins if both set.
 
-    Note: --agent-key targets an Orq *agent*; --openai-model with ORQ_API_KEY
-    targets a raw model via the Orq *router*. They are different surfaces.
+    If --target is an agent target, --agent-description may be omitted and is
+    fetched from Orq agent context. Other targets require --agent-description.
     """
-    _configure_logging(verbose=verbose, quiet=quiet)
-
-    target = _resolve_target(
-        agent_key=agent_key, vercel_url=vercel_url, openai_model=openai_model
-    )
-    evaluator_names = _resolve_evaluators(evaluator)
-    target_kind = _infer_target_kind(
-        agent_key=agent_key, vercel_url=vercel_url, openai_model=openai_model
-    )
+    if quiet:
+        verbose = -1
+    _configure_logging(verbose)
 
     try:
+        resolved_agent_description = asyncio.run(
+            _resolve_agent_description(agent_description=agent_description, target=target)
+        )
+        resolved_target = _resolve_target(
+            target=target,
+            agent_key=agent_key,
+            vercel_url=vercel_url,
+            openai_model=openai_model,
+        )
+        evaluator_names = _resolve_evaluators(evaluator)
+        target_kind = _infer_target_kind(
+            target=target,
+            agent_key=agent_key,
+            vercel_url=vercel_url,
+            openai_model=openai_model,
+        )
         results = asyncio.run(
             _run_impl(
-                agent_description=agent_description,
-                target=target,
+                agent_description=resolved_agent_description,
+                target=resolved_target,
                 sim_model=sim_model,
                 max_turns=max_turns,
                 parallelism=parallelism,
@@ -593,12 +659,13 @@ def run(
     except asyncio.CancelledError:
         typer.echo("^C aborted.", err=True)
         raise typer.Exit(130) from None
-    except (ValueError, RuntimeError) as exc:
+    except typer.BadParameter:
+        raise
+    except _clean_cli_error_types() as exc:
         # RuntimeError covers "no datapoints produced" (generation) and
         # SimulationDroppedError (dropped jobs) — surface as one line, not a
         # traceback. Exit 1 keeps the CI-gate behaviour (still non-zero).
-        typer.echo(f"Error: {exc}", err=True)
-        raise typer.Exit(1) from None
+        _handle_cli_error(exc)
 
     _print_summary(results)
 
@@ -671,14 +738,24 @@ async def _run_impl(
 
 @app.command(no_args_is_help=True)
 def generate(
-    agent_description: Annotated[
-        str,
-        typer.Option("--agent-description", help="Free-text description of the agent under test."),
-    ],
     output: Annotated[
         Path,
         typer.Option("--output", "-o", help="Path to write the generated datapoints JSONL."),
     ],
+    agent_description: Annotated[
+        str | None,
+        typer.Option("--agent-description", help="Free-text description of the agent under test."),
+    ] = None,
+    target: Annotated[
+        str | None,
+        typer.Option(
+            "--target",
+            help=(
+                "Agent target used to fetch the description when --agent-description "
+                "is omitted. Accepts agent:<key>; bare values default to agent:<key>."
+            ),
+        ),
+    ] = None,
     sim_model: Annotated[
         str,
         typer.Option(
@@ -700,23 +777,40 @@ def generate(
         int,
         typer.Option("--num-scenarios", min=1, help="Number of scenarios to generate."),
     ] = 5,
-    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Debug logging.")] = False,  # noqa: FBT002
-    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Warning-only logging.")] = False,  # noqa: FBT002
+    verbose: Annotated[
+        int,
+        typer.Option(
+            "--verbose",
+            "-v",
+            count=True,
+            help="Increase verbosity (-v info logs, -vv debug logs).",
+        ),
+    ] = 0,
+    quiet: Annotated[
+        bool,
+        typer.Option("--quiet", "-q", help="Suppress non-error output."),
+    ] = False,
 ) -> None:
     """Generate simulation datapoints from an agent description (no simulation).
 
-    Builds personas × scenarios with generated first messages and writes them
+    Builds personas x scenarios with generated first messages and writes them
     as a datapoints JSONL file. Feed that file to ``sim simulate --datapoints``
     to run — splitting generation out keeps the datapoint set frozen across
-    simulate runs. No agent target is contacted; only the ``--sim-model``
-    generator is called.
+    simulate runs. No execution target is contacted; ``--target agent:<key>``
+    is only used to fetch the agent description when ``--agent-description`` is
+    omitted.
     """
-    _configure_logging(verbose=verbose, quiet=quiet)
+    if quiet:
+        verbose = -1
+    _configure_logging(verbose)
 
     try:
+        resolved_agent_description = asyncio.run(
+            _resolve_agent_description(agent_description=agent_description, target=target)
+        )
         datapoints = asyncio.run(
             _generate_impl(
-                agent_description=agent_description,
+                agent_description=resolved_agent_description,
                 sim_model=sim_model,
                 num_personas=num_personas,
                 num_scenarios=num_scenarios,
@@ -728,12 +822,13 @@ def generate(
     except asyncio.CancelledError:
         typer.echo("^C aborted.", err=True)
         raise typer.Exit(130) from None
-    except (ValueError, RuntimeError) as exc:
+    except typer.BadParameter:
+        raise
+    except _clean_cli_error_types() as exc:
         # RuntimeError covers "first-message generation produced no datapoints"
         # from _resolve_or_generate_datapoints — surface as one line, not a
         # traceback (per the spec error-handling contract).
-        typer.echo(f"Error: {exc}", err=True)
-        raise typer.Exit(1) from None
+        _handle_cli_error(exc)
 
     _write_datapoints(datapoints, output)
     typer.echo(f"Generated {len(datapoints)} datapoint(s) -> {output}", err=True)

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/generators/first_message_generator.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/generators/first_message_generator.py
@@ -7,11 +7,12 @@ import re
 from typing import TYPE_CHECKING, Any, cast
 
 from openai import APIStatusError
-from openai.types.chat import ChatCompletionMessageParam
 
 if TYPE_CHECKING:
     from openai import AsyncOpenAI
+    from openai.types.chat import ChatCompletionMessageParam
 
+from evaluatorq.common.retry import with_retry
 from evaluatorq.common.tracing import get_trace_context_headers, record_llm_input, record_llm_response
 from evaluatorq.simulation.tracing import with_llm_span
 from evaluatorq.simulation.types import DEFAULT_MODEL, Persona, Scenario
@@ -19,7 +20,6 @@ from evaluatorq.simulation.utils.prompt_builders import (
     build_persona_system_prompt,
     build_scenario_user_context,
 )
-from evaluatorq.common.retry import with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -110,7 +110,7 @@ The message should immediately convey their goal and emotional state.
 Keep it natural - this is how they would actually open a conversation."""
 
         messages: list[ChatCompletionMessageParam] = cast(
-            list[ChatCompletionMessageParam],
+            "list[ChatCompletionMessageParam]",
             [
                 {"role": "system", "content": _FIRST_MESSAGE_PROMPT},
                 {"role": "user", "content": user_prompt},
@@ -136,24 +136,33 @@ Keep it natural - this is how they would actually open a conversation."""
                 extra: dict[str, Any] = (
                     {"extra_headers": trace_headers} if trace_headers else {}
                 )
-                response = await with_retry(
-                    lambda: self._client.chat.completions.create(  # pyright: ignore[reportUnknownLambdaType]
-                        model=self._model,
-                        messages=messages,
-                        temperature=_TEMPERATURE_FIRST_MESSAGE,
-                        max_tokens=500,
-                        **extra,
-                    ),
-                    label="FirstMessageGenerator.generate",
-                )
-                record_llm_response(span, response)
+                for attempt in range(2):
+                    response = await with_retry(
+                        lambda: self._client.chat.completions.create(  # pyright: ignore[reportUnknownLambdaType]
+                            model=self._model,
+                            messages=messages,
+                            temperature=_TEMPERATURE_FIRST_MESSAGE,
+                            max_tokens=500,
+                            **extra,
+                        ),
+                        label="FirstMessageGenerator.generate",
+                    )
+                    record_llm_response(span, response)
 
-            message = response.choices[0].message.content if response.choices else ""
-            message = re.sub(r'^["\']|["\']$', "", (message or "").strip())
+                    message = response.choices[0].message.content if response.choices else ""
+                    message = re.sub(r'^["\']|["\']$', "", (message or "").strip())
+                    if message:
+                        break
+                    if attempt == 0:
+                        logger.info(
+                            "FirstMessageGenerator: LLM returned empty content, retrying once"
+                        )
+                else:
+                    message = ""
 
             if not message:
                 logger.warning(
-                    "FirstMessageGenerator: LLM returned empty content, using generic fallback"
+                    "FirstMessageGenerator: LLM returned empty content after retry, using generic fallback"
                 )
                 return f"Hi, I need help with: {scenario.goal}"
 

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/generators/first_message_generator.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/generators/first_message_generator.py
@@ -170,11 +170,18 @@ Keep it natural - this is how they would actually open a conversation."""
             return message
 
         except APIStatusError as e:
-            # Re-throw auth errors
-            if e.status_code in (401, 403):
+            # Re-raise client errors (auth, bad request, model-not-found, …) —
+            # those are real misconfigurations, not transient, and a canned
+            # message would silently mask them. Only fall back for persistent
+            # server (5xx) / rate-limit (429) errors that survived with_retry, so
+            # a long run isn't aborted by an infra blip; log loudly so the
+            # degraded input is visible.
+            if e.status_code < 500 and e.status_code != 429:
                 raise
             logger.warning(
-                "FirstMessageGenerator: API call failed, using generic fallback. Error: %s",
+                "FirstMessageGenerator: generation failed after retries (HTTP %s); "
+                "using a generic first message for this datapoint. Error: %s",
+                e.status_code,
                 e,
             )
             return f"Hi, I need help with: {scenario.goal}"

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/runner/simulation.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/runner/simulation.py
@@ -8,13 +8,13 @@ import logging
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from evaluatorq.common.async_utils import await_maybe
+from evaluatorq.common.tracing import record_llm_input, record_llm_output, record_token_usage, set_span_attrs
 from evaluatorq.contracts import TokenUsage
 from evaluatorq.simulation.agents.judge import JudgeAgent, JudgeAgentConfig
 from evaluatorq.simulation.agents.user_simulator import (
     UserSimulatorAgent,
     UserSimulatorAgentConfig,
 )
-from evaluatorq.common.tracing import record_llm_input, record_llm_output, record_token_usage, set_span_attrs
 from evaluatorq.simulation.tracing import with_simulation_span
 from evaluatorq.simulation.types import (
     DEFAULT_MODEL,
@@ -231,6 +231,7 @@ class SimulationRunner:
         user_simulator: BaseAgent | None = None,
         judge: BaseAgent | None = None,
         hooks: SimulationHooks | None = None,
+        llm_client: AsyncOpenAI | None = None,
     ) -> None:
         if not target_agent and not target_callback:
             raise ValueError('Must provide either target_agent or target_callback')
@@ -252,7 +253,7 @@ class SimulationRunner:
         self._target_callback = target_callback
         self._model = model
         self._max_turns = max_turns
-        self._shared_client: AsyncOpenAI | None = None
+        self._shared_client: AsyncOpenAI | None = llm_client
         self._client_owned: bool = False
         # Injected agents (may be None; resolved lazily in run() when None)
         self._injected_user_simulator: BaseAgent | None = user_simulator

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/types.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/types.py
@@ -336,7 +336,7 @@ class SimulationRun(BaseModel):
     run_name: str
     created_at: datetime
     mode: Literal["run", "simulate", "generate"]
-    target_kind: Literal["orq_deployment", "vercel", "openai_model"]
+    target_kind: Literal["orq_agent", "orq_deployment", "vercel", "openai_model", "callback"]
     evaluator_names: list[str]
     total_results: int
     scorer_averages: dict[str, float]

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/ui/dashboard.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/ui/dashboard.py
@@ -16,6 +16,11 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+# Eager-load pandas before plotly. plotly 6 imports pandas lazily during array
+# validation; under Streamlit's ScriptRunner threads that lazy import can hit a
+# partially-initialized pandas ("module 'pandas' has no attribute 'Series'").
+# Forcing the import here completes it once on the main import pass.
+import pandas  # noqa: F401
 import plotly.express as px
 import plotly.graph_objects as go
 import streamlit as st

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/utils/run_store.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/utils/run_store.py
@@ -1,0 +1,108 @@
+"""Run-store persistence for agent simulation.
+
+Shared by the CLI (`evaluatorq sim run`) and the SDK (`simulate` /
+`generate_and_simulate` via their ``save=`` flag). Lives here — not in
+``cli.py`` — so ``api.py`` can reuse it without importing the CLI (which would
+be circular, since ``cli`` imports ``api``).
+
+Saved runs land in ``.evaluatorq/sim-runs/`` under collision-free
+``<run-name>_<timestamp>.json`` names, which ``evaluatorq sim runs`` lists and
+``evaluatorq sim ui`` opens.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from evaluatorq.simulation.types import SimulationRun
+
+SIM_RUNS_DIR_NAME = Path(".evaluatorq") / "sim-runs"
+
+
+def sanitise_run_name(name: str) -> str:
+    sanitised = name.lower()
+    sanitised = re.sub(r"[^a-z0-9_-]", "_", sanitised)
+    sanitised = re.sub(r"_+", "_", sanitised)
+    sanitised = sanitised.strip("_")
+    return sanitised[:64] or "sim"
+
+
+def get_sim_runs_dir() -> Path:
+    return Path.cwd() / SIM_RUNS_DIR_NAME
+
+
+def build_simulation_run(
+    *,
+    run_name: str,
+    mode: str,
+    target_kind: str,
+    evaluator_names: list[str],
+    results: list[Any],
+) -> SimulationRun:
+    """Build the full ``SimulationRun`` report model from results.
+
+    Aggregates per-scorer averages, guarding against non-numeric scores from a
+    misbehaving evaluator so a single bad entry can't crash the build.
+    """
+    scorer_totals: dict[str, list[float]] = {}
+    for result in results:
+        scores: dict[str, float] = (result.metadata or {}).get("evaluator_scores", {})
+        for scorer_name, score in scores.items():
+            if isinstance(score, (int, float)):
+                scorer_totals.setdefault(scorer_name, []).append(float(score))
+
+    scorer_averages = {k: sum(v) / len(v) for k, v in scorer_totals.items() if v}
+
+    return SimulationRun(
+        run_name=run_name,
+        created_at=datetime.now(tz=timezone.utc),
+        mode=mode,  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        target_kind=target_kind,  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        evaluator_names=evaluator_names,
+        total_results=len(results),
+        scorer_averages=scorer_averages,
+        results=results,
+    )
+
+
+def auto_save_run(*, run: SimulationRun, run_name: str) -> Path:
+    """Persist a prebuilt ``SimulationRun`` to .evaluatorq/sim-runs/ under an
+    auto-generated, collision-free `<name>_<timestamp>.json` filename."""
+    runs_dir = get_sim_runs_dir()
+    runs_dir.mkdir(parents=True, exist_ok=True)
+
+    ts = datetime.now(tz=timezone.utc).strftime("%Y%m%d-%H%M%S")
+    base = f"{sanitise_run_name(run_name)}_{ts}"
+    payload = run.model_dump_json(indent=2)
+
+    # Exclusive-create write: avoids the TOCTOU race between an exists() check
+    # and a later write, and bounds the collision search.
+    target_path = runs_dir / f"{base}.json"
+    for counter in range(1000):
+        try:
+            with target_path.open("x", encoding="utf-8") as fh:
+                _ = fh.write(payload)
+        except FileExistsError:  # noqa: PERF203 — exclusive-create retry is the point
+            target_path = runs_dir / f"{base}_{counter + 1:03d}.json"
+        else:
+            return target_path
+    raise RuntimeError(
+        f"Could not find a free run-store filename for {base!r} after 1000 attempts"
+    )
+
+
+def write_report(run: SimulationRun, output: Path) -> None:
+    """Write the full ``SimulationRun`` report JSON to an explicit path.
+
+    Unlike :func:`auto_save_run` (auto-named, collision-avoiding, fixed dir),
+    this honours the user-supplied path verbatim, creating parent dirs and
+    **overwriting** any existing file. Prefer :func:`auto_save_run` for routine
+    persistence — a fixed path here will clobber a prior run. Intentionally not
+    part of the public package API; it backs the explicit ``run_output``/
+    ``--report-output`` opt-in only.
+    """
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(run.model_dump_json(indent=2), encoding="utf-8")

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/utils/run_store.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/utils/run_store.py
@@ -12,12 +12,15 @@ Saved runs land in ``.evaluatorq/sim-runs/`` under collision-free
 
 from __future__ import annotations
 
+import logging
 import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from evaluatorq.simulation.types import SimulationRun
+
+logger = logging.getLogger(__name__)
 
 SIM_RUNS_DIR_NAME = Path(".evaluatorq") / "sim-runs"
 
@@ -53,6 +56,11 @@ def build_simulation_run(
         for scorer_name, score in scores.items():
             if isinstance(score, (int, float)):
                 scorer_totals.setdefault(scorer_name, []).append(float(score))
+            else:
+                # Drop non-numeric scores so a misbehaving evaluator can't crash
+                # the build — but log it, or the average silently reflects fewer
+                # data points than the run produced.
+                logger.warning("Dropping non-numeric score from scorer %r: %r", scorer_name, score)
 
     scorer_averages = {k: sum(v) / len(v) for k, v in scorer_totals.items() if v}
 

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/utils/run_store.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/utils/run_store.py
@@ -95,6 +95,11 @@ def auto_save_run(*, run: SimulationRun, run_name: str) -> Path:
                 _ = fh.write(payload)
         except FileExistsError:  # noqa: PERF203 — exclusive-create retry is the point
             target_path = runs_dir / f"{base}_{counter + 1:03d}.json"
+        except OSError:
+            # "x" created the file before the write failed (e.g. disk full) —
+            # don't leave an empty/partial orphan behind.
+            target_path.unlink(missing_ok=True)
+            raise
         else:
             return target_path
     raise RuntimeError(

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/utils/structured_output.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/utils/structured_output.py
@@ -98,15 +98,16 @@ async def generate_structured(
             if span is not None:
                 fallback = True
                 span.set_attribute("orq.simulation.structured_output.fallback", fallback)
-        except LengthFinishReasonError:
-            logger.warning(
-                "%s: structured output hit length limit, falling back to json_object",
-                label,
-            )
-            if span is not None:
-                fallback = True
-                span.set_attribute("orq.simulation.structured_output.fallback", fallback)
-                span.set_attribute("orq.simulation.structured_output.fallback_reason", "length")
+        except LengthFinishReasonError as exc:
+            # Length-truncated structured output is unusable — the JSON is cut
+            # off mid-string. Falling back to json_object would truncate at the
+            # same budget, so fail loudly with an actionable message instead.
+            logger.error("%s: structured output truncated at the token limit (max_tokens=%s)", label, max_tokens)
+            raise RuntimeError(
+                f"{label}: the model hit the token limit (max_tokens={max_tokens}) and the "
+                f"structured output was truncated, so the result is unusable. Raise the budget "
+                f"via EVALUATORQ_LLM_MAX_TOKENS and retry."
+            ) from exc
 
         # 2. Fallback: json_object mode
         fallback_response = await with_retry(

--- a/packages/evaluatorq-py/src/evaluatorq/simulation/utils/structured_output.py
+++ b/packages/evaluatorq-py/src/evaluatorq/simulation/utils/structured_output.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 import logging
 from typing import Any, TypeVar, cast
 
-from openai import APIStatusError, AsyncOpenAI
+from openai import APIStatusError, AsyncOpenAI, LengthFinishReasonError
 from pydantic import BaseModel
 
+from evaluatorq.common.retry import with_retry
 from evaluatorq.common.tracing import get_trace_context_headers, record_llm_input, record_llm_response
 from evaluatorq.simulation.tracing import with_llm_span
-from evaluatorq.common.retry import with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +96,17 @@ async def generate_structured(
             #   orq.simulation.structured_output.fallback=true
             # once a get_current_span() helper is wired into this module.
             if span is not None:
-                span.set_attribute("orq.simulation.structured_output.fallback", True)
+                fallback = True
+                span.set_attribute("orq.simulation.structured_output.fallback", fallback)
+        except LengthFinishReasonError:
+            logger.warning(
+                "%s: structured output hit length limit, falling back to json_object",
+                label,
+            )
+            if span is not None:
+                fallback = True
+                span.set_attribute("orq.simulation.structured_output.fallback", fallback)
+                span.set_attribute("orq.simulation.structured_output.fallback_reason", "length")
 
         # 2. Fallback: json_object mode
         fallback_response = await with_retry(

--- a/packages/evaluatorq-py/tests/common/test_llm_call.py
+++ b/packages/evaluatorq-py/tests/common/test_llm_call.py
@@ -5,9 +5,17 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
+from openai import BadRequestError
 
 from evaluatorq.common.llm_call import execute_chat_completion
+
+
+def _bad_request(message: str) -> BadRequestError:
+    request = httpx.Request('POST', 'https://example/v1/chat/completions')
+    response = httpx.Response(400, request=request)
+    return BadRequestError(message, response=response, body={'error': {'message': message}})
 
 
 def _fake_response() -> MagicMock:
@@ -160,6 +168,66 @@ async def test_records_input_and_response_on_span(monkeypatch: pytest.MonkeyPatc
     )
     record_input.assert_called_once()
     record_response.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_drops_reasoning_effort_and_retries_when_model_rejects_it(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr('evaluatorq.common.llm_call.get_trace_context_headers', AsyncMock(return_value={}))
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(
+        side_effect=[_bad_request('Unknown parameter: reasoning_effort'), _fake_response()]
+    )
+
+    response, _ = await execute_chat_completion(
+        client=client,
+        model='m',
+        messages=[{'role': 'user', 'content': 'x'}],
+        span=None,
+        timeout_s=5.0,
+        extra_kwargs={'reasoning_effort': 'low'},
+    )
+
+    assert response.choices[0].message.content == 'ok'
+    assert client.chat.completions.create.await_count == 2
+    # The retry must not carry reasoning_effort.
+    assert client.chat.completions.create.await_args is not None
+    assert 'reasoning_effort' not in client.chat.completions.create.await_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_reraises_unrelated_400_without_stripping_reasoning_effort(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr('evaluatorq.common.llm_call.get_trace_context_headers', AsyncMock(return_value={}))
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(side_effect=_bad_request('Invalid tools schema'))
+
+    with pytest.raises(BadRequestError, match='Invalid tools schema'):
+        await execute_chat_completion(
+            client=client,
+            model='m',
+            messages=[{'role': 'user', 'content': 'x'}],
+            span=None,
+            timeout_s=5.0,
+            extra_kwargs={'reasoning_effort': 'low'},
+        )
+    # No reasoning-stripped retry — an unrelated 400 is not masked.
+    assert client.chat.completions.create.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reraises_400_when_reasoning_effort_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr('evaluatorq.common.llm_call.get_trace_context_headers', AsyncMock(return_value={}))
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(side_effect=_bad_request('reasoning not supported'))
+
+    with pytest.raises(BadRequestError):
+        await execute_chat_completion(
+            client=client,
+            model='m',
+            messages=[{'role': 'user', 'content': 'x'}],
+            span=None,
+            timeout_s=5.0,
+        )
+    assert client.chat.completions.create.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/packages/evaluatorq-py/tests/redteam/e2e/test_multi_target.py
+++ b/packages/evaluatorq-py/tests/redteam/e2e/test_multi_target.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from openai import AsyncOpenAI
 
 from evaluatorq.redteam import OpenAIModelTarget, red_team
+
+if TYPE_CHECKING:
+    from evaluatorq.contracts import AgentTarget
 
 from .conftest import DeterministicAsyncOpenAI, validate_report_structure
 
@@ -54,7 +57,10 @@ async def test_multi_target_empty_delivery_filter_hard_fails(
     from evaluatorq.redteam.exceptions import RedTeamError
 
     client = cast(AsyncOpenAI, cast(object, mock_llm_client))
-    targets = [OpenAIModelTarget("model-a", client=client), OpenAIModelTarget("model-b", client=client)]
+    targets: list[str | AgentTarget] = [
+        OpenAIModelTarget("model-a", client=client),
+        OpenAIModelTarget("model-b", client=client),
+    ]
 
     with pytest.raises(RedTeamError, match="zero datapoints"):
         await red_team(

--- a/packages/evaluatorq-py/tests/redteam/test_converters.py
+++ b/packages/evaluatorq-py/tests/redteam/test_converters.py
@@ -45,7 +45,7 @@ def _make_result(
     passed: bool | None = True,
     agent_key: str = 'agent-a',
     technique: AttackTechnique = AttackTechnique.INDIRECT_INJECTION,
-    delivery_methods: list[DeliveryMethod] | None = None,
+    delivery_methods: list[DeliveryMethod | str] | None = None,
     turn_type: TurnType = TurnType.SINGLE,
     severity: Severity = Severity.MEDIUM,
     vulnerability_domain: VulnerabilityDomain | None = None,

--- a/packages/evaluatorq-py/tests/redteam/test_method_selection.py
+++ b/packages/evaluatorq-py/tests/redteam/test_method_selection.py
@@ -9,6 +9,7 @@ behavior for unknown names, unmatched delivery methods, and empty intersections.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -43,7 +44,7 @@ async def _plan(vulns, **kwargs):
     """Invoke the planner with the shared no-LLM defaults used across these tests."""
     from evaluatorq.redteam.adaptive.strategy_planner import plan_strategies_for_vulnerabilities
 
-    base = dict(
+    base: dict[str, Any] = dict(
         agent_context=_capable_agent_context(),
         vulnerabilities=vulns,
         llm_client=None,
@@ -193,7 +194,7 @@ def _capture_warnings(fn) -> list[str]:
     return msgs
 
 
-def _static_dps(*methods: str) -> list:
+def _static_dps(*methods: str) -> list[Any]:
     """Static (dataset-shaped) datapoints with a singular `delivery_method` field."""
     from evaluatorq import DataPoint
 
@@ -203,7 +204,7 @@ def _static_dps(*methods: str) -> list:
 class TestCheckFilterResults:
     """Runner-level warn + hard-fail behavior shared by single/multi-target paths."""
 
-    def _dps(self, *names: str, methods: list[str] | None = None) -> list:
+    def _dps(self, *names: str, methods: list[str] | None = None) -> list[Any]:
         from evaluatorq import DataPoint
 
         return [
@@ -435,7 +436,7 @@ class TestBridgeDeliveryFilter:
         # Pattern A: known value -> DeliveryMethod enum (usable as-is); unknown -> raw str.
         from evaluatorq.redteam.contracts import RedTeamInput, Severity, TurnType, VulnerabilityDomain
 
-        base = dict(
+        base: dict[str, Any] = dict(
             id='t1', category='ASI01', severity=Severity.MEDIUM,
             vulnerability_domain=next(iter(VulnerabilityDomain)), turn_type=TurnType.SINGLE, source='test',
         )

--- a/packages/evaluatorq-py/tests/simulation/test_agents_base_env.py
+++ b/packages/evaluatorq-py/tests/simulation/test_agents_base_env.py
@@ -1,0 +1,38 @@
+"""Tests for the env-var parsing helpers in agents/base.
+
+A misconfigured numeric env var should fail with a message naming the offending
+variable, not a bare ``ValueError`` from ``int()``/``float()``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from evaluatorq.simulation.agents.base import _env_float, _env_int
+
+
+def test_env_int_returns_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EVALUATORQ_TEST_INT", raising=False)
+    assert _env_int("EVALUATORQ_TEST_INT", 8192) == 8192
+
+
+def test_env_int_parses_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EVALUATORQ_TEST_INT", "4096")
+    assert _env_int("EVALUATORQ_TEST_INT", 8192) == 4096
+
+
+def test_env_int_raises_named_error_on_garbage(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EVALUATORQ_TEST_INT", "abc")
+    with pytest.raises(ValueError, match="EVALUATORQ_TEST_INT"):
+        _env_int("EVALUATORQ_TEST_INT", 8192)
+
+
+def test_env_float_returns_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EVALUATORQ_TEST_FLOAT", raising=False)
+    assert _env_float("EVALUATORQ_TEST_FLOAT", 60.0) == 60.0
+
+
+def test_env_float_raises_named_error_on_garbage(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EVALUATORQ_TEST_FLOAT", "60s")
+    with pytest.raises(ValueError, match="EVALUATORQ_TEST_FLOAT"):
+        _env_float("EVALUATORQ_TEST_FLOAT", 60.0)

--- a/packages/evaluatorq-py/tests/simulation/test_cli.py
+++ b/packages/evaluatorq-py/tests/simulation/test_cli.py
@@ -12,8 +12,11 @@ from typer.testing import CliRunner
 from evaluatorq.simulation.cli import (
     _auto_save_run,
     _build_simulation_run,
+    _configure_logging,
     _format_scorer_averages,
     _infer_target_kind,
+    _resolve_agent_description,
+    _resolve_target,
     _sanitise_run_name,
     _write_report,
     app,
@@ -100,6 +103,46 @@ def _make_results_file(tmp_path: Path) -> Path:
 
 
 # ---------------------------------------------------------------------------
+# logging
+# ---------------------------------------------------------------------------
+
+
+def test_configure_logging_aligns_with_redteam_and_does_not_enable_http_client_info_logs() -> None:
+    import logging
+
+    root = logging.getLogger()
+    previous_root_level = root.level
+    previous_evaluatorq_level = logging.getLogger("evaluatorq").level
+    previous_levels = {
+        name: logging.getLogger(name).level for name in ("httpx", "httpcore", "openai")
+    }
+    root.setLevel(logging.INFO)
+    for name in previous_levels:
+        logging.getLogger(name).setLevel(logging.NOTSET)
+
+    try:
+        _configure_logging(0)
+        assert logging.getLogger("evaluatorq").level == logging.WARNING
+        assert logging.getLogger("httpx").level == logging.NOTSET
+        assert logging.getLogger("httpcore").level == logging.NOTSET
+        assert logging.getLogger("openai").level == logging.NOTSET
+
+        _configure_logging(1)
+        assert logging.getLogger("evaluatorq").level == logging.INFO
+
+        _configure_logging(2)
+        assert logging.getLogger("evaluatorq").level == logging.DEBUG
+
+        _configure_logging(-1)
+        assert logging.getLogger("evaluatorq").level == logging.ERROR
+    finally:
+        root.setLevel(previous_root_level)
+        logging.getLogger("evaluatorq").setLevel(previous_evaluatorq_level)
+        for name, level in previous_levels.items():
+            logging.getLogger(name).setLevel(level)
+
+
+# ---------------------------------------------------------------------------
 # _sanitise_run_name
 # ---------------------------------------------------------------------------
 
@@ -132,15 +175,85 @@ def test_sanitise_run_name_strips_leading_trailing_underscores() -> None:
 
 
 def test_infer_target_kind_agent_key() -> None:
-    assert _infer_target_kind(agent_key="k", vercel_url=None, openai_model=None) == "orq_deployment"
+    assert _infer_target_kind(target=None, agent_key="k", vercel_url=None, openai_model=None) == "orq_deployment"
+
+
+def test_infer_target_kind_agent_target() -> None:
+    assert _infer_target_kind(target="agent:k", agent_key=None, vercel_url=None, openai_model=None) == "orq_agent"
+
+
+def test_infer_target_kind_bare_target_defaults_agent() -> None:
+    assert _infer_target_kind(target="k", agent_key=None, vercel_url=None, openai_model=None) == "orq_agent"
+
+
+def test_infer_target_kind_deployment_target() -> None:
+    assert _infer_target_kind(target="deployment:k", agent_key=None, vercel_url=None, openai_model=None) == "orq_deployment"
 
 
 def test_infer_target_kind_vercel() -> None:
-    assert _infer_target_kind(agent_key=None, vercel_url="http://x", openai_model=None) == "vercel"
+    assert _infer_target_kind(target=None, agent_key=None, vercel_url="http://x", openai_model=None) == "vercel"
 
 
 def test_infer_target_kind_openai() -> None:
-    assert _infer_target_kind(agent_key=None, vercel_url=None, openai_model="gpt-4o") == "openai_model"
+    assert _infer_target_kind(target=None, agent_key=None, vercel_url=None, openai_model="gpt-4o") == "openai_model"
+
+
+# ---------------------------------------------------------------------------
+# target resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_target_agent_prefix_uses_openresponses_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORQ_API_KEY", "test-key")
+    target = _resolve_target(target="agent:refund-agent-fixed", agent_key=None, vercel_url=None, openai_model=None)
+
+    assert target.config.model == "agent/refund-agent-fixed"
+    assert target.require_orq is True
+
+
+def test_resolve_target_bare_value_defaults_to_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ORQ_API_KEY", "test-key")
+    target = _resolve_target(target="refund-agent-fixed", agent_key=None, vercel_url=None, openai_model=None)
+
+    assert target.config.model == "agent/refund-agent-fixed"
+
+
+def test_resolve_target_deployment_prefix_uses_deployment_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+    marker = object()
+    monkeypatch.setenv("ORQ_API_KEY", "test-key")
+    with patch("evaluatorq.simulation.adapters.from_orq_deployment", return_value=marker) as factory:
+        target = _resolve_target(target="deployment:refund-agent-fixed", agent_key=None, vercel_url=None, openai_model=None)
+
+    assert target is marker
+    factory.assert_called_once_with("refund-agent-fixed")
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_description_fetches_agent_context_description() -> None:
+    from evaluatorq.contracts import AgentContext
+
+    backend = MagicMock()
+    backend.resolve_context = AsyncMock(
+        return_value=AgentContext(key="refund-agent-fixed", description="Handles refunds.")
+    )
+    with patch("evaluatorq.simulation.cli._make_sim_agent_backend", return_value=backend):
+        description = await _resolve_agent_description(
+            agent_description=None,
+            target="agent:refund-agent-fixed",
+        )
+
+    assert description == "Handles refunds."
+    backend.resolve_context.assert_awaited_once_with("refund-agent-fixed")
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_description_explicit_value_wins() -> None:
+    description = await _resolve_agent_description(
+        agent_description="Explicit bot description.",
+        target="agent:refund-agent-fixed",
+    )
+
+    assert description == "Explicit bot description."
 
 
 # ---------------------------------------------------------------------------
@@ -358,8 +471,8 @@ def test_simulate_rejects_multiple_targets(tmp_path: Path) -> None:
         [
             "simulate",
             "--datapoints", str(dp_file),
+            "--target", "agent:k",
             "--agent-key", "k",
-            "--openai-model", "gpt-4o",
         ],
         env={"ORQ_API_KEY": "test-key"},
     )
@@ -761,6 +874,105 @@ def test_run_requires_target() -> None:
     assert result.exit_code != 0
 
 
+def test_run_target_agent_uses_context_description_when_omitted(tmp_path: Path) -> None:
+    results = [_make_result()]
+
+    with (
+        patch("evaluatorq.simulation.cli._resolve_target") as mock_target,
+        patch(
+            "evaluatorq.simulation.cli._resolve_agent_description",
+            new_callable=AsyncMock,
+        ) as mock_description,
+        patch("evaluatorq.simulation.cli._run_impl", new_callable=AsyncMock) as mock_impl,
+    ):
+        mock_target.return_value = MagicMock()
+        mock_description.return_value = "Context description"
+        mock_impl.return_value = results
+
+        result = runner.invoke(
+            app,
+            [
+                "run",
+                "--target", "agent:refund-agent-fixed",
+                "--no-save",
+            ],
+            env={"ORQ_API_KEY": "test-key"},
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_description.assert_awaited_once_with(
+        agent_description=None,
+        target="agent:refund-agent-fixed",
+    )
+    assert mock_impl.call_args.kwargs["agent_description"] == "Context description"
+
+
+def test_run_explicit_agent_description_does_not_resolve_context(tmp_path: Path) -> None:
+    results = [_make_result()]
+
+    with (
+        patch("evaluatorq.simulation.cli._resolve_target") as mock_target,
+        patch(
+            "evaluatorq.simulation.cli._resolve_agent_description",
+            new_callable=AsyncMock,
+        ) as mock_description,
+        patch("evaluatorq.simulation.cli._run_impl", new_callable=AsyncMock) as mock_impl,
+    ):
+        mock_target.return_value = MagicMock()
+        mock_description.return_value = "Explicit description"
+        mock_impl.return_value = results
+
+        result = runner.invoke(
+            app,
+            [
+                "run",
+                "--target", "agent:refund-agent-fixed",
+                "--agent-description", "Explicit description",
+                "--no-save",
+            ],
+            env={"ORQ_API_KEY": "test-key"},
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_description.assert_awaited_once_with(
+        agent_description="Explicit description",
+        target="agent:refund-agent-fixed",
+    )
+    assert mock_impl.call_args.kwargs["agent_description"] == "Explicit description"
+
+
+def test_run_requires_description_for_non_agent_target() -> None:
+    with patch("evaluatorq.simulation.cli._resolve_target") as mock_target:
+        result = runner.invoke(
+            app,
+            ["run", "--target", "deployment:refund-agent-fixed", "--no-save"],
+            env={"ORQ_API_KEY": "test-key"},
+        )
+
+    assert result.exit_code == 1
+    assert "requires --agent-description" in result.output
+    mock_target.assert_not_called()
+
+
+def test_simulate_invalid_target_prefix_is_clean(tmp_path: Path) -> None:
+    dp_file = _make_datapoints_file(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "simulate",
+            "--datapoints", str(dp_file),
+            "--target", "unknown:refund-agent-fixed",
+            "--no-save",
+        ],
+        env={"ORQ_API_KEY": "test-key"},
+    )
+
+    assert result.exit_code == 1
+    assert "Error:" in result.output
+    assert "Unknown target kind" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_run_success_no_save(tmp_path: Path) -> None:
     results = [_make_result()]
 
@@ -896,6 +1108,38 @@ def test_generate_writes_datapoints(tmp_path: Path) -> None:
     assert len([ln for ln in out_file.read_text().splitlines() if ln.strip()]) == 3
 
 
+def test_generate_target_agent_uses_context_description_when_omitted(tmp_path: Path) -> None:
+    out_file = tmp_path / "dp.jsonl"
+    datapoints = _make_datapoints(1)
+
+    with (
+        patch(
+            "evaluatorq.simulation.cli._resolve_agent_description",
+            new_callable=AsyncMock,
+        ) as mock_description,
+        patch("evaluatorq.simulation.cli._generate_impl", new_callable=AsyncMock) as mock_impl,
+    ):
+        mock_description.return_value = "Context description"
+        mock_impl.return_value = datapoints
+
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--target", "agent:refund-agent-fixed",
+                "--output", str(out_file),
+            ],
+            env={"ORQ_API_KEY": "test-key"},
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_description.assert_awaited_once_with(
+        agent_description=None,
+        target="agent:refund-agent-fixed",
+    )
+    assert mock_impl.call_args.kwargs["agent_description"] == "Context description"
+
+
 def test_generate_output_roundtrips_through_simulate_loader(tmp_path: Path) -> None:
     # The whole point of gen-only: the file `generate` writes must load back
     # via the same loader `simulate --datapoints` uses, with id + fields intact.
@@ -938,7 +1182,7 @@ def test_generate_output_passes_validate_dataset(tmp_path: Path) -> None:
 
 
 def test_generate_no_datapoints_runtime_error_is_clean(tmp_path: Path) -> None:
-    # RuntimeError from generation (e.g. every persona×scenario pair failed)
+    # RuntimeError from generation (e.g. every persona x scenario pair failed)
     # surfaces as a one-line error, not a traceback.
     out_file = tmp_path / "dp.jsonl"
     with patch("evaluatorq.simulation.cli._generate_impl", new_callable=AsyncMock) as mock_impl:

--- a/packages/evaluatorq-py/tests/simulation/test_first_message_generator_errors.py
+++ b/packages/evaluatorq-py/tests/simulation/test_first_message_generator_errors.py
@@ -9,6 +9,7 @@ Covers:
 
 from __future__ import annotations
 
+# ruff: noqa: S101
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -63,6 +64,24 @@ def _client_with_response(message_content: str | None) -> MagicMock:
     return client
 
 
+def _client_with_responses(*message_contents: str | None) -> MagicMock:
+    responses = []
+    for message_content in message_contents:
+        msg = MagicMock()
+        msg.content = message_content
+        choice = MagicMock()
+        choice.message = msg
+        resp = MagicMock()
+        resp.choices = [choice]
+        resp.usage = MagicMock(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+        responses.append(resp)
+    client = MagicMock()
+    client.chat = MagicMock()
+    client.chat.completions = MagicMock()
+    client.chat.completions.create = AsyncMock(side_effect=responses)
+    return client
+
+
 def _client_raising(exc: Exception) -> MagicMock:
     client = MagicMock()
     client.chat = MagicMock()
@@ -110,6 +129,13 @@ class TestFirstMessageGeneratorErrors:
         gen = FirstMessageGenerator(model="gpt-4o", client=client)
         result = await gen.generate(_persona(), _scenario("login"))
         assert result == "Hi, I need help with: login"
+
+    async def test_empty_content_retries_before_fallback(self):
+        client = _client_with_responses("", "I need help logging in")
+        gen = FirstMessageGenerator(model="gpt-4o", client=client)
+        result = await gen.generate(_persona(), _scenario("login"))
+        assert result == "I need help logging in"
+        assert client.chat.completions.create.await_count == 2
 
     async def test_leading_and_trailing_double_quotes_stripped(self):
         client = _client_with_response('"hello there"')

--- a/packages/evaluatorq-py/tests/simulation/test_first_message_generator_errors.py
+++ b/packages/evaluatorq-py/tests/simulation/test_first_message_generator_errors.py
@@ -1,8 +1,8 @@
 """Tests for FirstMessageGenerator error / fallback paths.
 
 Covers:
-- 401/403 APIStatusError re-raised (auth errors are not silently masked)
-- non-auth APIStatusError returns generic fallback
+- 4xx APIStatusError re-raised (auth + client errors are not silently masked)
+- 5xx / 429 APIStatusError returns generic fallback (keeps a long run alive)
 - empty content returns generic fallback
 - leading/trailing quote stripping on returned message
 """
@@ -107,16 +107,27 @@ class TestFirstMessageGeneratorErrors:
         assert exc_info.value.status_code == 403
 
     async def test_500_falls_back_to_generic_message(self):
+        # Persistent server error (survived with_retry) — fall back to keep a
+        # long run alive rather than abort it.
         client = _client_raising(_api_error(500))
         gen = FirstMessageGenerator(model="gpt-4o", client=client)
         result = await gen.generate(_persona(), _scenario("reset my pw"))
         assert result == "Hi, I need help with: reset my pw"
 
-    async def test_400_non_auth_falls_back(self):
+    async def test_429_falls_back_to_generic_message(self):
+        client = _client_raising(_api_error(429))
+        gen = FirstMessageGenerator(model="gpt-4o", client=client)
+        result = await gen.generate(_persona(), _scenario("rate limited"))
+        assert result == "Hi, I need help with: rate limited"
+
+    async def test_400_is_reraised_not_masked(self):
+        # A 4xx client error (bad request / model-not-found) is a real
+        # misconfiguration — surface it, don't hide it behind a canned message.
         client = _client_raising(_api_error(400))
         gen = FirstMessageGenerator(model="gpt-4o", client=client)
-        result = await gen.generate(_persona(), _scenario("xyz"))
-        assert result == "Hi, I need help with: xyz"
+        with pytest.raises(APIStatusError) as exc_info:
+            await gen.generate(_persona(), _scenario("xyz"))
+        assert exc_info.value.status_code == 400
 
     async def test_empty_content_falls_back_to_generic(self):
         client = _client_with_response("")

--- a/packages/evaluatorq-py/tests/simulation/test_generation_injection.py
+++ b/packages/evaluatorq-py/tests/simulation/test_generation_injection.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from evaluatorq.simulation.api import generate, generate_and_simulate, simulate
-from evaluatorq.simulation.types import CommunicationStyle, Datapoint, Persona, Scenario
+from evaluatorq.simulation.types import CommunicationStyle, Datapoint, Judgment, Persona, Scenario
 
 
 def _persona() -> Persona:
@@ -154,3 +154,54 @@ async def test_generate_and_simulate_emit_datapoints_called_once(monkeypatch):
     assert emitted[0] is fake_datapoints
     assert isinstance(emitted[0], list)
     assert all(isinstance(dp, Datapoint) for dp in emitted[0])
+
+
+@pytest.mark.asyncio
+async def test_simulate_uses_generation_client_for_default_user_and_judge(monkeypatch):
+    monkeypatch.delenv("ORQ_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    from openai import AsyncOpenAI
+
+    injected = AsyncOpenAI(api_key="sk-test", base_url="https://example.test/v1")
+
+    async def fake_user_response(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        assert self._client is injected
+        return "next user message"
+
+    async def fake_judge_evaluate(self, messages):  # noqa: ANN001
+        assert self._client is injected
+        return Judgment(
+            should_terminate=True,
+            reason="done",
+            goal_achieved=True,
+            rules_broken=[],
+            goal_completion_score=1.0,
+        )
+
+    def fake_build_simulation_client(config_client=None, **kwargs):  # noqa: ANN001, ANN003
+        if config_client is not injected:
+            raise RuntimeError("runner built its own client")
+        return injected, False
+
+    with (
+        patch(
+            "evaluatorq.openresponses.client.build_simulation_client",
+            side_effect=fake_build_simulation_client,
+        ),
+        patch(
+            "evaluatorq.simulation.agents.user_simulator.UserSimulatorAgent.respond_async",
+            new=fake_user_response,
+        ),
+        patch(
+            "evaluatorq.simulation.agents.judge.JudgeAgent.evaluate",
+            new=fake_judge_evaluate,
+        ),
+    ):
+        results = await simulate(
+            datapoints=[_make_datapoint()],
+            target=lambda messages: "target reply",
+            generation_client=injected,
+            upload_results=False,
+        )
+
+    assert results[0].goal_achieved is True

--- a/packages/evaluatorq-py/tests/simulation/test_orq_agent_tailscale_script.py
+++ b/packages/evaluatorq-py/tests/simulation/test_orq_agent_tailscale_script.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+# ruff: noqa: S101, SLF001
+import asyncio
+import importlib.util
+from pathlib import Path
+from typing import ClassVar
+
+from evaluatorq.contracts import AgentResponse
+from evaluatorq.simulation.types import Message
+
+
+def _load_script_module():
+    root = Path(__file__).parents[2]
+    path = root / "examples" / "agent_simulation" / "orq_agent_tailscale_openai.py"
+    spec = importlib.util.spec_from_file_location("orq_agent_tailscale_openai", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_refund_agent_target_uses_local_tool_wrapper(monkeypatch) -> None:
+    module = _load_script_module()
+
+    class FakeRefundTarget:
+        def __init__(self, agent_key: str) -> None:
+            self.agent_key = agent_key
+
+        def new(self):
+            return type(self)(self.agent_key)
+
+        async def send_prompt(self, prompt: str) -> AgentResponse:
+            return AgentResponse(text=f"handled locally: {prompt}", model="refund-model")
+
+    monkeypatch.setattr(
+        module,
+        "_load_refund_agent_target_class",
+        lambda: FakeRefundTarget,
+    )
+
+    target = module._build_target("refund-agent-fixed")
+
+    assert isinstance(target, module.LocalRefundToolTarget)
+    assert target.name == "refund-agent-fixed"
+
+    response = asyncio.run(
+        target.respond(
+            [
+                Message(role="user", content="first"),
+                Message(role="assistant", content="previous"),
+                Message(role="user", content="please refund ord_a1"),
+            ]
+        )
+    )
+
+    assert response.text == "handled locally: please refund ord_a1"
+    assert response.model == "refund-model"
+
+
+def test_refund_agent_target_isolates_inner_target_per_message_list(monkeypatch) -> None:
+    module = _load_script_module()
+
+    class FakeRefundTarget:
+        instances: ClassVar[list[FakeRefundTarget]] = []
+
+        def __init__(self, agent_key: str) -> None:
+            self.agent_key = agent_key
+            self.prompts: list[str] = []
+            self.instance_id = len(self.instances)
+            self.instances.append(self)
+
+        async def send_prompt(self, prompt: str) -> AgentResponse:
+            self.prompts.append(prompt)
+            return AgentResponse(text=f"{self.instance_id}:{prompt}")
+
+    monkeypatch.setattr(
+        module,
+        "_load_refund_agent_target_class",
+        lambda: FakeRefundTarget,
+    )
+
+    target = module.LocalRefundToolTarget("refund-agent-fixed")
+    conversation_a = [Message(role="user", content="refund ord_a1")]
+    conversation_b = [Message(role="user", content="refund ord_a2")]
+
+    async def _run_both() -> tuple[AgentResponse, AgentResponse]:
+        return await asyncio.gather(
+            target.respond(conversation_a),
+            target.respond(conversation_b),
+        )
+
+    response_a, response_b = asyncio.run(_run_both())
+
+    assert response_a.text == "0:refund ord_a1"
+    assert response_b.text == "1:refund ord_a2"
+    assert len(FakeRefundTarget.instances) == 2

--- a/packages/evaluatorq-py/tests/simulation/test_responses_dispatch.py
+++ b/packages/evaluatorq-py/tests/simulation/test_responses_dispatch.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 # ruff: noqa: S101, SLF001
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
+from openai import BadRequestError
+
 import pytest
 
 from evaluatorq.contracts import LLMCallConfig
@@ -59,6 +62,12 @@ def _chat_response(content: str | None) -> MagicMock:
     mock_response.choices = [mock_choice]
     mock_response.usage = None
     return mock_response
+
+
+def _bad_request(message: str) -> BadRequestError:
+    request = httpx.Request("POST", "https://example/v1/responses")
+    response = httpx.Response(400, request=request)
+    return BadRequestError(message, response=response, body={"error": {"message": message}})
 
 
 # ---------------------------------------------------------------------------
@@ -221,3 +230,38 @@ class TestCallLlmDispatch:
 
         assert result.content == "second response"
         assert client.chat.completions.create.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_responses_drops_reasoning_and_retries_when_rejected(self, monkeypatch):
+        monkeypatch.setattr("evaluatorq.simulation.agents.base.DEFAULT_REASONING_EFFORT", "low")
+        client = _make_client()
+        ok = MagicMock()
+        ok.output = []
+        ok.usage = None
+        client.responses.create = AsyncMock(
+            side_effect=[_bad_request("Unsupported parameter: reasoning"), ok]
+        )
+
+        config = LLMCallConfig(model="gpt-4o", api="responses", client=client)
+        agent = _ConcreteAgent(config)
+
+        await agent._call_llm(_make_messages())
+
+        assert client.responses.create.await_count == 2
+        # The retry must not carry reasoning.
+        assert client.responses.create.await_args is not None
+        assert "reasoning" not in client.responses.create.await_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_responses_reraises_unrelated_400(self, monkeypatch):
+        monkeypatch.setattr("evaluatorq.simulation.agents.base.DEFAULT_REASONING_EFFORT", "low")
+        client = _make_client()
+        client.responses.create = AsyncMock(side_effect=_bad_request("Invalid tool schema"))
+
+        config = LLMCallConfig(model="gpt-4o", api="responses", client=client)
+        agent = _ConcreteAgent(config)
+
+        with pytest.raises(BadRequestError, match="Invalid tool schema"):
+            await agent._call_llm(_make_messages())
+        # No reasoning-stripped retry — an unrelated 400 is not masked.
+        assert client.responses.create.await_count == 1

--- a/packages/evaluatorq-py/tests/simulation/test_responses_dispatch.py
+++ b/packages/evaluatorq-py/tests/simulation/test_responses_dispatch.py
@@ -176,6 +176,7 @@ class TestCallLlmDispatch:
             ],
         )
 
+        assert client.responses.create.await_args is not None
         sent = client.responses.create.await_args.kwargs
         assert sent["tools"] == [
             {

--- a/packages/evaluatorq-py/tests/simulation/test_responses_dispatch.py
+++ b/packages/evaluatorq-py/tests/simulation/test_responses_dispatch.py
@@ -8,6 +8,7 @@ Verifies that:
 
 from __future__ import annotations
 
+# ruff: noqa: S101, SLF001
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -46,6 +47,18 @@ def _make_client() -> MagicMock:
 
 def _make_messages() -> list[Message]:
     return [Message(role="user", content="hello")]
+
+
+def _chat_response(content: str | None) -> MagicMock:
+    mock_message = MagicMock()
+    mock_message.content = content
+    mock_message.tool_calls = None
+    mock_choice = MagicMock()
+    mock_choice.message = mock_message
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    mock_response.usage = None
+    return mock_response
 
 
 # ---------------------------------------------------------------------------
@@ -131,20 +144,59 @@ class TestCallLlmDispatch:
         client.chat.completions.create.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_responses_path_converts_function_tools_to_chat_style_result(self):
+        client = _make_client()
+
+        mock_response = MagicMock()
+        mock_response.output = [
+            {
+                "type": "function_call",
+                "call_id": "call_123",
+                "name": "finish_conversation",
+                "arguments": '{"done": true}',
+            }
+        ]
+        mock_response.usage = None
+        client.responses.create = AsyncMock(return_value=mock_response)
+
+        config = LLMCallConfig(model="gpt-4o", api="responses", client=client)
+        agent = _ConcreteAgent(config)
+
+        result = await agent._call_llm(
+            _make_messages(),
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "finish_conversation",
+                        "description": "finish",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        )
+
+        sent = client.responses.create.await_args.kwargs
+        assert sent["tools"] == [
+            {
+                "type": "function",
+                "name": "finish_conversation",
+                "description": "finish",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+        assert result.tool_calls is not None
+        assert result.tool_calls[0].id == "call_123"
+        assert result.tool_calls[0].function.name == "finish_conversation"
+        assert result.tool_calls[0].function.arguments == '{"done": true}'
+
+    @pytest.mark.asyncio
     async def test_chat_completions_path_via_real_sdk_mock(self):
         """End-to-end: _call_chat_completions uses client.chat.completions.create, not responses."""
         client = _make_client()
 
         # Build a minimal chat completion response
-        mock_message = MagicMock()
-        mock_message.content = "hello"
-        mock_message.tool_calls = None
-        mock_choice = MagicMock()
-        mock_choice.message = mock_message
-        mock_response = MagicMock()
-        mock_response.choices = [mock_choice]
-        mock_response.usage = None
-        client.chat.completions.create = AsyncMock(return_value=mock_response)
+        client.chat.completions.create = AsyncMock(return_value=_chat_response("hello"))
 
         config = LLMCallConfig(model="gpt-4o", api="chat_completions", client=client)
         agent = _ConcreteAgent(config)
@@ -153,3 +205,18 @@ class TestCallLlmDispatch:
 
         client.chat.completions.create.assert_awaited_once()
         client.responses.create.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_retries_once_on_empty_response(self):
+        client = _make_client()
+        client.chat.completions.create = AsyncMock(
+            side_effect=[_chat_response(""), _chat_response("second response")]
+        )
+
+        config = LLMCallConfig(model="gpt-4o", api="chat_completions", client=client)
+        agent = _ConcreteAgent(config)
+
+        result = await agent._call_llm(_make_messages())
+
+        assert result.content == "second response"
+        assert client.chat.completions.create.await_count == 2

--- a/packages/evaluatorq-py/tests/simulation/test_run_store.py
+++ b/packages/evaluatorq-py/tests/simulation/test_run_store.py
@@ -420,3 +420,32 @@ async def test_simulate_run_output_writes_explicit_path(tmp_path: Path, monkeypa
     await _run_simulate(runs_dir=auto_dir, monkeypatch=monkeypatch, save=True, run_output=str(explicit))
     assert explicit.exists()
     assert list(auto_dir.glob("*.json")) == []  # explicit path bypasses auto-save dir
+
+
+@pytest.mark.asyncio
+async def test_simulate_save_failure_still_returns_results(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A persistence failure must not discard a completed, paid-for run.
+    from unittest.mock import AsyncMock, patch
+
+    from evaluatorq.simulation.api import simulate
+
+    monkeypatch.setattr("evaluatorq.simulation.utils.run_store.get_sim_runs_dir", lambda: tmp_path)
+    results = [_make_result(scorer_scores={"goal_achieved": 1.0})]
+
+    def _boom(**_kwargs: Any) -> Path:
+        raise OSError("disk full")
+
+    with (
+        patch("evaluatorq.simulation.api._simulate_via_evaluatorq", AsyncMock(return_value=results)),
+        patch("evaluatorq.simulation.api.auto_save_run", _boom),
+    ):
+        out = await simulate(
+            target=lambda _messages: "hi",
+            datapoints=[_make_datapoint()],
+            sim_model="test",
+            upload_results=False,
+            save=True,
+        )
+
+    assert out == results  # results survived the save failure
+    assert list(tmp_path.glob("*.json")) == []  # nothing written

--- a/packages/evaluatorq-py/tests/simulation/test_run_store.py
+++ b/packages/evaluatorq-py/tests/simulation/test_run_store.py
@@ -106,8 +106,9 @@ def test_build_simulation_run_aggregates_scorer_averages() -> None:
 
 
 def test_build_simulation_run_skips_non_numeric_scores() -> None:
+    bad_scores: dict[str, Any] = {"goal_achieved": 1.0, "bad_scorer": "not_a_number"}
     results = [
-        _make_result(scorer_scores={"goal_achieved": 1.0, "bad_scorer": "not_a_number"}),
+        _make_result(scorer_scores=bad_scores),
         _make_result(scorer_scores={"goal_achieved": 0.5}),
     ]
     run = build_simulation_run(

--- a/packages/evaluatorq-py/tests/simulation/test_run_store.py
+++ b/packages/evaluatorq-py/tests/simulation/test_run_store.py
@@ -1,0 +1,421 @@
+"""Unit tests for evaluatorq.simulation.utils.run_store (public API)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from evaluatorq.simulation.utils.run_store import (
+    SIM_RUNS_DIR_NAME,
+    auto_save_run,
+    build_simulation_run,
+    get_sim_runs_dir,
+    sanitise_run_name,
+    write_report,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_result(
+    *,
+    goal_achieved: bool = True,
+    turn_count: int = 3,
+    scorer_scores: dict[str, float] | None = None,
+) -> Any:
+    from evaluatorq.contracts import TokenUsage
+    from evaluatorq.simulation.types import SimulationResult, TerminatedBy
+
+    return SimulationResult(
+        messages=[],
+        terminated_by=TerminatedBy.judge,
+        reason="done",
+        goal_achieved=goal_achieved,
+        goal_completion_score=1.0 if goal_achieved else 0.0,
+        rules_broken=[],
+        turn_count=turn_count,
+        token_usage=TokenUsage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+        turn_metrics=[],
+        metadata={"evaluator_scores": scorer_scores or {}},
+    )
+
+
+# ---------------------------------------------------------------------------
+# sanitise_run_name
+# ---------------------------------------------------------------------------
+
+
+def test_sanitise_run_name_lowercases() -> None:
+    assert sanitise_run_name("MyRun") == "myrun"
+
+
+def test_sanitise_run_name_illegal_chars_become_underscore() -> None:
+    assert sanitise_run_name("sim:agent/run") == "sim_agent_run"
+
+
+def test_sanitise_run_name_collapses_repeated_underscores() -> None:
+    assert sanitise_run_name("a  b  c") == "a_b_c"
+
+
+def test_sanitise_run_name_empty_falls_back_to_sim() -> None:
+    assert sanitise_run_name("") == "sim"
+
+
+def test_sanitise_run_name_only_illegal_chars_falls_back_to_sim() -> None:
+    # All chars get replaced by "_", strip leaves "", fallback kicks in.
+    assert sanitise_run_name("!!!") == "sim"
+
+
+def test_sanitise_run_name_strips_leading_trailing_underscores() -> None:
+    result = sanitise_run_name("__hello__")
+    assert not result.startswith("_")
+    assert not result.endswith("_")
+
+
+def test_sanitise_run_name_truncates_at_64() -> None:
+    long_name = "a" * 100
+    assert len(sanitise_run_name(long_name)) == 64
+
+
+# ---------------------------------------------------------------------------
+# build_simulation_run
+# ---------------------------------------------------------------------------
+
+
+def test_build_simulation_run_aggregates_scorer_averages() -> None:
+    results = [
+        _make_result(scorer_scores={"goal_achieved": 1.0, "criteria_met": 0.5}),
+        _make_result(scorer_scores={"goal_achieved": 0.0}),  # criteria_met absent
+    ]
+    run = build_simulation_run(
+        run_name="test-run",
+        mode="run",
+        target_kind="openai_model",
+        evaluator_names=["goal_achieved", "criteria_met"],
+        results=results,
+    )
+    # goal_achieved present in both -> mean(1.0, 0.0) = 0.5
+    assert run.scorer_averages["goal_achieved"] == pytest.approx(0.5)
+    # criteria_met present in one -> mean(0.5) = 0.5, not zero-filled
+    assert run.scorer_averages["criteria_met"] == pytest.approx(0.5)
+    assert run.total_results == 2
+
+
+def test_build_simulation_run_skips_non_numeric_scores() -> None:
+    results = [
+        _make_result(scorer_scores={"goal_achieved": 1.0, "bad_scorer": "not_a_number"}),
+        _make_result(scorer_scores={"goal_achieved": 0.5}),
+    ]
+    run = build_simulation_run(
+        run_name="skip-non-numeric",
+        mode="run",
+        target_kind="openai_model",
+        evaluator_names=["goal_achieved", "bad_scorer"],
+        results=results,
+    )
+    # Non-numeric score must be silently skipped — no crash.
+    assert run.scorer_averages["goal_achieved"] == pytest.approx(0.75)
+    # bad_scorer only had a non-numeric entry, so it should be absent or 0.
+    assert "bad_scorer" not in run.scorer_averages or run.scorer_averages["bad_scorer"] == pytest.approx(0.0)
+
+
+def test_build_simulation_run_empty_results() -> None:
+    run = build_simulation_run(
+        run_name="empty",
+        mode="simulate",
+        target_kind="openai_model",
+        evaluator_names=[],
+        results=[],
+    )
+    assert run.scorer_averages == {}
+    assert run.total_results == 0
+
+
+def test_build_simulation_run_sets_run_name_and_mode() -> None:
+    run = build_simulation_run(
+        run_name="my-run",
+        mode="run",
+        target_kind="orq_agent",
+        evaluator_names=["goal_achieved"],
+        results=[_make_result(scorer_scores={"goal_achieved": 1.0})],
+    )
+    assert run.run_name == "my-run"
+    assert run.mode == "run"
+    assert run.target_kind == "orq_agent"
+
+
+# ---------------------------------------------------------------------------
+# auto_save_run
+# ---------------------------------------------------------------------------
+
+
+def test_auto_save_run_writes_json_under_sim_runs_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "evaluatorq.simulation.utils.run_store.get_sim_runs_dir",
+        lambda: tmp_path / "sim-runs",
+    )
+    run = build_simulation_run(
+        run_name="my-run",
+        mode="run",
+        target_kind="openai_model",
+        evaluator_names=[],
+        results=[_make_result()],
+    )
+    path = auto_save_run(run=run, run_name="my-run")
+
+    assert path.exists()
+    assert path.suffix == ".json"
+    # Hyphens are kept by sanitise_run_name (only non-[a-z0-9_-] chars are replaced).
+    assert path.name.startswith("my-run_")
+    data = json.loads(path.read_text())
+    assert data["run_name"] == "my-run"
+
+
+def test_auto_save_run_creates_parent_dirs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runs_dir = tmp_path / "deep" / "nested" / "sim-runs"
+    monkeypatch.setattr(
+        "evaluatorq.simulation.utils.run_store.get_sim_runs_dir",
+        lambda: runs_dir,
+    )
+    run = build_simulation_run(
+        run_name="nested-run",
+        mode="run",
+        target_kind="openai_model",
+        evaluator_names=[],
+        results=[],
+    )
+    path = auto_save_run(run=run, run_name="nested-run")
+    assert path.exists()
+
+
+def test_auto_save_run_collision_gets_suffix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runs_dir = tmp_path / "sim-runs"
+    monkeypatch.setattr(
+        "evaluatorq.simulation.utils.run_store.get_sim_runs_dir",
+        lambda: runs_dir,
+    )
+    run = build_simulation_run(
+        run_name="collide",
+        mode="run",
+        target_kind="openai_model",
+        evaluator_names=[],
+        results=[_make_result()],
+    )
+    path1 = auto_save_run(run=run, run_name="collide")
+    path2 = auto_save_run(run=run, run_name="collide")
+
+    assert path1 != path2
+    assert path2.name.endswith("_001.json")
+
+
+def test_auto_save_run_sanitises_filename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "evaluatorq.simulation.utils.run_store.get_sim_runs_dir",
+        lambda: tmp_path / "sim-runs",
+    )
+    run = build_simulation_run(
+        run_name="weird / name",
+        mode="run",
+        target_kind="openai_model",
+        evaluator_names=[],
+        results=[_make_result()],
+    )
+    path = auto_save_run(run=run, run_name="weird / name")
+
+    # Raw name preserved in the payload, filename is sanitised.
+    assert json.loads(path.read_text())["run_name"] == "weird / name"
+    assert "/" not in path.name
+    assert path.name.startswith("weird_name_")
+
+
+def test_auto_save_run_scorer_averages_persisted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "evaluatorq.simulation.utils.run_store.get_sim_runs_dir",
+        lambda: tmp_path / "sim-runs",
+    )
+    results = [
+        _make_result(scorer_scores={"goal_achieved": 1.0, "criteria_met": 0.5}),
+        _make_result(scorer_scores={"goal_achieved": 0.0}),
+    ]
+    run = build_simulation_run(
+        run_name="agg",
+        mode="run",
+        target_kind="openai_model",
+        evaluator_names=["goal_achieved", "criteria_met"],
+        results=results,
+    )
+    path = auto_save_run(run=run, run_name="agg")
+    data = json.loads(path.read_text())
+
+    assert data["scorer_averages"]["goal_achieved"] == pytest.approx(0.5)
+    assert data["scorer_averages"]["criteria_met"] == pytest.approx(0.5)
+    assert data["total_results"] == 2
+
+
+# ---------------------------------------------------------------------------
+# write_report
+# ---------------------------------------------------------------------------
+
+
+def test_write_report_writes_json_to_explicit_path(tmp_path: Path) -> None:
+    run = build_simulation_run(
+        run_name="rep",
+        mode="run",
+        target_kind="openai_model",
+        evaluator_names=["goal_achieved"],
+        results=[_make_result(scorer_scores={"goal_achieved": 1.0})],
+    )
+    out = tmp_path / "report.json"
+    write_report(run, out)
+
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert data["run_name"] == "rep"
+    assert data["total_results"] == 1
+    assert data["scorer_averages"]["goal_achieved"] == pytest.approx(1.0)
+
+
+def test_write_report_creates_parent_dirs(tmp_path: Path) -> None:
+    run = build_simulation_run(
+        run_name="nested-rep",
+        mode="run",
+        target_kind="openai_model",
+        evaluator_names=[],
+        results=[],
+    )
+    out = tmp_path / "nested" / "deeply" / "report.json"
+    write_report(run, out)
+
+    assert out.exists()
+
+
+def test_write_report_full_run_json(tmp_path: Path) -> None:
+    run = build_simulation_run(
+        run_name="full-rep",
+        mode="simulate",
+        target_kind="orq_agent",
+        evaluator_names=["goal_achieved"],
+        results=[
+            _make_result(scorer_scores={"goal_achieved": 1.0}),
+            _make_result(goal_achieved=False, scorer_scores={"goal_achieved": 0.0}),
+        ],
+    )
+    out = tmp_path / "subdir" / "full.json"
+    write_report(run, out)
+
+    data = json.loads(out.read_text())
+    assert data["mode"] == "simulate"
+    assert data["target_kind"] == "orq_agent"
+    assert data["total_results"] == 2
+    assert data["scorer_averages"]["goal_achieved"] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# get_sim_runs_dir / SIM_RUNS_DIR_NAME
+# ---------------------------------------------------------------------------
+
+
+def test_get_sim_runs_dir_returns_cwd_relative_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = get_sim_runs_dir()
+    expected = tmp_path / SIM_RUNS_DIR_NAME
+    assert result == expected
+
+
+def test_sim_runs_dir_name_is_path() -> None:
+    assert isinstance(SIM_RUNS_DIR_NAME, Path)
+
+
+# ---------------------------------------------------------------------------
+# SDK save wiring: simulate(save=..., run_output=...) through _simulate_core
+# (plan Verification §3). Patches the choke point _simulate_via_evaluatorq so
+# no LLM/runner is needed — exercises the save gate, target_kind, and branch.
+# ---------------------------------------------------------------------------
+
+
+def _make_datapoint() -> Any:
+    from evaluatorq.simulation.types import CommunicationStyle, Datapoint, Persona, Scenario
+
+    persona = Persona(
+        name="T",
+        patience=0.5,
+        assertiveness=0.5,
+        politeness=0.5,
+        technical_level=0.5,
+        communication_style=CommunicationStyle.casual,
+        background="t",
+    )
+    return Datapoint(
+        id="dp-1",
+        persona=persona,
+        scenario=Scenario(name="S", goal="help"),
+        user_system_prompt="sys",
+        first_message="hi",
+    )
+
+
+async def _run_simulate(*, runs_dir: Path, monkeypatch: pytest.MonkeyPatch, **kwargs: Any) -> None:
+    from unittest.mock import AsyncMock, patch
+
+    from evaluatorq.simulation.api import simulate
+
+    monkeypatch.setattr("evaluatorq.simulation.utils.run_store.get_sim_runs_dir", lambda: runs_dir)
+    results = [_make_result(scorer_scores={"goal_achieved": 1.0})]
+    with patch("evaluatorq.simulation.api._simulate_via_evaluatorq", AsyncMock(return_value=results)):
+        await simulate(
+            target=lambda _messages: "hi",
+            datapoints=[_make_datapoint()],
+            sim_model="test",
+            upload_results=False,
+            **kwargs,
+        )
+
+
+@pytest.mark.asyncio
+async def test_simulate_save_true_writes_one_run_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    await _run_simulate(runs_dir=tmp_path, monkeypatch=monkeypatch, save=True)
+    assert len(list(tmp_path.glob("*.json"))) == 1
+
+
+@pytest.mark.asyncio
+async def test_simulate_save_true_callable_target_kind_is_callback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression: a plain-callable target produced target_kind='callback', which
+    # was not in the SimulationRun.target_kind Literal and crashed on save=True.
+    await _run_simulate(runs_dir=tmp_path, monkeypatch=monkeypatch, save=True)
+    data = json.loads(next(tmp_path.glob("*.json")).read_text())
+    assert data["target_kind"] == "callback"
+    assert data["mode"] == "simulate"
+
+
+@pytest.mark.asyncio
+async def test_simulate_save_false_writes_nothing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    await _run_simulate(runs_dir=tmp_path, monkeypatch=monkeypatch, save=False)
+    assert list(tmp_path.glob("*.json")) == []
+
+
+@pytest.mark.asyncio
+async def test_simulate_run_output_writes_explicit_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    auto_dir = tmp_path / "auto"
+    auto_dir.mkdir()
+    explicit = tmp_path / "nested" / "explicit.json"
+    await _run_simulate(runs_dir=auto_dir, monkeypatch=monkeypatch, save=True, run_output=str(explicit))
+    assert explicit.exists()
+    assert list(auto_dir.glob("*.json")) == []  # explicit path bypasses auto-save dir

--- a/packages/evaluatorq-py/tests/simulation/test_run_store.py
+++ b/packages/evaluatorq-py/tests/simulation/test_run_store.py
@@ -423,7 +423,15 @@ async def test_simulate_run_output_writes_explicit_path(tmp_path: Path, monkeypa
 
 
 @pytest.mark.asyncio
-async def test_simulate_save_failure_still_returns_results(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    "error",
+    # OSError = disk/perms, RuntimeError = collision exhaustion, ValueError =
+    # pydantic serialization (PydanticSerializationError <: ValueError).
+    [OSError("disk full"), RuntimeError("no free filename"), ValueError("cannot serialize")],
+)
+async def test_simulate_save_failure_still_returns_results(
+    error: Exception, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     # A persistence failure must not discard a completed, paid-for run.
     from unittest.mock import AsyncMock, patch
 
@@ -433,7 +441,7 @@ async def test_simulate_save_failure_still_returns_results(tmp_path: Path, monke
     results = [_make_result(scorer_scores={"goal_achieved": 1.0})]
 
     def _boom(**_kwargs: Any) -> Path:
-        raise OSError("disk full")
+        raise error
 
     with (
         patch("evaluatorq.simulation.api._simulate_via_evaluatorq", AsyncMock(return_value=results)),

--- a/packages/evaluatorq-py/tests/simulation/test_structured_output.py
+++ b/packages/evaluatorq-py/tests/simulation/test_structured_output.py
@@ -15,31 +15,26 @@ class SampleResponse(BaseModel):
 
 
 @pytest.mark.asyncio
-async def test_generate_structured_falls_back_when_parse_hits_length_limit() -> None:
-    parsed_completion = MagicMock()
-    parse_error = LengthFinishReasonError(completion=parsed_completion)
-
-    fallback_message = MagicMock()
-    fallback_message.content = '{"value": "fallback"}'
-    fallback_choice = MagicMock()
-    fallback_choice.message = fallback_message
-    fallback_response = MagicMock()
-    fallback_response.choices = [fallback_choice]
+async def test_generate_structured_raises_when_parse_hits_length_limit() -> None:
+    # Length-truncated structured output is unusable — fail with a clear,
+    # actionable error instead of falling back to a same-budget json_object call
+    # that would truncate again.
+    parse_error = LengthFinishReasonError(completion=MagicMock())
 
     client = MagicMock()
     client.chat.completions.parse = AsyncMock(side_effect=parse_error)
-    client.chat.completions.create = AsyncMock(return_value=fallback_response)
+    client.chat.completions.create = AsyncMock()
 
-    parsed, raw = await generate_structured(
-        client,
-        model="local-model",
-        messages=[{"role": "user", "content": "return json"}],
-        response_format=SampleResponse,
-        temperature=0.0,
-        max_tokens=4000,
-        label="Sample.generate",
-    )
+    with pytest.raises(RuntimeError, match="EVALUATORQ_LLM_MAX_TOKENS"):
+        await generate_structured(
+            client,
+            model="local-model",
+            messages=[{"role": "user", "content": "return json"}],
+            response_format=SampleResponse,
+            temperature=0.0,
+            max_tokens=4000,
+            label="Sample.generate",
+        )
 
-    assert parsed is None
-    assert raw == '{"value": "fallback"}'
-    client.chat.completions.create.assert_awaited_once()
+    # No json_object fallback call — the truncated result is not salvaged.
+    client.chat.completions.create.assert_not_awaited()

--- a/packages/evaluatorq-py/tests/simulation/test_structured_output.py
+++ b/packages/evaluatorq-py/tests/simulation/test_structured_output.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+# ruff: noqa: S101
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from openai import LengthFinishReasonError
+from pydantic import BaseModel
+
+from evaluatorq.simulation.utils.structured_output import generate_structured
+
+
+class SampleResponse(BaseModel):
+    value: str
+
+
+@pytest.mark.asyncio
+async def test_generate_structured_falls_back_when_parse_hits_length_limit() -> None:
+    parsed_completion = MagicMock()
+    parse_error = LengthFinishReasonError(completion=parsed_completion)
+
+    fallback_message = MagicMock()
+    fallback_message.content = '{"value": "fallback"}'
+    fallback_choice = MagicMock()
+    fallback_choice.message = fallback_message
+    fallback_response = MagicMock()
+    fallback_response.choices = [fallback_choice]
+
+    client = MagicMock()
+    client.chat.completions.parse = AsyncMock(side_effect=parse_error)
+    client.chat.completions.create = AsyncMock(return_value=fallback_response)
+
+    parsed, raw = await generate_structured(
+        client,
+        model="local-model",
+        messages=[{"role": "user", "content": "return json"}],
+        response_format=SampleResponse,
+        temperature=0.0,
+        max_tokens=4000,
+        label="Sample.generate",
+    )
+
+    assert parsed is None
+    assert raw == '{"value": "fallback"}'
+    client.chat.completions.create.assert_awaited_once()


### PR DESCRIPTION
## Summary

One branch bundling three complete, green pieces. All were developed together on
the same files and can't be cleanly split, so they ship as one PR.

1. **Run-store reuse + SDK save flag** (primary, this session) — RES-933 follow-up
2. **`--target` redteam alignment** — complete, was uncommitted in the working tree
3. **Self-hosted / reasoning-model robustness** — complete, same situation

### 1. Run-store reuse + SDK save flag

Scripts used to hand-roll run-saving into **fixed filenames**, which silently clobbered prior runs (a 50-conversation run got overwritten by a later 10-conversation one). Fix: make saving reusable and expose it on the SDK.

- **New `simulation/utils/run_store.py`** — public savers (`build_simulation_run`, `auto_save_run`, `get_sim_runs_dir`, `sanitise_run_name`, `SIM_RUNS_DIR_NAME`) moved out of `cli.py` so `api.py` reuses them without a circular import. `cli.py` keeps the old `_`-prefixed names as re-export aliases (zero test churn).
- **`simulate` / `generate_and_simulate` gain `save=False` / `run_output=`** — persist once in `_simulate_core` (success path) to `.evaluatorq/sim-runs/<name>_<ts>.json` (collision-free, exclusive-create) or an explicit path. Discoverable by `eq sim runs` / `eq sim ui`.
- **`_log_saved_run`** logs a cwd-relative path + `eq sim ui` hint; the example's logging shows it without `-v`.
- **Renamed `path` → `orq_results_path`** (it's an Orq folder path for the uploaded experiment, not a filesystem path; the external `evaluatorq(path=…)` keyword is untouched).
- **`types.py`: added `callback` to `SimulationRun.target_kind`** — a plain-callable target had no valid value and crashed on `save=True` (caught by `/hate`, now regression-tested).
- **`write_report` kept private** (not exported) — it overwrites a verbatim path and would re-expose the clobber footgun.
- **example `orq_agent_tailscale_openai.py`** passes `save=`/`run_output=` through; `--no-save` / `--run-output` retained.

### 2. `--target` redteam alignment

`eq sim` gains `--target agent:<key>` / `deployment:<key>` so simulation targets are specified the same way red teaming specifies them. `cli.py` resolves the spec via `_resolve_target` / `_parse_target_spec` / `_resolve_agent_description` / `_infer_target_kind`. This was already implemented and green in the working tree — it just hadn't been committed. 21 target/resolve tests pass. See `docs/superpowers/plans/2026-06-18-sim-target-redteam-alignment.md` (the plan's checkboxes are stale; the code + tests are done).

### 3. Self-hosted / reasoning-model robustness

Hardening for self-hosted and reasoning models, also complete-but-uncommitted:

- `agents/base.py` — env-driven timeout / token budget (`EVALUATORQ_LLM_MAX_TOKENS`), retry-once on an empty/truncated response, explicit error when a reasoning model exhausts its token budget (`finish_reason=length`).
- `common/llm_call.py` — drop `reasoning_effort` and retry when a model rejects it.
- `utils/structured_output.py` — fall back on `LengthFinishReasonError`.
- `generators/first_message_generator.py` — retry on transient failure.
- `runner/simulation.py` — share one `llm_client` across the run.
- `refund_agent_demo` build files + tests updated to match.

## Sanity checks & validations performed

- **Root-caused the clobber bug**: confirmed the fixed-filename writes in the example overwrote a 50-conversation run with a later 10-conversation one; the run-store's collision-free exclusive-create naming is the fix.
- **`/hate` (4-critic adversarial review)**: reproduced a **live `save=True` crash** on a callable target (`ValidationError` — `callback` missing from the `target_kind` Literal), fixed it, and added the missing SDK-save integration tests the critics flagged.
- **`/ponytail` simplicity review**: new code is lean; `write_report` deliberately kept module-private rather than exported.
- **CI was red on basedpyright** (16 errors under the full-package strict run, stricter than a path-scoped local run) → driven to **0 errors**:
  - typed `_handle_cli_error` as `NoReturn` so post-`try` vars in the sim/generate commands aren't seen as possibly-unbound (11 errors)
  - initialised `finish_reason=None` before the retry loop in `agents/base.py` (2 errors)
  - fixed two test-only type issues (`test_run_store.py`, `test_responses_dispatch.py`) (3 errors)

## Test plan

- `uv run pytest tests/simulation -q -m 'not integration'` → **425 passed, 2 skipped**
- `--target` / resolve tests → **21 passed**
- `uv run basedpyright` (full package) → **0 errors, 0 warnings**
- `uv run ruff check` on changed src + new `run_store.py` → no new findings (pre-existing repo-wide W191/RUF029 untouched; lint is not a CI gate)

## Follow-ups

- RES-963 — make `hooks=` accept a list (composable hooks); unblocks moving save to an `on_run_complete` hook
- RES-964 — unify simulation + redteam run-store into `common/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
