### PR TITLE
chore: silence Dependabot for packages/evaluatorq-py

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# ponytail: this file exists only to silence Dependabot for packages/evaluatorq-py,
+# which is now managed in its own standalone repo. A repo-level config overrides the
+# org-level default; open-pull-requests-limit: 0 disables version-update PRs.
+# Delete this file once packages/evaluatorq-py is removed from the monorepo.
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/packages/evaluatorq-py"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+  - package-ecosystem: "uv"
+    directory: "/packages/evaluatorq-py/examples/redteam/refund_agent_demo"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## What

Adds a repo-level `.github/dependabot.yml` that sets `open-pull-requests-limit: 0` for both `packages/evaluatorq-py` directories, stopping Dependabot version-update PRs against the monorepo.

## Why

`packages/evaluatorq-py` is now managed in its own standalone repo. The repo previously had **no** `dependabot.yml`; the version-update PRs came from an org-level default. A repo-level config overrides that default, so this file silences the dir without adding update noise for anything else.

Delete this file once `packages/evaluatorq-py` is removed from the monorepo.

## Note

Does not close the existing open Dependabot PRs (#182, #181, #179) — config only stops future ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)