### PR TITLE
feat(evaluatorq): surface upload diagnostics in _send_cleaned_results (RES-823)

### DIFF
--- a/packages/evaluatorq-py/src/evaluatorq/redteam/contracts.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/contracts.py
@@ -1498,6 +1498,13 @@ class RedTeamReport(BaseModel):
     duration_seconds: float | None = None
     pipeline_warnings: list[str] = Field(default_factory=list)
     experiment_url: str | None = None
+    uploaded_count: int | None = Field(
+        default=None, description='Cleaned result rows sent to the Orq platform'
+    )
+    rows_created: int | None = Field(
+        default=None,
+        description='Rows the Orq platform actually registered; a value below uploaded_count explains a smaller Explorer sample count',
+    )
 
     @field_validator('pipeline', mode='before')
     @classmethod

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -153,8 +153,10 @@ async def _send_cleaned_results(
     empty job results so the experiment shows one clean row per datapoint
     without duplication.
 
-    If *report* is provided, ``report.experiment_url`` is set to the URL
-    returned by the platform on a successful upload.
+    If *report* is provided, the upload diagnostics are persisted on it:
+    ``experiment_url``, ``uploaded_count`` (cleaned rows sent), and
+    ``rows_created`` (rows the platform actually registered) — so a local
+    JSON is enough to diagnose an Explorer sample-count mismatch.
     """
     api_key = os.environ.get('ORQ_API_KEY')
     if not api_key:
@@ -178,9 +180,11 @@ async def _send_cleaned_results(
         logger.debug('No cleaned results to send to Orq platform')
         return
 
-    logger.debug(f'Sending {len(cleaned)} cleaned results to Orq platform (stripped from {len(results)} raw)')
+    logger.info(
+        f'Uploading {len(cleaned)} cleaned result(s) to Orq platform ({len(results)} raw report rows)'
+    )
     try:
-        experiment_url = await send_results_to_orq(
+        response = await send_results_to_orq(
             api_key=api_key,
             evaluation_name=name,
             evaluation_description=description,
@@ -189,8 +193,19 @@ async def _send_cleaned_results(
             start_time=start_time,
             end_time=datetime.now(tz=timezone.utc),
         )
-        if report is not None and experiment_url:
-            report.experiment_url = experiment_url
+        if report is not None:
+            report.uploaded_count = len(cleaned)
+        if response is None:
+            return
+        # send_results_to_orq already warns when rows_created < uploaded.
+        logger.info(
+            f'Orq registered {response.rows_created}/{len(cleaned)} uploaded row(s)'
+            + (f' — {response.experiment_url}' if response.experiment_url else '')
+        )
+        if report is not None:
+            report.rows_created = response.rows_created
+            if response.experiment_url:
+                report.experiment_url = response.experiment_url
     except Exception as e:
         logger.error(f'Failed to upload {len(cleaned)} results to Orq platform: {e}. Results have been saved locally.')
 

--- a/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
+++ b/packages/evaluatorq-py/src/evaluatorq/redteam/runner.py
@@ -177,12 +177,27 @@ async def _send_cleaned_results(
         cleaned.append(clean)
 
     if not cleaned:
-        logger.debug('No cleaned results to send to Orq platform')
+        if report is not None:
+            report.uploaded_count = 0
+        if results:
+            # The worst-case "0 samples in Explorer" mismatch: rows existed
+            # locally but every job output was None, so nothing is uploaded
+            # and no experiment will exist. Surface it loudly, not at DEBUG.
+            logger.warning(
+                f'All {len(results)} result row(s) had no real output — nothing uploaded '
+                f'to Orq; the experiment will not exist in the Explorer.'
+            )
+        else:
+            logger.debug('No cleaned results to send to Orq platform')
         return
 
     logger.info(
         f'Uploading {len(cleaned)} cleaned result(s) to Orq platform ({len(results)} raw report rows)'
     )
+    if report is not None:
+        # Recorded before the attempt so even an exception path leaves the
+        # attempt count in the persisted JSON.
+        report.uploaded_count = len(cleaned)
     try:
         response = await send_results_to_orq(
             api_key=api_key,
@@ -193,8 +208,6 @@ async def _send_cleaned_results(
             start_time=start_time,
             end_time=datetime.now(tz=timezone.utc),
         )
-        if report is not None:
-            report.uploaded_count = len(cleaned)
         if response is None:
             return
         # send_results_to_orq already warns when rows_created < uploaded.

--- a/packages/evaluatorq-py/src/evaluatorq/send_results.py
+++ b/packages/evaluatorq-py/src/evaluatorq/send_results.py
@@ -51,7 +51,7 @@ async def send_results_to_orq(
     *,
     path: str | None = None,
     raise_on_error: bool = False,
-) -> str | None:
+) -> OrqResponse | None:
     """
     Send evaluation results to Orq platform.
 
@@ -68,8 +68,10 @@ async def send_results_to_orq(
         raise_on_error: Raise upload errors instead of treating upload as best-effort.
 
     Returns:
-        The experiment URL from the Orq platform on success, or ``None`` if the
-        upload failed or the platform did not return a URL.
+        The full ``OrqResponse`` (``experiment_url``, ``rows_created``,
+        ``experiment_name``, ``sheet_id``, ...) on success, or ``None`` if the
+        upload failed. Callers that only need the URL read
+        ``response.experiment_url``.
     """
     try:
         # Calculate duration in milliseconds
@@ -146,10 +148,21 @@ async def send_results_to_orq(
                 orq_result.experiment_name,
                 orq_result.rows_created,
             )
+            if orq_result.rows_created < len(results):
+                # The "missing samples" footgun: the platform registered fewer
+                # rows than we uploaded. One loud line with both numbers + URL.
+                logger.warning(
+                    "Orq registered {} of {} uploaded rows for experiment {!r} — "
+                    "some results will be missing from the Explorer. URL: {}",
+                    orq_result.rows_created,
+                    len(results),
+                    orq_result.experiment_name,
+                    orq_result.experiment_url or "<no url returned>",
+                )
             if orq_result.experiment_url:
                 logger.info("View your evaluation at: {}", orq_result.experiment_url)
 
-            return orq_result.experiment_url
+            return orq_result
 
     except SendResultsError:
         raise

--- a/packages/evaluatorq-py/tests/redteam/test_send_cleaned_results.py
+++ b/packages/evaluatorq-py/tests/redteam/test_send_cleaned_results.py
@@ -215,3 +215,121 @@ async def test_report_json_roundtrips_diagnostics() -> None:
     legacy = RedTeamReport.model_validate(data)
     assert legacy.uploaded_count is None
     assert legacy.rows_created is None
+
+
+@pytest.mark.asyncio
+async def test_all_rows_stripped_warns_and_records_zero_uploaded() -> None:
+    """Raw rows that all strip to nothing must warn loudly (not DEBUG) and
+    persist uploaded_count=0 — the worst-case '0 samples in Explorer' path."""
+    from loguru import logger as _logger
+
+    report = _make_report()
+    stripped = DataPointResult(
+        data_point=DataPoint(inputs={"x": 1}),
+        job_results=[JobResult(job_name="j", output=None)],  # pyright: ignore[reportArgumentType]
+    )
+    lines: list[str] = []
+    handler_id = _logger.add(lambda m: lines.append(str(m)), level="WARNING", format="{message}")
+    try:
+        with (
+            patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+            patch(
+                "evaluatorq.redteam.runner.send_results_to_orq",
+                new_callable=AsyncMock,
+            ) as mock_send,
+        ):
+            await _send_cleaned_results(
+                results=[stripped],
+                name="n",
+                description="d",
+                start_time=datetime.now(tz=timezone.utc),
+                report=report,
+            )
+    finally:
+        _logger.remove(handler_id)
+    mock_send.assert_not_awaited()
+    assert report.uploaded_count == 0
+    assert report.rows_created is None
+    warnings = [ln for ln in lines if "nothing uploaded" in ln]
+    assert len(warnings) == 1
+    assert "1 result row" in warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_empty_results_stays_quiet() -> None:
+    """No raw rows at all is not a mismatch — no warning, uploaded_count=0."""
+    from loguru import logger as _logger
+
+    report = _make_report()
+    lines: list[str] = []
+    handler_id = _logger.add(lambda m: lines.append(str(m)), level="WARNING", format="{message}")
+    try:
+        with patch.dict(os.environ, {"ORQ_API_KEY": "test"}):
+            await _send_cleaned_results(
+                results=[],
+                name="n",
+                description="d",
+                start_time=datetime.now(tz=timezone.utc),
+                report=report,
+            )
+    finally:
+        _logger.remove(handler_id)
+    assert report.uploaded_count == 0
+    assert not lines
+
+
+@pytest.mark.asyncio
+async def test_uploaded_count_recorded_when_upload_raises() -> None:
+    """The attempt count survives an upload exception in the persisted report."""
+    report = _make_report()
+    with (
+        patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+        patch(
+            "evaluatorq.redteam.runner.send_results_to_orq",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ),
+    ):
+        await _send_cleaned_results(
+            results=[_make_result()],
+            name="n",
+            description="d",
+            start_time=datetime.now(tz=timezone.utc),
+            report=report,
+        )
+    assert report.uploaded_count == 1
+    assert report.rows_created is None
+
+
+@pytest.mark.asyncio
+async def test_auto_saved_run_json_contains_diagnostics(tmp_path) -> None:
+    """The runs-index JSON written by _auto_save_run carries the diagnostics
+    after _send_cleaned_results mutates the report (guards the mutate-before-
+    save ordering the pipelines rely on)."""
+    import json as _json
+
+    from evaluatorq.redteam import runner as runner_mod
+
+    report = _make_report()
+    with (
+        patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+        patch(
+            "evaluatorq.redteam.runner.send_results_to_orq",
+            new_callable=AsyncMock,
+            return_value=_make_response(rows_created=1),
+        ),
+    ):
+        await _send_cleaned_results(
+            results=[_make_result()],
+            name="n",
+            description="d",
+            start_time=datetime.now(tz=timezone.utc),
+            report=report,
+        )
+    with patch.object(runner_mod, "get_runs_dir", return_value=tmp_path):
+        path = runner_mod._auto_save_run(report, name="diag-test")
+    assert path is not None
+    data = _json.loads(path.read_text())
+    assert data["uploaded_count"] == 1
+    assert data["rows_created"] == 1
+    assert data["experiment_url"] == "https://orq.example/experiments/abc"

--- a/packages/evaluatorq-py/tests/redteam/test_send_cleaned_results.py
+++ b/packages/evaluatorq-py/tests/redteam/test_send_cleaned_results.py
@@ -10,7 +10,18 @@ import pytest
 
 from evaluatorq.redteam.contracts import Pipeline, RedTeamReport, ReportSummary
 from evaluatorq.redteam.runner import _send_cleaned_results
+from evaluatorq.send_results import OrqResponse
 from evaluatorq.types import DataPoint, DataPointResult, JobResult
+
+
+def _make_response(rows_created: int = 1, url: str | None = "https://orq.example/experiments/abc") -> OrqResponse:
+    return OrqResponse(
+        sheet_id="sheet-1",
+        manifest_id="manifest-1",
+        experiment_name="n",
+        rows_created=rows_created,
+        experiment_url=url,
+    )
 
 
 def _make_report() -> RedTeamReport:
@@ -44,7 +55,7 @@ async def test_sets_experiment_url_on_success() -> None:
         patch(
             "evaluatorq.redteam.runner.send_results_to_orq",
             new_callable=AsyncMock,
-            return_value="https://orq.example/experiments/abc",
+            return_value=_make_response(),
         ),
     ):
         await _send_cleaned_results(
@@ -112,3 +123,95 @@ async def test_upload_exception_does_not_break_report() -> None:
             report=report,
         )
     assert report.experiment_url is None
+
+
+@pytest.mark.asyncio
+async def test_persists_upload_diagnostics_on_report() -> None:
+    """uploaded_count + rows_created land on the report alongside the URL, so a
+    local JSON is enough to diagnose an Explorer sample-count mismatch."""
+    report = _make_report()
+    with (
+        patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+        patch(
+            "evaluatorq.redteam.runner.send_results_to_orq",
+            new_callable=AsyncMock,
+            return_value=_make_response(rows_created=1),
+        ),
+    ):
+        await _send_cleaned_results(
+            results=[_make_result()],
+            name="n",
+            description="d",
+            start_time=datetime.now(tz=timezone.utc),
+            report=report,
+        )
+    assert report.uploaded_count == 1
+    assert report.rows_created == 1
+    assert report.experiment_url == "https://orq.example/experiments/abc"
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_none_when_upload_returns_none() -> None:
+    """A failed upload leaves rows_created unset but records the attempt count."""
+    report = _make_report()
+    with (
+        patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+        patch(
+            "evaluatorq.redteam.runner.send_results_to_orq",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        await _send_cleaned_results(
+            results=[_make_result()],
+            name="n",
+            description="d",
+            start_time=datetime.now(tz=timezone.utc),
+            report=report,
+        )
+    assert report.uploaded_count == 1
+    assert report.rows_created is None
+    assert report.experiment_url is None
+
+
+@pytest.mark.asyncio
+async def test_url_persisted_even_when_rows_created_gap() -> None:
+    """A rows_created < uploaded gap still persists all three diagnostics."""
+    report = _make_report()
+    results = [_make_result(), _make_result()]
+    with (
+        patch.dict(os.environ, {"ORQ_API_KEY": "test"}),
+        patch(
+            "evaluatorq.redteam.runner.send_results_to_orq",
+            new_callable=AsyncMock,
+            return_value=_make_response(rows_created=1),
+        ),
+    ):
+        await _send_cleaned_results(
+            results=results,
+            name="n",
+            description="d",
+            start_time=datetime.now(tz=timezone.utc),
+            report=report,
+        )
+    assert report.uploaded_count == 2
+    assert report.rows_created == 1
+    assert report.experiment_url == "https://orq.example/experiments/abc"
+
+
+@pytest.mark.asyncio
+async def test_report_json_roundtrips_diagnostics() -> None:
+    """The new optional fields serialize into the run JSON and old JSONs
+    without them still validate."""
+    report = _make_report()
+    report.uploaded_count = 17
+    report.rows_created = 8
+    data = report.model_dump(mode="json")
+    assert data["uploaded_count"] == 17
+    assert data["rows_created"] == 8
+    # backward compat: a legacy payload without the new keys still validates
+    data.pop("uploaded_count")
+    data.pop("rows_created")
+    legacy = RedTeamReport.model_validate(data)
+    assert legacy.uploaded_count is None
+    assert legacy.rows_created is None

--- a/packages/evaluatorq-py/tests/test_send_results.py
+++ b/packages/evaluatorq-py/tests/test_send_results.py
@@ -20,7 +20,7 @@ from evaluatorq.types import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def build_results():
     """Factory fixture that creates a single DataPointResult with given score and error."""
 
@@ -483,3 +483,133 @@ class TestSendResultsUploadFailures:
             raise_on_error=False,
         )
         assert result is None
+
+
+class TestUploadDiagnostics:
+    """RES-823: the full OrqResponse is returned and upload gaps warn loudly."""
+
+    @staticmethod
+    def _fake_post(rows_created: int, url: str | None = "https://my.orq.ai/e/abc"):
+        async def fake_post(self: httpx.AsyncClient, *args: Any, **kwargs: Any) -> httpx.Response:
+            request = httpx.Request("POST", "https://my.orq.ai/v2/spreadsheets/evaluations/receive")
+            body = {
+                "sheet_id": "s1",
+                "manifest_id": "m1",
+                "experiment_name": "eval",
+                "rows_created": rows_created,
+            }
+            if url is not None:
+                body["experiment_url"] = url
+            return httpx.Response(200, request=request, json=body)
+
+        return fake_post
+
+    @staticmethod
+    def _capture_loguru() -> tuple[list[str], int]:
+        from loguru import logger as _logger
+
+        lines: list[str] = []
+        handler_id = _logger.add(
+            lambda message: lines.append(str(message)), level="WARNING", format="{message}"
+        )
+        return lines, handler_id
+
+    @pytest.mark.asyncio
+    async def test_success_returns_full_orq_response(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        build_results: Callable[..., list[DataPointResult]],
+    ):
+        monkeypatch.setattr(httpx.AsyncClient, "post", self._fake_post(rows_created=1))
+        response = await send_results_to_orq(
+            api_key="key",
+            evaluation_name="eval",
+            evaluation_description=None,
+            dataset_id=None,
+            results=build_results(0.5),
+            start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            end_time=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+        )
+        assert response is not None
+        assert response.rows_created == 1
+        assert response.experiment_url == "https://my.orq.ai/e/abc"
+        assert response.experiment_name == "eval"
+        assert response.sheet_id == "s1"
+
+    @pytest.mark.asyncio
+    async def test_gap_between_uploaded_and_rows_created_warns_once(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        build_results: Callable[..., list[DataPointResult]],
+    ):
+        from loguru import logger as _logger
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", self._fake_post(rows_created=0))
+        lines, handler_id = self._capture_loguru()
+        try:
+            await send_results_to_orq(
+                api_key="key",
+                evaluation_name="eval",
+                evaluation_description=None,
+                dataset_id=None,
+                results=build_results(0.5),  # 1 uploaded, 0 registered
+                start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                end_time=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+            )
+        finally:
+            _logger.remove(handler_id)
+        gap_warnings = [ln for ln in lines if "registered 0 of 1 uploaded" in ln]
+        assert len(gap_warnings) == 1
+        assert "https://my.orq.ai/e/abc" in gap_warnings[0]
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_all_rows_created(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        build_results: Callable[..., list[DataPointResult]],
+    ):
+        from loguru import logger as _logger
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", self._fake_post(rows_created=1))
+        lines, handler_id = self._capture_loguru()
+        try:
+            await send_results_to_orq(
+                api_key="key",
+                evaluation_name="eval",
+                evaluation_description=None,
+                dataset_id=None,
+                results=build_results(0.5),
+                start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                end_time=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+            )
+        finally:
+            _logger.remove(handler_id)
+        assert not [ln for ln in lines if "registered" in ln]
+
+    @pytest.mark.asyncio
+    async def test_gap_warning_without_url_uses_placeholder(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        build_results: Callable[..., list[DataPointResult]],
+    ):
+        from loguru import logger as _logger
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", self._fake_post(rows_created=0, url=None))
+        lines, handler_id = self._capture_loguru()
+        try:
+            response = await send_results_to_orq(
+                api_key="key",
+                evaluation_name="eval",
+                evaluation_description=None,
+                dataset_id=None,
+                results=build_results(0.5),
+                start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                end_time=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+            )
+        finally:
+            _logger.remove(handler_id)
+        assert response is not None
+        assert response.experiment_url is None
+        gap_warnings = [ln for ln in lines if "registered 0 of 1 uploaded" in ln]
+        assert len(gap_warnings) == 1
+        assert "<no url returned>" in gap_warnings[0]


### PR DESCRIPTION
## Summary

Implements RES-823: the upload boundary no longer throws away the diagnostics that explain the recurring "34 local rows, 8 in Explorer" mismatch.

- **`send_results_to_orq` returns the full `OrqResponse`** (`experiment_url`, `rows_created`, `experiment_name`, `sheet_id`) instead of just the URL string — the ticket's option A, reusing the existing model. The **gap warning** lives at this boundary: `rows_created < uploaded rows` produces exactly one WARNING line with both numbers and the URL, so both the red-team runner and plain `evaluatorq()` uploads get mismatch visibility from one implementation. (The ticket's item 4, `print()` → loguru, had already landed on main; verified.)
- **`_send_cleaned_results`** logs at INFO: cleaned vs raw row counts before upload, registered/uploaded counts + URL after; and persists **`uploaded_count`**, **`rows_created`**, and `experiment_url` on `RedTeamReport`, so the local run JSON alone diagnoses an Explorer sample-count gap.
- **Strip-to-zero path surfaced**: when raw rows exist but every job output is `None` (the worst-case "0 samples in Explorer"), the skip now warns loudly (was DEBUG-only) and persists `uploaded_count=0`; the attempt count is recorded before the upload call so even an exception path leaves it in the JSON.
- **`RedTeamReport`**: two new optional fields, backward compatible — legacy run JSONs without them still validate (tested).
- `evaluatorq.py:310` (non-redteam caller) verified safe: it discards the return; basedpyright clean.

## Verification

- An 18-agent adversarial swarm (spec, correctness, security, silent-fails, regression finders + per-finding refutation + completeness critic) checked the work against the ticket; the confirmed findings (strip-to-zero silence, exception-path count) are fixed in `3f07c85` with regression tests. The two `test_main_module` full-suite failures were proven pre-existing on clean main (corrupted local editable install, not this diff).
- **Real end-to-end run** against the live platform: 2 raw rows → 1 cleaned (one stripped) → `Orq registered 1/1 uploaded row(s)` with the experiment URL in the INFO logs, and all three fields persisted on the report (experiment `res-823-upload-diagnostics-verification`, marked safe to delete).
- 20 tests on the touched surface (12 new); 1203 redteam+send_results tests green; `ruff` and `basedpyright` clean on changed files.

## Out of scope (per ticket)

Why the platform de-dupes 17 → 8 (platform-side), and the broader `send_results.py` error-handling refactor.

Ticket: RES-823