### PR TITLE
chore(evaluatorq-py): repoint URLs to standalone repo + moved banner (RES-949)

### DIFF
--- a/packages/evaluatorq-py/README.md
+++ b/packages/evaluatorq-py/README.md
@@ -1,5 +1,13 @@
 # evaluatorq-py
 
+> # 📦➡️ This package has moved
+>
+> **`evaluatorq-py` now lives in its own repository: [github.com/orq-ai/evaluatorq](https://github.com/orq-ai/evaluatorq)**
+>
+> Docs: <https://orq-ai.github.io/evaluatorq/>
+>
+> This in-monorepo copy is **frozen** — do not open new PRs against `packages/evaluatorq-py`. All Python `evaluatorq` development happens in the standalone repo.
+
 An evaluation framework library for Python that provides a flexible way to run parallel evaluations and optionally integrate with the Orq AI platform.
 
 ## Why evaluatorq?

--- a/packages/evaluatorq-py/pyproject.toml
+++ b/packages/evaluatorq-py/pyproject.toml
@@ -199,9 +199,9 @@ dependencies = [
   eq = "evaluatorq.cli:main"
 
   [project.urls]
-  Homepage = "https://github.com/orq-ai/orqkit"
-  Repository = "https://github.com/orq-ai/orqkit/tree/main/packages/evaluatorq-py"
-  Documentation = "https://github.com/orq-ai/orqkit/tree/main/packages/evaluatorq-py"
+  Homepage = "https://github.com/orq-ai/evaluatorq"
+  Repository = "https://github.com/orq-ai/evaluatorq"
+  Documentation = "https://orq-ai.github.io/evaluatorq/"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Part of [RES-949](https://linear.app/orqai/issue/RES-949) (subticket of RES-864 — evaluatorq repo split).

## What

- `packages/evaluatorq-py/pyproject.toml` `[project.urls]` Homepage/Repository/Documentation → `github.com/orq-ai/evaluatorq` (+ docs site `orq-ai.github.io/evaluatorq`).
- `packages/evaluatorq-py/README.md` — big "📦➡️ This package has moved" banner; marks the in-monorepo copy **frozen** (no new PRs here).

## Why

Python `evaluatorq-py` now lives in the standalone `orq-ai/evaluatorq` repo. This repoints the last live orqkit metadata references and signals the freeze. TS `packages/evaluatorq` stays untouched.

> Old-path teardown stays HELD under RES-864 step 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)